### PR TITLE
Clean up AI from HQ and Factory objectives.

### DIFF
--- a/mission/functions/systems/sites/fn_sites_create_factory.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_factory.sqf
@@ -104,5 +104,9 @@ params ["_pos"];
 		{
 			deleteMarker _x;
 		} forEach (_siteStore getVariable "markers");
+
+		// release AI from associated objectives
+		// note -- AI can vanish in front of players when this is executed
+		_siteStore getVariable "aiObjectives" apply {[_x] call para_s_fnc_ai_obj_finish_objective};
 	}
 ] call vn_mf_fnc_sites_create_site;

--- a/mission/functions/systems/sites/fn_sites_create_hq.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_hq.sqf
@@ -115,5 +115,9 @@ params ["_pos"];
 		{
 			deleteMarker _x;
 		} forEach (_siteStore getVariable "markers");
+
+		// release AI from associated objectives
+		// note -- AI can vanish in front of players when this is executed
+		_siteStore getVariable "aiObjectives" apply {[_x] call para_s_fnc_ai_obj_finish_objective};
 	}
 ] call vn_mf_fnc_sites_create_site;


### PR DESCRIPTION
### Summary

Perform clean up of additional AI objectives at HQ and Factory sites.

AI are tasked with defending the HQ and factory locations in two different functions. When the sites are generated (see files in diff) and when the overarching player objectives are created (see `fn_task_pri_capture.sqf`).

The AI tasking from player objective handling was being cleaned up.

But the site creation AI taskings were not cleaned up, leading to a bunch of AI attempting to defend / crew objectives that no longer exist.

Note -- cleaning up seems to allow AIs to vanish in front of players, or at least when players are still close by. So I wonder if that was the original reason these AI were allowed to remain tasked with these locations.