### PR TITLE
[UPDATE] Add a selection of flags as buildable items.

### DIFF
--- a/mission/config/subconfigs/buildables.hpp
+++ b/mission/config/subconfigs/buildables.hpp
@@ -6405,7 +6405,7 @@ class vn_flag_pavn
 {
 	name = "";
 	type = "flag";
-	categories[] = {"flags"};
+	categories[] = {"flags", "nv"};
 	rank = 0;
 	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
 	resupply = "BuildingSupplies";

--- a/mission/config/subconfigs/buildables.hpp
+++ b/mission/config/subconfigs/buildables.hpp
@@ -6401,14 +6401,11 @@ class Land_vn_usaf_revetment_helipad_02
 	};
 };*/
 
-/*
-BN CUSTOM -- FLAGS!
-*/
-class flag_POWMIA_F
+class vn_flag_pavn
 {
 	name = "";
-	type = "radio";
-	categories[] = {"decorative"};
+	type = "flag";
+	categories[] = {"flags"};
 	rank = 0;
 	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
 	resupply = "BuildingSupplies";
@@ -6417,31 +6414,30 @@ class flag_POWMIA_F
 		CONDITION_IS_ENGINEER,
 		CONDITION_IS_ON_FOOT,
 		CONDITION_NOT_IN_RESTRICTED_ZONE,
-		CONDITION_IS_ACAV
+		CONDITION_IS_DAC_CONG
 	};
 	class build_states
 	{
 		class initial_state
 		{
-			object_class = "flag_POWMIA_F";
+			object_class = "vn_flag_pavn";
 		};
 		class middle_state
 		{
-			object_class = "flag_POWMIA_F";
+			object_class = "vn_flag_pavn";
 		};
 		class final_state
 		{
-			object_class = "flag_POWMIA_F";
+			object_class = "vn_flag_pavn";
 		};
 	};
-
 };
 
-class flag_RedCrystal_F
+class vn_flag_usa
 {
 	name = "";
-	type = "radio";
-	categories[] = {"decorative"};
+	type = "flag";
+	categories[] = {"flags"};
 	rank = 0;
 	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
 	resupply = "BuildingSupplies";
@@ -6456,59 +6452,24 @@ class flag_RedCrystal_F
 	{
 		class initial_state
 		{
-			object_class = "flag_RedCrystal_F";
+			object_class = "vn_flag_usa";
 		};
 		class middle_state
 		{
-			object_class = "flag_RedCrystal_F";
+			object_class = "vn_flag_usa";
 		};
 		class final_state
 		{
-			object_class = "flag_RedCrystal_F";
+			object_class = "vn_flag_usa";
 		};
 	};
-
-};
-
-class flag_USA_F
-{
-	name = "";
-	type = "radio";
-	categories[] = {"decorative"};
-	rank = 0;
-	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
-	resupply = "BuildingSupplies";
-	conditions[] = {
-		CONDITION_HAS_RANK,
-		CONDITION_IS_ENGINEER,
-		CONDITION_IS_ON_FOOT,
-		CONDITION_NOT_IN_RESTRICTED_ZONE,
-		CONDITION_IS_ACAV
-	};
-	class build_states
-	{
-		class initial_state
-		{
-			object_class = "flag_USA_F";
-		};
-		class middle_state
-		{
-			object_class = "flag_USA_F";
-		};
-		class final_state
-		{
-			object_class = "flag_USA_F";
-		};
-	};
-	class features
-
 };
 
 class vn_flag_aus
 {
 	name = "";
-	type = "radio";
-	categories[] = {"decorative"};
+	type = "flag";
+	categories[] = {"flags"};
 	rank = 0;
 	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
 	resupply = "BuildingSupplies";
@@ -6534,14 +6495,13 @@ class vn_flag_aus
 			object_class = "vn_flag_aus";
 		};
 	};
-
 };
 
 class vn_flag_nz
 {
 	name = "";
-	type = "radio";
-	categories[] = {"decorative"};
+	type = "flag";
+	categories[] = {"flags"};
 	rank = 0;
 	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
 	resupply = "BuildingSupplies";
@@ -6565,38 +6525,6 @@ class vn_flag_nz
 		class final_state
 		{
 			object_class = "vn_flag_nz";
-		};
-	};
-};
-
-class vn_flag_rok
-{
-	name = "";
-	type = "radio";
-	categories[] = {"decorative"};
-	rank = 0;
-	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
-	resupply = "BuildingSupplies";
-	conditions[] = {
-		CONDITION_HAS_RANK,
-		CONDITION_IS_ENGINEER,
-		CONDITION_IS_ON_FOOT,
-		CONDITION_NOT_IN_RESTRICTED_ZONE,
-		CONDITION_IS_ACAV
-	};
-	class build_states
-	{
-		class initial_state
-		{
-			object_class = "vn_flag_rok";
-		};
-		class middle_state
-		{
-			object_class = "vn_flag_rok";
-		};
-		class final_state
-		{
-			object_class = "vn_flag_rok";
 		};
 	};
 };
@@ -6604,8 +6532,8 @@ class vn_flag_rok
 class vn_flag_arvn
 {
 	name = "";
-	type = "radio";
-	categories[] = {"decorative"};
+	type = "flag";
+	categories[] = {"flags"};
 	rank = 0;
 	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
 	resupply = "BuildingSupplies";

--- a/mission/config/subconfigs/buildables.hpp
+++ b/mission/config/subconfigs/buildables.hpp
@@ -6400,3 +6400,235 @@ class Land_vn_usaf_revetment_helipad_02
 		};
 	};
 };*/
+
+/*
+BN CUSTOM -- FLAGS!
+*/
+class flag_POWMIA_F
+{
+	name = "";
+	type = "radio";
+	categories[] = {"decorative"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "flag_POWMIA_F";
+		};
+		class middle_state
+		{
+			object_class = "flag_POWMIA_F";
+		};
+		class final_state
+		{
+			object_class = "flag_POWMIA_F";
+		};
+	};
+
+};
+
+class flag_RedCrystal_F
+{
+	name = "";
+	type = "radio";
+	categories[] = {"decorative"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "flag_RedCrystal_F";
+		};
+		class middle_state
+		{
+			object_class = "flag_RedCrystal_F";
+		};
+		class final_state
+		{
+			object_class = "flag_RedCrystal_F";
+		};
+	};
+
+};
+
+class flag_USA_F
+{
+	name = "";
+	type = "radio";
+	categories[] = {"decorative"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "flag_USA_F";
+		};
+		class middle_state
+		{
+			object_class = "flag_USA_F";
+		};
+		class final_state
+		{
+			object_class = "flag_USA_F";
+		};
+	};
+	class features
+
+};
+
+class vn_flag_aus
+{
+	name = "";
+	type = "radio";
+	categories[] = {"decorative"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "vn_flag_aus";
+		};
+		class middle_state
+		{
+			object_class = "vn_flag_aus";
+		};
+		class final_state
+		{
+			object_class = "vn_flag_aus";
+		};
+	};
+
+};
+
+class vn_flag_nz
+{
+	name = "";
+	type = "radio";
+	categories[] = {"decorative"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "vn_flag_nz";
+		};
+		class middle_state
+		{
+			object_class = "vn_flag_nz";
+		};
+		class final_state
+		{
+			object_class = "vn_flag_nz";
+		};
+	};
+};
+
+class vn_flag_rok
+{
+	name = "";
+	type = "radio";
+	categories[] = {"decorative"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "vn_flag_rok";
+		};
+		class middle_state
+		{
+			object_class = "vn_flag_rok";
+		};
+		class final_state
+		{
+			object_class = "vn_flag_rok";
+		};
+	};
+};
+
+class vn_flag_arvn
+{
+	name = "";
+	type = "radio";
+	categories[] = {"decorative"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "vn_flag_arvn";
+		};
+		class middle_state
+		{
+			object_class = "vn_flag_arvn";
+		};
+		class final_state
+		{
+			object_class = "vn_flag_arvn";
+		};
+	};
+};

--- a/mission/stringtable.xml
+++ b/mission/stringtable.xml
@@ -1284,6 +1284,10 @@
         <Original>Barracks</Original>
         <English>Barracks</English>
       </Key>
+      <Key ID="STR_vn_mf_buildingMenu_category_flags">
+          <Original>Flags</Original>
+          <English>Flags</English>
+      </Key>
       <Key ID="STR_vn_mf_buildingMenu_category_walls">
         <Original>Walls</Original>
         <English>Walls</English>


### PR DESCRIPTION
Adds a collection of flags that players can build (potential in future to re-add the flag raising/capture mechanic between players and DC).

Here's the *final* list

- `vn_flag_pavn` (DC Only)
- `vn_flag_usa`
- `vn_flag_aus`
- `vn_flag_nz`
- `vn_flag_arvn`

### screenshots

![20230729165909_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/416f82c1-04a3-48f9-aedb-e4d2b81366dc)
![20230729165816_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/4e052909-466c-42da-8572-5c1afb29e20b)
![20230729170811_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/a708f8b0-ba80-4739-831c-2335db1cd10b)
![20230729170639_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/c7913f19-8181-4ab7-ae1f-471b3c4352b7)


### TODO

- [x] Add a new category for `flags` in build UI
- [x] Switch all flags over to new `flags` category (currently using `radio`)
- [x] testing