### PR TITLE
[FIX] Mitigate sites spawning in the same location

### DIFF
--- a/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
+++ b/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
@@ -55,13 +55,23 @@ private _fnc_noSitesZoneCheck = {
 	_result
 };
 
-private _hqSites = missionNamespace getVariable ["side_sites_hq",[]];
-private _factorySites = missionNamespace getVariable ["side_sites_factory",[]];
-private _currentSites = _hqSites + _factorySites;
-private _blacklistedSiteAreas  = []; 
-{ 
-	_blacklistedSiteAreas  append [getPos _x, vn_mf_sites_minimum_distance_between_sites]; 
-} forEach _blacklistedSiteAreas;
+// existing sites that we do not want to spawn other sites inside of
+private _currentSites = missionNamespace getVariable ["sites", []];
+private _occupiedSiteAreas = _currentSites apply {
+	[getPos _x, vn_mf_sites_minimum_distance_between_sites]
+};
+
+// BIS_fnc_findSafePos requires a 2D position and a radius
+// but "no_sites_*" area markers could be any shape (rect, square, circle).
+// so we feed in some default value first (not within 100m of centre point)
+// and then do a more correct double check during validation afterwards.
+
+// TODO: Find the maximum edge or radius of the area marker
+private _blacklistedMapZones = vn_mf_markers_no_sites apply {
+	[getMarkerPos _x, 100]
+};
+
+private _blacklistedSiteAreas = _occupiedSiteAreas + _blacklistedMapZones;
 
 private _finalPosition = [_position, 0, _radius, 0, _waterMode, 0.5, 0, [_blacklistedSiteAreas], [_position, _position]] call BIS_fnc_findSafePos;
 private _radGrad = aCos ([0,0,1] vectorCos (surfaceNormal _finalPosition));

--- a/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
+++ b/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
@@ -126,11 +126,11 @@ while  {(_radGrad > _gradientDegrees)
 
 // BIS_getSafePos normally return an [x, y] co-ordinate
 // but will return debug position [0,0,0] if it cannot find anywhere suitable ... 
-// randomise the site position somewhere in the zone if this happens
-if (_finalPosition isEqualTo [0, 0, 0] || (count _finalPosition) == 3) then {
-	_finalPosition = _position getPos [_radius, random 360];
+// randomise the site position somewhere in the zone if this happens.
+// this isn't ideal, but it's better than a tunnel placed in debug!
+if (_finalPosition isEqualTo [0, 0, 0]) then {
+	_finalPosition = _position getPos [random _radius, random 360];
 };
-
 
 if(!(_terrainObjects isEqualTo [])) then 
 {

--- a/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
+++ b/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
@@ -124,6 +124,14 @@ while  {(_radGrad > _gradientDegrees)
 	_iterations = _iterations + 1;
 };
 
+// BIS_getSafePos normally return an [x, y] co-ordinate
+// but will return debug position [0,0,0] if it cannot find anywhere suitable ... 
+// randomise the site position somewhere in the zone if this happens
+if (_finalPosition isEqualTo [0, 0, 0] || (count _finalPosition) == 3) then {
+	_finalPosition = _position getPos [_radius, random 360];
+};
+
+
 if(!(_terrainObjects isEqualTo [])) then 
 {
 	{

--- a/mission/functions/systems/sites/fn_sites_init.sqf
+++ b/mission/functions/systems/sites/fn_sites_init.sqf
@@ -24,6 +24,11 @@ vn_mf_s_max_fortifications_per_zone = getNumber (missionConfigFile >> "map_confi
 vn_mf_s_max_tunnels_per_zone = getNumber (missionConfigFile >> "map_config" >> "max_tunnels_per_zone");
 vn_mf_s_max_vehicle_depots_per_zone = getNumber (missionConfigFile >> "map_config" >> "max_vehicle_depots_per_zone");
 
+// factory and HQ have minimum radius of 55. 
+// Some radars seem to be larger than 55 as well.
+// Add 20 for safety / reliability / QoL.
+vn_mf_sites_minimum_distance_between_sites = 75;
+
 vn_mf_g_sites_partial_discovery_radius = 300;
 publicVariable "vn_mf_g_sites_partial_discovery_radius";
 vn_mf_g_sites_discovery_radius = 50;


### PR DESCRIPTION
The `_blacklistedSiteAreas` variable was always an empty array, meaning `BIS_getSafePos` would never consider existing sites as invalid positions to select.

I've added all existing generated sites and all the `"no_sites_..."` map markers into the check to stop sites spawning on top of one another.

if `BIS_getSafePos` doesn't find a suitable site, it'll return debug position `[0, 0, 0]` so I've added a safety check that'll spawn the site somewhere within the zone.