### PR TITLE
Fix dead players triggering the 'go away' phase

### DIFF
--- a/mission/functions/tasks/primary/fn_task_pri_go_away.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_go_away.sqf
@@ -77,7 +77,18 @@ _taskDataStore setVariable ["go_away", {
 	params ["_taskDataStore"];
 
 	private _areaDescriptor = _taskDataStore getVariable ["areaDescriptor", []];
-	private _playersInArea = allPlayers inAreaArray _areaDescriptor;
+	/*
+	ignore people who are dead. if a counterattack failed and the zone resets
+	there might be 1x AFK player who would block the zone from starting until
+	they disconnect.
+
+	if you change this logic, make sure to change the logic
+	over in fn_task_pri_prepare.sqf too...
+
+	TODO: optimise this so we don't have two different tasks repeating the same code
+	*/
+	private _playersAlive = allPlayers select {alive _x};
+	private _playersInArea = _playersAlive inAreaArray _areaDescriptor;
 	private _playersAreNotInArea = (count _playersInArea) == 0;
 
 	/*

--- a/mission/functions/tasks/primary/fn_task_pri_prepare.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_prepare.sqf
@@ -64,7 +64,19 @@ _taskDataStore setVariable ["prepare", {
 
 	private _endTime = _taskDataStore getVariable ["endTime", 0];
 	private _areaDescriptor = _taskDataStore getVariable ["areaDescriptor", []];
-	private _playersInArea = allPlayers inAreaArray _areaDescriptor;
+	/*
+	ignore people who are dead. if a counterattack failed and the zone resets
+	there might be 1x AFK player who would block the zone from starting until
+	they disconnect.
+
+	if you change this logic, make sure to change the logic
+	over in fn_task_pri_go_away.sqf too...
+
+	TODO: optimise this so we don't have two different tasks repeating the same code
+	*/
+
+	private _playersAlive = allPlayers select {alive _x};
+	private _playersInArea = _playersAlive inAreaArray _areaDescriptor;
 	private _arePlayersInArea = (count _playersInArea) > 0;
 
 	/*


### PR DESCRIPTION
Recent DC unleashed event had an issue where there was 1x dead + AFK player forcing the AO to stay in the black 'go away' phase. 

Had to kick player off the server to get the AO to trigger the blue phase.


![20230426235600_1](https://user-images.githubusercontent.com/11841332/234722377-b9b55810-616e-4f50-8d31-324e14268192.jpg)
