### PR TITLE
Add simple field detain mechanic

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -161,6 +161,7 @@ class CfgFunctions
 			class action_gather_intel {};
 			class action_radiotap {};
 			class action_capture_player {};
+			class action_detain_player {};
 			class action_drink_water {};
 			class action_eat_food {};
 		};
@@ -194,6 +195,7 @@ class CfgFunctions
 			file = "functions\systems\dac_cong";
 
 			class capture_player {};
+			class detain_player {};
 		}
 
 		//Gameplay director, responsible for main game progression and flow.

--- a/mission/functions/systems/actions/fn_action_detain_player.sqf
+++ b/mission/functions/systems/actions/fn_action_detain_player.sqf
@@ -1,0 +1,35 @@
+/*
+	File: fn_action_detain_player.sqf
+	Author: 'DJ' Dijksterhuis
+	Public: No
+	
+	Description:
+		Detain a incapacitated opponent
+	
+	Parameter(s): none
+	
+	Returns:
+	
+	Example(s):
+		call vn_mf_fnc_action_capture_player;
+*/
+
+[
+	player,											// Object the action is attached to
+	format ["<t color='#0000FF'>%1</t>", localize 'STR_vn_mf_capture_player'],							// Title of the action
+	"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_secure_ca.paa",	// Idle icon shown on screen
+	"\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_secure_ca.paa",	// Progress icon shown on screen
+	"player getVariable ['vn_mf_side', WEST] != cursorTarget getVariable ['vn_mf_side', WEST] && player distance cursorTarget <= 3 && { vehicle player isEqualTo player && {cursorTarget isKindOf 'Man' && {alive cursorTarget && { [cursorTarget] call vn_fnc_revive_moving && {[player] call vn_fnc_revive_moving && { [cursorTarget] call vn_fnc_revive_incap && { !([player] call vn_fnc_revive_incap) }}}}}}}",	// Condition for the action to be shown
+	"player distance cursorTarget < 5",						// Condition for the action to progress
+	{},	// Code executed when action starts
+	{},	// Code executed on every progress tick
+	{
+		[cursorTarget, player] remoteExec ["vn_mf_fnc_detain_player", 2];
+	},// Code executed on completion
+	{},	// Code executed on interrupted
+	[],													// Arguments passed to the scripts as _this select 3
+	1,													// Action duration [s]
+	100,													// Priority
+	false,											// Remove on completion
+	false												// Show in unconscious state
+] call BIS_fnc_holdActionAdd;

--- a/mission/functions/systems/dac_cong/fn_detain_player.sqf
+++ b/mission/functions/systems/dac_cong/fn_detain_player.sqf
@@ -1,0 +1,46 @@
+/*
+    File: fn_detain_player.sqf
+    Author: "DJ" Dijksterhuis
+    Public: No
+
+    Description:
+	Detain target player (strip them of gear) but *do not* send them to the cages.
+
+    Parameter(s): _target - [PLAYER]
+
+    Returns: nothing
+
+    Example(s):
+	[_target] call vn_mf_fnc_detain_player;
+*/
+params ["_target", "_player"];
+
+if !(isPlayer _target) exitWith {};
+
+{
+	removeAllAssignedItems player;
+	removeAllItems player;
+	removeGoggles player;
+	removeHeadgear player;
+	removeAllWeapons player;
+	removeVest player;
+	removeBackpack player;
+	//temporarily moved aside player forceAddUniform "vn_o_uniform_nva_army_01_01" (selectRandom ["vn_b_uniform_macv_01_01","vn_b_uniform_macv_01_02","vn_b_uniform_macv_01_03","vn_b_uniform_macv_01_04","vn_b_uniform_macv_01_05","vn_b_uniform_macv_01_06"])
+	player addItem "vn_o_item_firstaidkit";
+	player addItem "vn_o_item_firstaidkit";
+	player addItem "vn_o_item_firstaidkit";
+	player addItem "vn_o_item_firstaidkit";
+	
+} remoteExec ["call", _target];
+
+private _message = format ["%1 has detained %2!", name _player, name _target];
+private _nearbyCages = nearestObjects [getPos _target, ["Logic"], 10, false];
+
+if(_player getVariable 'vn_mf_side' == east) then {
+	["POWCapturedRed", [_message]] remoteExec ["para_c_fnc_show_notification", allPlayers];
+} else {
+	private _cage = selectRandom vn_dc_cages;
+	["POWCapturedBlue", [_message]] remoteExec ["para_c_fnc_show_notification", allPlayers];
+};
+
+

--- a/mission/functions/systems/dac_cong/fn_detain_player.sqf
+++ b/mission/functions/systems/dac_cong/fn_detain_player.sqf
@@ -34,7 +34,6 @@ if !(isPlayer _target) exitWith {};
 } remoteExec ["call", _target];
 
 private _message = format ["%1 has detained %2!", name _player, name _target];
-private _nearbyCages = nearestObjects [getPos _target, ["Logic"], 10, false];
 
 if(_player getVariable 'vn_mf_side' == east) then {
 	["POWCapturedRed", [_message]] remoteExec ["para_c_fnc_show_notification", allPlayers];

--- a/mission/para_player_init_server.sqf
+++ b/mission/para_player_init_server.sqf
@@ -113,6 +113,7 @@ if !(rank _player isEqualTo _rank) then
 // send all variables to player
 [_local_vars] remoteExecCall ["para_c_fnc_set_local_var",_player];
 
+_player call vn_mf_fnc_action_detain_player;
 _player call vn_mf_fnc_action_capture_player;
 
 _player setVariable ["para_s_player_initialised", true];


### PR DESCRIPTION
Default hold action interaction changed to new **detain** script, which removes all gear from the target player except 4x FAKs, leaving them stranded in the field while incapacitated.

There's no "arrest" mechanic implemented, but savvy players will know it is possible to stabilise someone, then then just carry them away to have your way with them.

If the players doing the detaining don't want to carry the enemy away, they can still use the **capture** mechanic via the scroll wheel (should be the second option).

Detain script makes an announcement to all players, adding risk to using the detain option -- detainee's allies can still see the detainee on map and could either try to rescue their friend and/or search for the enemy player(s) in the vicinity.

Leaving in draft until I have a chance to test on local dedi instance (because client-server-client code and needs two arma instances to test it properly)