### PR TITLE
[CHANGE] Add a configurable BN global zone size for each map

### DIFF
--- a/maps/altis/map_config/init.hpp
+++ b/maps/altis/map_config/init.hpp
@@ -8,6 +8,7 @@ class map_config {
 	max_water_supply_per_zone = 2;
 	max_tunnels_per_zone = 3;
 	max_vehicle_depots_per_zone = 3;
+	bn_zone_radius = 1000;
 	class zones {
 		#include "zones.hpp"
 	};

--- a/maps/cam_lao_nam/map_config/init.hpp
+++ b/maps/cam_lao_nam/map_config/init.hpp
@@ -8,6 +8,7 @@ class map_config {
 	max_water_supply_per_zone = 2;
 	max_tunnels_per_zone = 3;
 	max_vehicle_depots_per_zone = 3;
+	bn_zone_radius = 1000;
 	class zones {
 		#include "zones.hpp"
 	};

--- a/maps/vn_khe_sanh/map_config/init.hpp
+++ b/maps/vn_khe_sanh/map_config/init.hpp
@@ -8,6 +8,7 @@ class map_config {
 	max_water_supply_per_zone = 2;
 	max_vehicle_depots_per_zone = 3;
 	starting_zones[] = {"zone_khe_sanh", "zone_kok", "zone_french_fort"};
+	bn_zone_radius = 1000;
 	class zones {
 		#include "zones.hpp"
 	};

--- a/maps/vn_the_bra/map_config/init.hpp
+++ b/maps/vn_the_bra/map_config/init.hpp
@@ -8,6 +8,7 @@ class map_config {
 	max_water_supply_per_zone = 2;
 	max_vehicle_depots_per_zone = 3;
 	starting_zones[] = {"zone_nam_phat", "zone_ban_pakha", "zone_ban_dac_maruk"};
+	bn_zone_radius = 1000;
 	class zones {
 		#include "zones.hpp"
 	};

--- a/mission/functions/systems/sites/fn_sites_generate.sqf
+++ b/mission/functions/systems/sites/fn_sites_generate.sqf
@@ -24,48 +24,48 @@ private _center = markerPos (_zoneData select struct_zone_m_marker);
 private _size = markerSize (_zoneData select struct_zone_m_marker);
 private _sizeX = _size select 0;
 //Create zone HQ
-private _hqPosition = [_center, 1000, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+private _hqPosition = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 [_hqPosition, _zone] call vn_mf_fnc_sites_create_hq;
 
 //Create zone factory
-private _factoryPosition = [_center, 1000, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+private _factoryPosition = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 [_factoryPosition, _zone] call vn_mf_fnc_sites_create_factory;
 
 //Create AA emplacements (ZPUs)
 for "_i" from 1 to (1 + ceil random (vn_mf_s_max_aa_per_zone - 1)) do
 {
-	private _aaSite = [_center, 1000, 0, 20, 10, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+	private _aaSite = [_center, vn_mf_bn_s_zone_radius, 0, 20, 10, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 	[_aaSite, _zone] call vn_mf_fnc_sites_create_aa_site;
 };
 
 //Create initial artillery emplacements
 for "_i" from 1 to (1 + ceil random (vn_mf_s_max_artillery_per_zone - 1)) do
 {
-	private _artySite = [_center, 1000, 0, 20, 10, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+	private _artySite = [_center, vn_mf_bn_s_zone_radius, 0, 20, 10, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 	[_artySite, _zone] call vn_mf_fnc_sites_create_artillery_site;
 };
 
 for "_i" from 1 to (1 + ceil random (vn_mf_s_max_camps_per_zone - 1)) do
 {
 	//[_zoneData] call vn_mf_fnc_sites_create_camp;
-	private _campSite = [_center, 1000, 0, 35, 8, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+	private _campSite = [_center, vn_mf_bn_s_zone_radius, 0, 35, 8, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 	[_campSite, _zone] call vn_mf_fnc_sites_create_camp_site;
 };
 
 for "_i" from 1 to (1 + ceil random (vn_mf_s_max_tunnels_per_zone - 1)) do
 {
-	private _tunnelSite = [_center, 1000, 0, 5, 20, _unnaturalObjects] call vn_mf_fnc_sites_get_safe_location;
+	private _tunnelSite = [_center, vn_mf_bn_s_zone_radius, 0, 5, 20, _unnaturalObjects] call vn_mf_fnc_sites_get_safe_location;
 	[_tunnelSite, _zone] call vn_mf_fnc_sites_create_tunnel_site;
 };
 
 for "_i" from 1 to (1 + ceil random (vn_mf_s_max_water_supply_per_zone - 1)) do
 {
-	private _tunnelWaterSupply = [_center, 1000, 2, 5, 20, _unnaturalObjects] call vn_mf_fnc_sites_get_safe_location;
+	private _tunnelWaterSupply = [_center, vn_mf_bn_s_zone_radius, 2, 5, 20, _unnaturalObjects] call vn_mf_fnc_sites_get_safe_location;
 	[_tunnelWaterSupply, _zone] call vn_mf_fnc_sites_create_water_supply_site;
 };
 for "_i" from 1 to (1 + ceil random (vn_mf_s_max_radars_per_zone - 1)) do
 {
-	private _radar = [_center, 1000, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+	private _radar = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 	[_radar, _zone] call vn_mf_fnc_sites_create_radar;
 };
 

--- a/mission/functions/systems/zones/fn_zones_init.sqf
+++ b/mission/functions/systems/zones/fn_zones_init.sqf
@@ -33,6 +33,8 @@ mf_s_attack_base_priority = 2;
 mf_s_ongoing_attacks = [];
 mf_s_last_attack = serverTime;
 
+vn_mf_bn_s_zone_radius = getNumber (missionConfigFile >> "map_config" >> "bn_zone_radius");
+
 //All zone info
 mf_s_zones = [];
 //All zone names

--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -37,10 +37,12 @@ _taskDataStore setVariable ["INIT", {
 	_zone setMarkerColor "ColorRed";
 	_zone setMarkerBrush "DiagGrid";
 
+	private _areaMarkerSize = vn_mf_bn_s_zone_radius + 100;
+
 	// custom BN: yellow circle around the AO
 	private _areaMarker = createMarker ["activeZoneCircle", _zonePosition];
 	_areaMarker setMarkerShape "ELLIPSE";
-	_areaMarker setMarkerSize [1100, 1100];
+	_areaMarker setMarkerSize [_areaMarkerSize, _areaMarkerSize];
 	_areaMarker setMarkerAlpha 1;
 	_areaMarker setMarkerBrush "Border";
 	_areaMarker setMarkerColor "ColorYellow";

--- a/mission/functions/tasks/primary/fn_task_pri_go_away.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_go_away.sqf
@@ -51,7 +51,7 @@ _taskDataStore setVariable ["INIT", {
 	WARNING: Do not change size here without checking the other AO tasks too!
 	NOTE: marker is deleted during task clean up (bottom of script file)
 	*/
-	private _areaMarkerSize = 1100;
+	private _areaMarkerSize = vn_mf_bn_s_zone_radius + 100;
 	private _areaDescriptor = [_zonePosition, _areaMarkerSize, _areaMarkerSize, 0, false];
 
 	private _areaMarker = createMarker ["goAwayZoneCircle", _zonePosition];

--- a/mission/functions/tasks/primary/fn_task_pri_prepare.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_prepare.sqf
@@ -36,7 +36,7 @@ _taskDataStore setVariable ["INIT", {
 	WARNING: Do not change size here without checking the capture logic too!
 	NOTE: marker is deleted during task clean up (bottom of script file)
 	*/
-	private _areaMarkerSize = 1100;
+	private _areaMarkerSize = vn_mf_bn_s_zone_radius + 100;
 	private _areaDescriptor = [_zonePosition, _areaMarkerSize, _areaMarkerSize, 0, false];
 
 	private _areaMarker = createMarker ["prepZoneCircle", _zonePosition];


### PR DESCRIPTION
There are a few places where the BN zone radius of `1000` is hardcoded. This change switches it to a config value defined for each map.

This is **very useful** for maps like The Bra, which tends to have a LOT of compositions spawned off the edge of the map (the zone radius is way too high). 

Initial The Bra zone with radius config set to 500m (yellow circle radius = `vn_mf_bn_s_zone_radius + 100`)

![20230514183736_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/b409ad33-4ced-4f46-b23a-62ef2cc46097)


edit -- just a note about something I found during testing -- Factory and HQ compositions will not spawn on the Bra map because of the below line in each of the scripts for [HQ Buildings](https://github.com/Bro-Nation/Mike-Force/blob/development/mission/functions/systems/sites/fn_create_hq_buildings.sqf#L35) and [Factory Buildings](https://github.com/Bro-Nation/Mike-Force/blob/development/mission/functions/systems/sites/fn_create_factory_buildings.sqf#L33)

```sqf
if(toLower(worldName) in ["cam_lao_nam", "vn_khe_sanh"])then {
``` 
