### PR TITLE
[SiteGen] change elephant grass to be more dynamic 

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -275,6 +275,7 @@ class CfgFunctions
 			// Placement functions
 			class sites_get_safe_location {};
 			class sites_find_area_gradient {};
+			class sites_objmapper_dynamic_grass {};
 
 			class destroy_task {};
 

--- a/mission/functions/systems/sites/fn_create_camp_buildings.sqf
+++ b/mission/functions/systems/sites/fn_create_camp_buildings.sqf
@@ -749,7 +749,8 @@ vn_mf_camp_compositions = [
 ]
 ];
 
-private _campObjects = [_position, 0, selectRandom vn_mf_camp_compositions] call BIS_fnc_objectsMapper;
+private _site_objs = [selectRandom vn_mf_camp_compositions, 0.7] call vn_mf_fnc_sites_objmapper_dynamic_grass;
+
 {
 
 	if (_x isKindOf "StaticWeapon") then {
@@ -759,6 +760,6 @@ private _campObjects = [_position, 0, selectRandom vn_mf_camp_compositions] call
 		_x allowDamage true;
 	};
 	
-} forEach _campObjects;
+} forEach _site_objs;
 
-_campObjects
+_site_objs

--- a/mission/functions/systems/sites/fn_create_mortar_buildings.sqf
+++ b/mission/functions/systems/sites/fn_create_mortar_buildings.sqf
@@ -525,7 +525,8 @@ vn_mf_arty_compositions = [
 ]
 ];
 
-private _artyObjects = [_position, 0, selectRandom vn_mf_arty_compositions] call BIS_fnc_objectsMapper;
+private _site_objs = [selectRandom vn_mf_arty_compositions, 0.3] call vn_mf_fnc_sites_objmapper_dynamic_grass;
+
 {
 
 	if (_x isKindOf "StaticWeapon") then {
@@ -535,6 +536,6 @@ private _artyObjects = [_position, 0, selectRandom vn_mf_arty_compositions] call
 		_x allowDamage true;
 	};
 	
-} forEach _artyObjects;
+} forEach _site_objs;
 
-_artyObjects
+_site_objs

--- a/mission/functions/systems/sites/fn_create_radar_buildings.sqf
+++ b/mission/functions/systems/sites/fn_create_radar_buildings.sqf
@@ -789,13 +789,8 @@ if(toLower(worldName) in ["cam_lao_nam", "vn_khe_sanh"])then {
 
 };
 
-//if(toLower(worldName) isEqualTo "tanoa")then {
-//	vn_mf_hq_composition = [
-//	];
-//};
+private _site_objs = [selectRandom vn_mf_radar_compositions, 0.5] call vn_mf_fnc_sites_objmapper_dynamic_grass;
 
-private _randomAngle = [0,360] call BIS_fnc_randomInt;
-private _radarObjects = [_position, _randomAngle, selectRandom vn_mf_radar_compositions] call BIS_fnc_objectsMapper;
 {
     if (_x isKindOf "GRAD_envelope_giant") then {
         _x setVectorUp (surfaceNormal getPos _x);
@@ -804,6 +799,6 @@ private _radarObjects = [_position, _randomAngle, selectRandom vn_mf_radar_compo
 	if (_x isKindOf "Land_vn_o_trench_firing_01") then {
         _x setVectorUp (surfaceNormal getPos _x);
     };
-} forEach _radarObjects;
+} forEach _site_objs;
 
-_radarObjects
+_site_objs

--- a/mission/functions/systems/sites/fn_sites_objmapper_dynamic_grass.sqf
+++ b/mission/functions/systems/sites/fn_sites_objmapper_dynamic_grass.sqf
@@ -19,7 +19,7 @@
 		call vn_mf_fnc_action_destroy_respawn;
 */
 
-params ["_composition_arr", ["_grassBadChance", 0.333]];
+params ["_composition_arr", ["_grassBadChance", 0.4]];
 
 private _grass_arr = _composition_arr select { ((_x select 0) isEqualTo "Land_vn_elephant_grass_01" ) };
 private _non_grass_arr = _composition_arr select { !((_x select 0) isEqualTo "Land_vn_elephant_grass_01" ) };

--- a/mission/functions/systems/sites/fn_sites_objmapper_dynamic_grass.sqf
+++ b/mission/functions/systems/sites/fn_sites_objmapper_dynamic_grass.sqf
@@ -1,0 +1,31 @@
+/*
+	File: fn_sites_objmapper_dynamic_grass.sqf
+	Author: "DJ" dijksterhuis
+	Public: No
+	
+	Description:
+		Spawns in objects for site generation with BIS_fnc_objectsMapper.
+
+		If the object is a type of "Land_vn_elephant_grass_01" then set the 
+		badChance randomisation parameter to make sites more dynamic.
+	
+	Parameter(s): 
+		_composition_arr: array of all object to spawn with BIS_fnc_objectsMapper
+		_grassBadChance: random chance of *not* spawning "Land_vn_elephant_grass_01" objects
+	
+	Returns: all objects spawned in by object mapper BIS_fnc_objectsMapper
+	
+	Example(s):
+		call vn_mf_fnc_action_destroy_respawn;
+*/
+
+params ["_composition_arr", ["_grassBadChance", 0.333]];
+
+private _grass_arr = _composition_arr select { ((_x select 0) isEqualTo "Land_vn_elephant_grass_01" ) };
+private _non_grass_arr = _composition_arr select { !((_x select 0) isEqualTo "Land_vn_elephant_grass_01" ) };
+
+private _randomAngle = [0,360] call BIS_fnc_randomInt;
+private _grass_objs = [_position, _randomAngle, _grass_arr, _grassBadChance] call BIS_fnc_objectsMapper;
+private _non_grass_objs = [_position, _randomAngle, _non_grass_arr, 0] call BIS_fnc_objectsMapper;
+
+_grass_objs + _non_grass_objs


### PR DESCRIPTION
**TL;DR** -- Each time certain sites are created the grass placement will be randomised, and there will be less grass.


### Details

Now a random % chance for grass objects to not spawn in depending on the site being created. This only happens for `Land_vn_elephant_grass_01` classes. Chances of each grass object not being spawned in

- Camps: 70% 
- Radars: 50%
- Arty: 30%

Camps have a significantly higher "do not spawn" % at there was a **lot** of elephant grass in some of the site arrays.

I have not touched the HQ as I'm thinking it should be a hard position to capture. And there's not much in the way of defences without the grass. But can add it in to the new system if requested.

### Screenshots

Radar

![20230620031841_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/2424bf11-0a6f-44be-9660-5e59533d29d5)

Camp

![20230620031904_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/efedec7e-0619-4b9c-b484-a216ce576182)

Arty (spawn position was in grass anyway)

![20230620031926_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/286aa0f5-ef5c-4412-b2ea-1e291f23e22c)

Arty (spawn position not in grass)

![20230620031938_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/848386c4-b818-4ad1-8d9c-8e0a9fcc5d01)
