### PR TITLE
[UPDATE] Switch around the order sites are spawned in.

### DIFF
--- a/mission/functions/systems/sites/fn_sites_generate.sqf
+++ b/mission/functions/systems/sites/fn_sites_generate.sqf
@@ -23,19 +23,26 @@ private _unnaturalObjects = 	["HIDE", "WATERTOWER", "STACK", "FOUNTAIN", "RUIN",
 private _center = markerPos (_zoneData select struct_zone_m_marker);
 private _size = markerSize (_zoneData select struct_zone_m_marker);
 private _sizeX = _size select 0;
-//Create zone HQ
-private _hqPosition = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
-[_hqPosition, _zone] call vn_mf_fnc_sites_create_hq;
 
 //Create zone factory
 private _factoryPosition = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 [_factoryPosition, _zone] call vn_mf_fnc_sites_create_factory;
 
-//Create AA emplacements (ZPUs)
-for "_i" from 1 to (1 + ceil random (vn_mf_s_max_aa_per_zone - 1)) do
+//Create zone HQ
+private _hqPosition = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+[_hqPosition, _zone] call vn_mf_fnc_sites_create_hq;
+
+for "_i" from 1 to (1 + ceil random (vn_mf_s_max_radars_per_zone - 1)) do
 {
-	private _aaSite = [_center, vn_mf_bn_s_zone_radius, 0, 20, 10, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
-	[_aaSite, _zone] call vn_mf_fnc_sites_create_aa_site;
+	private _radar = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+	[_radar, _zone] call vn_mf_fnc_sites_create_radar;
+};
+
+for "_i" from 1 to (1 + ceil random (vn_mf_s_max_camps_per_zone - 1)) do
+{
+	//[_zoneData] call vn_mf_fnc_sites_create_camp;
+	private _campSite = [_center, vn_mf_bn_s_zone_radius, 0, 35, 8, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+	[_campSite, _zone] call vn_mf_fnc_sites_create_camp_site;
 };
 
 //Create initial artillery emplacements
@@ -45,11 +52,11 @@ for "_i" from 1 to (1 + ceil random (vn_mf_s_max_artillery_per_zone - 1)) do
 	[_artySite, _zone] call vn_mf_fnc_sites_create_artillery_site;
 };
 
-for "_i" from 1 to (1 + ceil random (vn_mf_s_max_camps_per_zone - 1)) do
+//Create AA emplacements (ZPUs)
+for "_i" from 1 to (1 + ceil random (vn_mf_s_max_aa_per_zone - 1)) do
 {
-	//[_zoneData] call vn_mf_fnc_sites_create_camp;
-	private _campSite = [_center, vn_mf_bn_s_zone_radius, 0, 35, 8, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
-	[_campSite, _zone] call vn_mf_fnc_sites_create_camp_site;
+	private _aaSite = [_center, vn_mf_bn_s_zone_radius, 0, 20, 10, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+	[_aaSite, _zone] call vn_mf_fnc_sites_create_aa_site;
 };
 
 for "_i" from 1 to (1 + ceil random (vn_mf_s_max_tunnels_per_zone - 1)) do
@@ -62,11 +69,6 @@ for "_i" from 1 to (1 + ceil random (vn_mf_s_max_water_supply_per_zone - 1)) do
 {
 	private _tunnelWaterSupply = [_center, vn_mf_bn_s_zone_radius, 2, 5, 20, _unnaturalObjects] call vn_mf_fnc_sites_get_safe_location;
 	[_tunnelWaterSupply, _zone] call vn_mf_fnc_sites_create_water_supply_site;
-};
-for "_i" from 1 to (1 + ceil random (vn_mf_s_max_radars_per_zone - 1)) do
-{
-	private _radar = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
-	[_radar, _zone] call vn_mf_fnc_sites_create_radar;
 };
 
 // add the "Tap Radio Comms" hold action to all generated radio sets


### PR DESCRIPTION
Fixing the "don't spawn sites on top of each other" code means the order in which sites are spawned is more important. The later in the order, the less spaces in an AO there is as existing sites may have taken the best spots for spawning already.

Factory + HQ are largest sites, so need to go first. Factory has greatest chance of blowing up, so I've put it first now.

Radars are next largest, taking up same amount of space as the HQ/Factory.

Then camps.

Then Arty/AA

WS / Tunnels require least space so they go last.