### PR TITLE
[UPDATE] Add Land_Shed_06_F as buildable under 'buildings' category.

### DIFF
--- a/mission/config/subconfigs/buildables.hpp
+++ b/mission/config/subconfigs/buildables.hpp
@@ -6277,6 +6277,43 @@ class Land_vn_hut_river_03
 	};
 };
 
+class Land_Shed_06_F
+{
+	name = "";
+	type = "buildings";
+	categories[] = {"buildings"};
+	rank = 0;
+	SUPPLY_CAPACITY(200, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		/*
+		the Land_vn_shed_06_f object does not have
+		corresponding partX assets so it cannot show
+		wireframe stages during the player build.
+		*/
+		class initial_state
+		{
+			object_class = "Land_vn_shed_06_f";
+		};
+		class middle_state
+		{
+			object_class = "Land_vn_shed_06_f";
+		};
+		class final_state
+		{
+			object_class = "Land_vn_shed_06_f";
+		};
+	};
+};
+
 /*
 class Land_vn_usaf_revetment_helipad_02
 {
@@ -6400,41 +6437,3 @@ class Land_vn_usaf_revetment_helipad_02
 		};
 	};
 };*/
-
-class Land_Shed_06_F
-{
-	name = "";
-	type = "buildings";
-	categories[] = {"buildings"};
-	rank = 0;
-	SUPPLY_CAPACITY(200, DAYS_TO_SECONDS(1));
-	resupply = "BuildingSupplies";
-	conditions[] = {
-		CONDITION_HAS_RANK,
-		CONDITION_IS_ENGINEER,
-		CONDITION_IS_ON_FOOT,
-		CONDITION_NOT_IN_RESTRICTED_ZONE,
-		CONDITION_IS_ACAV
-	};
-	class build_states
-	{
-		/*
-		the Land_vn_shed_06_f object does not have
-		corresponding partX assets so it cannot show
-		wireframe stages during the player build.
-		*/
-		class initial_state
-		{
-			object_class = "Land_vn_shed_06_f";
-		};
-		class middle_state
-		{
-			object_class = "Land_vn_shed_06_f";
-		};
-		class final_state
-		{
-			object_class = "Land_vn_shed_06_f";
-		};
-	};
-};
-

--- a/mission/config/subconfigs/buildables.hpp
+++ b/mission/config/subconfigs/buildables.hpp
@@ -6400,3 +6400,35 @@ class Land_vn_usaf_revetment_helipad_02
 		};
 	};
 };*/
+class Land_Shed_06_F
+{
+	name = "";
+	type = "buildings";
+	categories[] = {"buildings"};
+	rank = 0;
+	SUPPLY_CAPACITY(200, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "Land_Shed_06_F_part0";
+		};
+		class middle_state
+		{
+			object_class = "Land_Shed_06_F_part1";
+		};
+		class final_state
+		{
+			object_class = "Land_Shed_06_F";
+		};
+	};
+};
+

--- a/mission/config/subconfigs/buildables.hpp
+++ b/mission/config/subconfigs/buildables.hpp
@@ -6400,6 +6400,7 @@ class Land_vn_usaf_revetment_helipad_02
 		};
 	};
 };*/
+
 class Land_Shed_06_F
 {
 	name = "";
@@ -6417,17 +6418,22 @@ class Land_Shed_06_F
 	};
 	class build_states
 	{
+		/*
+		the Land_vn_shed_06_f object does not have
+		corresponding partX assets so it cannot show
+		wireframe stages during the player build.
+		*/
 		class initial_state
 		{
-			object_class = "Land_Shed_06_F_part0";
+			object_class = "Land_vn_shed_06_f";
 		};
 		class middle_state
 		{
-			object_class = "Land_Shed_06_F_part1";
+			object_class = "Land_vn_shed_06_f";
 		};
 		class final_state
 		{
-			object_class = "Land_Shed_06_F";
+			object_class = "Land_vn_shed_06_f";
 		};
 	};
 };


### PR DESCRIPTION
- [x] Tested

As per ticket in discord.

Changed the categories from the provided configuration (was `barracks`, now `buildings`)

![20230729162856_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/6af25cd3-91a5-4074-934a-c927c44e70c9)

Something to note -- we can't show a red/green/blue wireframe for this one as it has no associated `_partX` objects (all the `partX` suffixed objects were custom added by SGD I believe).

### can build, but no colours
![20230729162916_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/8ced4a00-b4b8-412e-8ad4-c9f50d38cedd)


### can't build, but no colours
![20230729164402_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/176b98ea-7182-4de5-a8c9-90634b0fd0fc)
