### PR TITLE
[FIX] radio tap could 'reveal' sites already on map (intel).

### DIFF
--- a/mission/functions/systems/sites/fn_reveal_supply_line.sqf
+++ b/mission/functions/systems/sites/fn_reveal_supply_line.sqf
@@ -6,14 +6,23 @@ if (_intelType == 'Land_Map_unfolded_F') then
 {
 	private _hqSites = missionNamespace getVariable ["side_sites_hq", []];
 	{
+		// set the site as "discovered" so the radio tap feature does not 
+		// try and reveal this site
+		_x setVariable ["discovered", true];
+
 		private _markers = _x getVariable ["markers", []];
 		{
 			_x setMarkerAlpha 0.5;
 		} forEach _markers;
+
 	} forEach _hqSites;
 } else {
 	private _factorySites = missionNamespace getVariable ["side_sites_factory", []];
 	{
+		// set the site as "discovered" so the radio tap feature does not 
+		// try and reveal this site
+		_x setVariable ["discovered", true];
+
 		private _markers = _x getVariable ["markers", []];
 		{
 			if((_x find "AA_zone_") >= 0) then {


### PR DESCRIPTION
If an intel revealed sites on map, that site would not be set as 'discovered', meaning the radio tap could "reveal" the site... even though it was already marked on map.