### PR TITLE
Fix infinite stamina on first life bug

### DIFF
--- a/mission/para_server_init.sqf
+++ b/mission/para_server_init.sqf
@@ -56,8 +56,8 @@ vn_mf_duskLength = ["dusk_length", 1200] call BIS_fnc_getParamValue;
 vn_mf_nightLength = ["night_length", 1800] call BIS_fnc_getParamValue;
 
 //Set whether stamia is enabled
-vn_mf_param_enable_stamina = (["param_enable_stamina", 0] call BIS_fnc_getParamValue) > 0;
-vn_mf_param_set_stamina = (["param_set_stamina", 1] call BIS_fnc_getParamValue);
+vn_mf_param_enable_stamina = (["enable_stamina", 0] call BIS_fnc_getParamValue) > 0;
+vn_mf_param_set_stamina = (["set_stamina", 1] call BIS_fnc_getParamValue);
 publicVariable "vn_mf_param_enable_stamina";
 publicVariable "vn_mf_param_set_stamina";
 


### PR DESCRIPTION
The two edited lines are supposed to look up the parameters in this file https://github.com/Bro-Nation/Mike-Force/blob/development/mission/config/params.hpp#L423-L437

```
# params.hpp
class enable_stamina
{
    title = $STR_vn_mf_param_enable_stamina;
    values[] = {1, 0};
    texts[] = {"True", "False"};
    default = 1;
};

class set_stamina
{
    title = $STR_vn_mf_param_set_stamina;
    values[] = {0, 1, 2, 3};
    texts[] = {"Normal", "Default", "FastDrain", "Exhausted"};
    default = 1;
};
```

Neither `param_enable_stamina` nor `param_set_stamina` match those classes, so the init script defaults to the provided fallback value of `0` --> stamina disabled.

When I start up a local instance with this fix I have stamina settings turned on.
When I don't I can run around for my first life to my heart's content.

I think when the player dies the `loadCoef` value from `teams.hpp` gets applied. But I'm not 100% certain. Leaving as draft for now until I can dig a bit deeper/feel more confident it's not having any side effects.

