### PR TITLE
[FIX] Radio channels disabled on respawn

### DIFF
--- a/mission/functions/core/teams/fn_update_channels.sqf
+++ b/mission/functions/core/teams/fn_update_channels.sqf
@@ -23,14 +23,14 @@
 
 		6 ===> Ground (CC1)
 		7 ===> Air (CC2)
-        8 ===> ACAV (CC3)
-        9 ===> MACV (CC4)
+		8 ===> ACAV (CC3)
+		9 ===> MACV (CC4)
 
-        Note that custom radio channel specific functions like `radioChannelAdd`
-        and `radioChannelRemove` will refer to channel 6 as custom channel 1,
-        channel 7 as custom channel 2 and channel 8 as custom channel 3.
+		Note that custom radio channel specific functions like `radioChannelAdd`
+		and `radioChannelRemove` will refer to channel 6 as custom channel 1,
+		channel 7 as custom channel 2 and channel 8 as custom channel 3.
 
-        Just to keep life interesting.
+		Just to keep life interesting.
     
     Parameter(s):
 		None

--- a/mission/functions/core/teams/fn_update_channels.sqf
+++ b/mission/functions/core/teams/fn_update_channels.sqf
@@ -1,10 +1,36 @@
 /*
     File: fn_update_channels.sqf
     Author: Cerebral
+    Modified: @dijksterhuis
     Public: No
     
     Description:
+
         Update player's chat channels.
+
+		Reference: https://community.bistudio.com/wiki/enableChannel
+
+		base game:
+
+		0 ===> Global
+		1 ===> Side
+		2 ===> Command
+		3 ===> Group
+		4 ===> Vehicle
+		5 ===> Direct
+
+		custom:
+
+		6 ===> Ground (CC1)
+		7 ===> Air (CC2)
+        8 ===> ACAV (CC3)
+        9 ===> MACV (CC4)
+
+        Note that custom radio channel specific functions like `radioChannelAdd`
+        and `radioChannelRemove` will refer to channel 6 as custom channel 1,
+        channel 7 as custom channel 2 and channel 8 as custom channel 3.
+
+        Just to keep life interesting.
     
     Parameter(s):
 		None

--- a/mission/functions/core/teams/fn_update_channels.sqf
+++ b/mission/functions/core/teams/fn_update_channels.sqf
@@ -107,6 +107,14 @@ switch(_team) do
 		8 enableChannel [true, true];
 	};
 
+	case "ARVN" : {
+		1 radioChannelAdd [player];
+		3 radioChannelAdd [player];
+
+		6 enableChannel [true, true];
+		8 enableChannel [true, true];
+	};
+
 	case "Frogmen" : {
 		1 radioChannelAdd [player];
 

--- a/mission/para_player_loaded_client.sqf
+++ b/mission/para_player_loaded_client.sqf
@@ -52,8 +52,13 @@ private _fnc_disableChatter = {
 	[player, "NoVoice"] remoteExec ["setSpeaker", 0];
 	{ _x disableAI "RADIOPROTOCOL"; _x setSpeaker "NoVoice"; } forEach allPlayers;
 };
-[] call _fnc_disableChatter;
-player addEventHandler ["Respawn", _fnc_disableChatter];
+
+private _fnc_respawnEventHandler = {
+	call _fnc_disableChatter;
+	call vn_mf_fnc_update_channels;
+};
+
+player addEventHandler ["Respawn", _fnc_respawnEventHandler];
 [true, "arsenalClosed", {
 	[player, "NoVoice"] remoteExec ["setSpeaker", 0];
 }] call BIS_fnc_addScriptedEventHandler;


### PR DESCRIPTION
Radio channel update script function was never called during player respawn event handling.

Have created a new inline respawn eventhandler function to differentiate between disabling friendly AI radio chatter and anything else that might need to be added in future.

Have also added a config for ARVN basing them on the Quarterhorse config (they have access to 105s).

Fixes https://github.com/Bro-Nation/Mike-Force/issues/86