### PR TITLE
Fix for radio tap hold action

### DIFF
--- a/mission/functions/systems/actions/fn_action_init.sqf
+++ b/mission/functions/systems/actions/fn_action_init.sqf
@@ -1,6 +1,7 @@
 /*
 	File: fn_action_init.sqf
 	Author: Cerebral
+	Modified: @dijksterhuis
 	Public: No
 	
 	Description:
@@ -27,6 +28,7 @@ if (isNil "vn_mf_actions_initialized" || vn_mf_actions_player != player) then //
 	call vn_mf_fnc_action_capture_player;
 	call vn_mf_fnc_action_destroy_task;
 	call vn_mf_fnc_action_gather_intel;
+	call vn_mf_fnc_action_radiotap;
 	"vn_holdActionAdd_layer" cutText ["","PLAIN"];
 };
 

--- a/mission/functions/systems/actions/fn_action_radiotap.sqf
+++ b/mission/functions/systems/actions/fn_action_radiotap.sqf
@@ -24,27 +24,14 @@
         [obj_1, obj2, obj_3] call vn_mf_fnc_action_radiotap_reveal;
 */
 
-// if nothing got passed in the call don't bother trying to execute the script
-if (count _this == 0) exitwith {
-	diag_log format ["Radiotap Action: Empty array passed in call so not executing."];
-};
-
-////////////////////////////////////////////////////////////////////
-// set up the variables for holdActionAdd
-
 private _actionText = "Wiretap Radio Communications";
 private _actionIdleIcon = "custom\holdactions\holdAction_listen_ca.paa";
 private _actionProgressIcon = _actionIdleIcon;
 
-/*
-holdActionAdd CONDITIONS field variables
-	_target ==> the current object / object action is attached to
-	_this   ==> player executing the action (WARN: different to CODE!)
-*/
 
-private _isNotOpfor = "side _this != east";
-private _isInRangeOfRadio = "_this distance _target < 5";
-private _isValidObjectType = "typeOf _target in ['vn_o_prop_t102e_01', 'vn_o_prop_t884_01']";
+private _isNotOpfor = "side player != east";
+private _isInRangeOfRadio = "player distance cursorObject < 5";
+private _isValidObjectType = "typeOf cursorObject in ['vn_o_prop_t102e_01', 'vn_o_prop_t884_01']";
 
 private _conditionToShow = format [
 	"(%1 && %2 && %3)",
@@ -54,8 +41,8 @@ private _conditionToShow = format [
 ];
 
 // WARN: if changing this make sure you change the logic in _codeOnStart too!!
-private _isPlayerExplosiveSpecialist = "_this getUnitTrait 'explosiveSpecialist'";
-private _isPlayerHasWiretapKit = "'vn_b_item_wiretap' in (backpackItems _this)";
+private _isPlayerExplosiveSpecialist = "player getUnitTrait 'explosiveSpecialist'";
+private _isPlayerHasWiretapKit = "'vn_b_item_wiretap' in (backpackItems player)";
 
 private _conditionToProgress = format [
 	"(%1 && %2 && %3)",
@@ -64,56 +51,42 @@ private _conditionToProgress = format [
 	_isPlayerHasWiretapKit
 ];
 
-/*
-holdActionAdd CODE field variables
-	_target ==> the current object / object action is attached to
-	_caller ==> player executing the action (WARN: different to CONDITIONS!)
-*/
-
-// show some notifications
-// WARN: if changing this make sure you change the logic for _conditionToProgress too!!
 private _codeOnStart = {
-	private _playerIsExplosiveSpecialist = _caller getUnitTrait 'explosiveSpecialist';
-	private _playerHasWiretapKit = 'vn_b_item_wiretap' in (backpackItems _caller);
+	private _playerIsExplosiveSpecialist = player getUnitTrait 'explosiveSpecialist';
+	private _playerHasWiretapKit = 'vn_b_item_wiretap' in (backpackItems player);
 	if (not _playerHasWiretapKit || not _playerIsExplosiveSpecialist) exitWith {
-	    ["RadioTapFailed", []] remoteExec ["para_c_fnc_show_notification", _caller];
+	    ["RadioTapFailed", []] remoteExec ["para_c_fnc_show_notification", player];
 	};
 	if (true) exitWith {
-	    ["RadioTapStart", []] remoteExec ["para_c_fnc_show_notification", _caller];
+	    ["RadioTapStart", []] remoteExec ["para_c_fnc_show_notification", player];
 	};
 };
 private _codeOnTick = {};
 private _codeOnComplete = {
-	[_target] remoteExec ["vn_mf_fnc_reveal_radiotap_nearest_sites", 2];
-	["RadioTapSuccess", []] remoteExec ["para_c_fnc_show_notification", _caller];
+	[cursorObject] remoteExec ["vn_mf_fnc_reveal_radiotap_nearest_sites", 2];
+	["RadioTapSuccess", []] remoteExec ["para_c_fnc_show_notification", player];
 };
 private _codeOnInterrupted = {};
 private _extraArgsArr = [];
 private _actionDurationSeconds = 10;
 private _actionPriority = 100;
-private _actionRemoveOnComplete = true;
+private _actionRemoveOnComplete = false;
 private _showWhenUncon = false;
 
-////////////////////////////////////////////////////////////////////
-// apply holdActionAdd to all the objects passed in with call syntax
-
-_this apply {
-	[
-		_x,
-		_actionText,
-		_actionIdleIcon,
-		_actionProgressIcon,
-		_conditionToShow,
-		_conditionToProgress,
-		_codeOnStart,
-		_codeOnTick,
-		_codeOnComplete,
-		_codeOnInterrupted,
-		_extraArgsArr,
-		_actionDurationSeconds,
-		_actionPriority,
-		_actionRemoveOnComplete,
-		_showWhenUncon
-	] call BIS_fnc_holdActionAdd;	
-};
-
+[
+	player,
+	_actionText,
+	_actionIdleIcon,
+	_actionProgressIcon,
+	_conditionToShow,
+	_conditionToProgress,
+	_codeOnStart,
+	_codeOnTick,
+	_codeOnComplete,
+	_codeOnInterrupted,
+	_extraArgsArr,
+	_actionDurationSeconds,
+	_actionPriority,
+	_actionRemoveOnComplete,
+	_showWhenUncon
+] call BIS_fnc_holdActionAdd;

--- a/mission/functions/systems/sites/fn_reveal_radiotap_nearest_sites.sqf
+++ b/mission/functions/systems/sites/fn_reveal_radiotap_nearest_sites.sqf
@@ -25,9 +25,6 @@ private _radioPos = getPos _radioObj;
 private _sitesArr = missionNamespace getVariable ["sites",[]];
 private _sitesUndiscoveredArr = _sitesArr select {!(_x getVariable ["discovered", false])};
 
-// randomised number of sites to reveal on map to make life interesting
-private _nSitesToReveal = (selectRandom [2, 1]);
-
 /* 
 nested arrays of [site distance from radio, site object]
 sorted by ascending distance
@@ -36,7 +33,12 @@ then resize to the random N sites to reveal
 */ 
 private _sitesDistanceSortedAscArr = _sitesUndiscoveredArr apply {[_x distance2d _radioPos, _x]};
 _sitesDistanceSortedAscArr sort true;
-_sitesDistanceSortedAscArr deleteAt 0;
+
+// randomised number of sites to reveal on map to make life interesting
+// this is set to two or three to cover the case where
+// - the marker discovery system is disabled (BN MF#1 and MF#2) -- reveals current + 1 or 2 others
+// - the marker discovery system is enabled (others) -- reveals 2 or 3 others
+private _nSitesToReveal = (selectRandom [2, 3]);
 
 // we can end up trying to select too many and ending up with null values
 if (_nSitesToReveal > count _sitesDistanceSortedAscArr) then {
@@ -48,7 +50,6 @@ _sitesDistanceSortedAscArr resize _nSitesToReveal;
 // no need for messy forEach loops or multiple searches 
 // as we can do one apply call
 _sitesDistanceSortedAscArr apply {
-    // private _candidateSiteDistance = _x # 0;
     private _candidateSiteObj = _x # 1;
     private _markersArr = _candidateSiteObj getVariable ["markers", []];
     _markersArr apply {_x setMarkerAlpha 0.5};

--- a/mission/functions/systems/sites/fn_reveal_radiotap_nearest_sites.sqf
+++ b/mission/functions/systems/sites/fn_reveal_radiotap_nearest_sites.sqf
@@ -48,7 +48,7 @@ _sitesDistanceSortedAscArr resize _nSitesToReveal;
 // no need for messy forEach loops or multiple searches 
 // as we can do one apply call
 _sitesDistanceSortedAscArr apply {
-    private _candidateSiteArr = _x # 0;
+    // private _candidateSiteDistance = _x # 0;
     private _candidateSiteObj = _x # 1;
     private _markersArr = _candidateSiteObj getVariable ["markers", []];
     _markersArr apply {_x setMarkerAlpha 0.5};

--- a/mission/functions/systems/sites/fn_sites_generate.sqf
+++ b/mission/functions/systems/sites/fn_sites_generate.sqf
@@ -74,4 +74,4 @@ private _radios = vn_site_objects select {
 	typeOf _x in ["vn_o_prop_t102e_01", "vn_o_prop_t884_01"];
 };
 
-_radios call vn_mf_fnc_action_radiotap;
+_radios apply {_x call vn_mf_fnc_action_radiotap};


### PR DESCRIPTION
Now shows multiple scroll wheel menu entries when running everything locally, which is what the intel does... so hopefully this actually adds the hold action when running on the dedicated server now.

i've also edited the main script to consider the cases where the marker discovery subsystem is disabled / enabled by increasing the maximum number of sites that can be discovered (the current site the player is inside won't have been marked as "discovered" when the job is disabled).

comment from the code below
```
// this is set to two or three to cover the case where
// - the marker discovery system is disabled (BN MF#1 and MF#2) -- reveals current + 1 or 2 others
// - the marker discovery system is enabled (others) -- reveals 2 or 3 others
private _nSitesToReveal = (selectRandom [2, 3]);
```

---

screenshots

radio tap scroll wheel menu options when looking at the object:

![20230426215523_1](https://user-images.githubusercontent.com/11841332/234701596-cd895b11-c9f5-4f7b-bbce-934ed0268860.jpg)

which matches the intel, which has multiple scroll wheel options when looking at the object:

![20230426215525_1](https://user-images.githubusercontent.com/11841332/234701615-fcebc643-08d8-466c-a884-679d15491f3d.jpg)
