### PR TITLE
[FIX] Fail counterattack after 5 *concurrent* minutes of no valid players

### DIFF
--- a/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
+++ b/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
@@ -158,6 +158,7 @@ _taskDataStore setVariable ["defend_zone", {
 		_taskDataStore setVariable ["enemyZoneHeldTime", _enemyZoneHeldTime];
 		_taskDataStore setVariable ["lastCheck", _lastCheck];
 	} else {
+		_taskDataStore setVariable ["enemyZoneHeldTime", 0];
 		_lastCheck = serverTime;
 		_taskDataStore setVariable ["lastCheck", _lastCheck];
 	};


### PR DESCRIPTION
Previously would trigger the failure after a TOTAL of 5 minutes where no valid players.

Previously: Player is only one on server. Dies in the AO. Timer starts. Speed runs back to the AO. Timer **pauses**. Become incapacitated. Timer **continues**. Counterattack fails.

Now: Player is only one on server. Dies in the AO. Timer starts. Speed runs back to the AO. Timer **resets**. Become incapacitated. Timer starts. Counterattack phase still ongoing.