### PR TITLE
Change the location of counterattack phase's target based on conditions.

### DIFF
--- a/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
+++ b/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
@@ -97,10 +97,10 @@ _taskDataStore setVariable ["prepare_zone", {
 	private _infantryMultiplier = _baseMultiplier;
 
 	/*
-	add the "attack" objectives to the AI objectives task system
+	add the "attack" objective to the AI objectives task system.
 
-	attackDifficulty determines how large to make the AI groups that attack this objective
-	but it is never set as a variable on this player task so it will only the default setting provided below
+	attackDifficulty determines how large to make the AI groups that attack this objective,
+	but it is never set as a variable on this player task so it will only use the default setting provided below.
 	*/
 	private _attackObjective = [
 		_taskDataStore getVariable "attackPos",

--- a/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
+++ b/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
@@ -30,32 +30,39 @@ _taskDataStore setVariable ["INIT", {
 	private _zonePosition = getMarkerPos _marker;
 	private _prepTime = _taskDataStore getVariable ["prepTime", 0];
 
-	// OLD: current_hq vairable is never set in missionNamespace
-	// so this always  defaults to _zonePositon, which is the centre point of the zone
+	// OLD: current_hq variable is never set in missionNamespace
+	// so _attackPos always defaults to _zonePositon, which is just the centre point of the zone
 
 	// private _hq = (missionNamespace getVariable ["current_hq", objNull]);
 	// private _attackPos = if !(_hq isEqualTo objNull) then {getPos (_hq)} else {_zonePosition};
 
-	// default attck position is the centre of the zone when no FOBs
-	// basically just sending some troops to the centre and hoping they bump into players
-	private _attackPos = _zonePosition;
-
 	/*
-	if there's a bases within range of the AO, look for a suitable base to send attacks towards
-	TODO: candidate arrays should really be hashmaps.
+	if there's a bases within range of the AO, look for a suitable base to send attacks towards,
+	otherwise send AI towards the centre of the zone and hope they run into players
 
-	get nearby FOBs within a 2000m square area of the zone
-	sorted in descending order of the current supplies of the base
+	current implementation --
+
+	get nearby FOBs within a 2000m square area of the zone,
+	sorted in descending order of the current supplies of the base,
+	using the first array item as the target
 	*/
 
+	// default attack position is the centre of the zone when no FOBs
+	// basically just send some troops to the centre and hoping they bump into players
+	private _attackPos = _zonePosition;
+
+	// construct an array containing another small sub-array for each candidate FOB: [FOB supplies: number, FOB: object]
+	// TODO: candidate arrays should really be hashmaps.
 	private _candidate_bases_to_attack = para_g_bases inAreaArray [_zonePosition, 2000, 2000, 0] apply { [ _x getVariable "para_g_current_supplies", _x] };
 	_candidate_bases_to_attack sort false;
 
+	// candidate FOBs exist
 	if ((count _candidate_bases_to_attack) > 0) then {
 
 		diag_log format ["Counterattack: Co-Ordinates of FOBs within range of counter attack: %1", _candidate_bases_to_attack apply {getPos (_x # 1)}];
 
 		// TODO: candidate arrays should really be hashmaps.
+		// get the first item from the sorted array
 		private _base_to_attack = (_candidate_bases_to_attack # 0 ) # 1;
 		diag_log format ["Counterattack: Co-Ordinates of selected FOB: %1", _base_to_attack];
 
@@ -63,7 +70,7 @@ _taskDataStore setVariable ["INIT", {
 		_attackPos = getPos _base_to_attack;
 	};
 
-    diag_log format ["Counterattack: Co-ordinates for counter attack target: %1", _attackPos];
+	diag_log format ["Counterattack: Co-ordinates for counter attack target: %1", _attackPos];
 
 	private _attackTime = serverTime + (_taskDataStore getVariable ["prepTime", 0]);
 	_taskDataStore setVariable ["attackTime", _attackTime];

--- a/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
+++ b/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
@@ -34,21 +34,18 @@ _taskDataStore setVariable ["INIT", {
 	if no candidate FOBs, send AI towards the centre of the zone
 	hoping they run into players.
 
-	if there are bases within range of the AO, 
-	get nearby FOBs within a specified radius of the zone's centre point,
-	sort in descending order of the current supplies of the base,
+	if there are bases within an AO's hexagon radius,
+	get nearby FOBs sorted in descending order of the current supplies,
 	use the first array item as the target for counter attack.
 	*/
 
 	// default attack position is centre of the zone
 	private _attackPos = _zonePosition;
+	private _areaSize = markerSize _marker;
 
-	// search for candidate FOBs
-	// NOTE: 1100 is the area of the yellow circle during the AO's capture phase.
-	// TODO: may want to make the AO's engagement area a global parameter so we can access 
-	// in multiple places as this is also defined in the capture zone phase.
-
-	private _candidate_bases_to_attack = para_g_bases inAreaArray [_zonePosition, 1100, 1100, 0, false] apply { [ _x getVariable "para_g_current_supplies", _x] };
+	// search for candidate FOBs within the zone's area.
+	private _base_search_area = [_zonePosition, _areaSize select 0, _areaSize select 1, 0, false];
+	private _candidate_bases_to_attack = para_g_bases inAreaArray _base_search_area apply { [ _x getVariable "para_g_current_supplies", _x] };
 	_candidate_bases_to_attack sort false;
 
 	// candidate FOBs exist
@@ -69,7 +66,7 @@ _taskDataStore setVariable ["INIT", {
 	private _attackTime = serverTime + (_taskDataStore getVariable ["prepTime", 0]);
 	_taskDataStore setVariable ["attackTime", _attackTime];
 	_taskDataStore setVariable ["attackPos", _attackPos];
-	_taskDataStore setVariable ["attackAreaSize", markerSize _marker];
+	_taskDataStore setVariable ["attackAreaSize", _areaSize];
 
 	if (_prepTime > 0) then 
 	{

--- a/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
+++ b/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
@@ -40,13 +40,13 @@ _taskDataStore setVariable ["INIT", {
 	// basically just sending some troops to the centre and hoping they bump into players
 	private _attackPos = _zonePosition;
 
-    /*
+	/*
 	if there's a bases within range of the AO, look for a suitable base to send attacks towards
-    TODO: candidate arrays should really be hashmaps.
+	TODO: candidate arrays should really be hashmaps.
 
-    get nearby FOBs within a 2000m square area of the zone
-    sorted in descending order of the current supplies of the base
-    */
+	get nearby FOBs within a 2000m square area of the zone
+	sorted in descending order of the current supplies of the base
+	*/
 
 	private _candidate_bases_to_attack = para_g_bases inAreaArray [_zonePosition, 2000, 2000, 0] apply { [ _x getVariable "para_g_current_supplies", _x] };
 	_candidate_bases_to_attack sort false;
@@ -66,7 +66,6 @@ _taskDataStore setVariable ["INIT", {
     diag_log format ["Counterattack: Co-ordinates for counter attack target: %1", _attackPos];
 
 	private _attackTime = serverTime + (_taskDataStore getVariable ["prepTime", 0]);
-
 	_taskDataStore setVariable ["attackTime", _attackTime];
 	_taskDataStore setVariable ["attackPos", _attackPos];
 	_taskDataStore setVariable ["attackAreaSize", markerSize _marker];

--- a/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
+++ b/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
@@ -44,17 +44,9 @@ _taskDataStore setVariable ["INIT", {
 	if there's a bases within range of the AO, look for a suitable base to send attacks towards
     TODO: candidate arrays should really be hashmaps.
 
-    ==> option 1
-    get nearby FOBs within a 2000m square area of the zone
-    sorted in ascending order of distance to the centre of the zone
-
-	==> option 2 (active)
     get nearby FOBs within a 2000m square area of the zone
     sorted in descending order of the current supplies of the base
     */
-
-	// private _nearby_bases = para_g_bases inAreaArray [_zonePosition, 2000, 2000, 0] apply { [ getPos _x distance2D _zonePosition, _x] };
-	// _nearby_bases sort false;
 
 	private _candidate_bases_to_attack = para_g_bases inAreaArray [_zonePosition, 2000, 2000, 0] apply { [ _x getVariable "para_g_current_supplies", _x] };
 	_candidate_bases_to_attack sort false;


### PR DESCRIPTION
### Summary

Tweak the AI's pathing during the counterattack phase.

This does not alter the number of AI that are tasked with this objective. Please see the comment towards the end of the diff!

### Previously

The script would try to read the `current_hq` variable from `missionNamespace` and use that as the target for AI pathing. But `current_hq` is never set at any point, so the target for AI pathing would always fall back to `_zonePosition`, which is the centre point of the AO.

### Changes

Instead of looking up `current_hq`, find FOBs within a 2000m area from the centre point of the AO (`_zonePosition`).

Then select the FOB with the largest amount of supplies as the attack point for AI.

If no candidate FOBs exist, set the default AI pathing target as the centre of the AO and hope the AI run into players at some point.

### Additional work

We'll want to tweak the `attackDifficulty` default value, as it will likely be too low (not tweaked in PR).

### Screenshots

3x FOBs set up in an AO at the start of the yellow phase. 

![20230320025130_1](https://user-images.githubusercontent.com/11841332/226239506-f81eee21-1e73-4946-92be-059469edd4ff.jpg)

Papa-39 has the most supplies.

![20230320025109_1](https://user-images.githubusercontent.com/11841332/226239585-6085a5e9-445f-46b9-9350-b1277fbb7d2d.jpg)

Papa-39 is set as the FOB that needs defending

![20230320025300_1](https://user-images.githubusercontent.com/11841332/226239608-9f88df48-4f23-4f41-aeaf-96845d4bfc9b.jpg)

Newly spawned AI with "attack" objective are pathing directly towards the new objective.

![20230320025308_1](https://user-images.githubusercontent.com/11841332/226239653-c1ea27a7-6825-47c1-9601-10bb181f6a57.jpg)
