### PR TITLE
[BUGFIX] Disable group AI chatter on player init

### DIFF
--- a/mission/functions/core/teams/fn_force_team_change.sqf
+++ b/mission/functions/core/teams/fn_force_team_change.sqf
@@ -41,8 +41,12 @@ _player setVariable ["vn_mf_db_player_group", _team, true];
 private _nextPlayerTeamArray = missionNamespace getVariable [_team, []];
 _nextPlayerTeamArray pushBackUnique _player;
 
-// @dijksterhuis commenting out as it just causes script errors (no-one from
-// SGD responded to my discord post about it)
+/*
+  @dijksterhuis commenting out line below as it just causes script errors 
+  (no-one from SGD responded to my discord post about it).
+  Have tested and it does not affect players switching teams.
+  The list of players in a given team is updated regardless of the line below.
+*/
 // publicVariable _nextPlayerTeam;
 
 [[_team], {

--- a/mission/functions/core/teams/fn_force_team_change.sqf
+++ b/mission/functions/core/teams/fn_force_team_change.sqf
@@ -40,7 +40,10 @@ publicVariable _playerGroup;
 _player setVariable ["vn_mf_db_player_group", _team, true];
 private _nextPlayerTeamArray = missionNamespace getVariable [_team, []];
 _nextPlayerTeamArray pushBackUnique _player;
-publicVariable _nextPlayerTeam;
+
+// @dijksterhuis commenting out as it just causes script errors (no-one from
+// SGD responded to my discord post about it)
+// publicVariable _nextPlayerTeam;
 
 [[_team], {
 	[] call vn_mf_fnc_task_refresh_tasks_client;

--- a/mission/para_player_loaded_client.sqf
+++ b/mission/para_player_loaded_client.sqf
@@ -53,8 +53,11 @@ private _fnc_disableChatter = {
 	{ _x disableAI "RADIOPROTOCOL"; _x setSpeaker "NoVoice"; } forEach allPlayers;
 };
 
+// need to run this now to disable AO radio chatter on first life.
+[] call _fnc_disableChatter;
+
 private _fnc_respawnEventHandler = {
-	call _fnc_disableChatter;
+	[] call _fnc_disableChatter;
 	call vn_mf_fnc_update_channels;
 };
 


### PR DESCRIPTION
[This line change in merged PR](https://github.com/Bro-Nation/Mike-Force/pull/133/files#diff-d4f0c19f2bdd12033df58bd21b29a5feb5abe3ce83b6842604253ad182458103L55) means that AI group chatter isn't disabled on initial player init.

[This line was added by upstream SGD changes](https://github.com/Bro-Nation/Mike-Force/blob/development/mission/functions/core/teams/fn_force_team_change.sqf#L43) but I've never see it do anything except throw a script error. There is no reference to a to `_nextPlayerTeam` anywhere in the entire Mike Force codebase and the list of players in a given team is updated without it. Asked in SGD discord but got no response. Have tested with and without the change and it does absolutely nothing from what I can tell.