### PR TITLE
[FIXUP] Overlay timer was showing 360 minutes for 6 minute task.

### DIFF
--- a/mission/functions/tasks/primary/fn_task_pri_prepare.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_prepare.sqf
@@ -310,7 +310,7 @@ _taskDataStore setVariable ["INIT", {
 	private _totalTaskDurationSeconds = (_taskDataStore getVariable ["subtaskDurationSeconds", 0]) * 2;
 	["AttackPreparing", [format ["%1", _totalTaskDurationSeconds]]] remoteExec ["para_c_fnc_show_notification", 0];
 	[] call vn_mf_fnc_timerOverlay_removeGlobalTimer;
-	["Attack Operation preparation", serverTime + (_totalTaskDurationSeconds * 60), true] call vn_mf_fnc_timerOverlay_setGlobalTimer;
+	["Attack Operation preparation", serverTime + _totalTaskDurationSeconds, true] call vn_mf_fnc_timerOverlay_setGlobalTimer;
 
 	diag_log format ["Prepare AO: Init Finished, switching to RTB subtask"];
 


### PR DESCRIPTION
I multiplied a variable by 60 when not needed...

Timer in the bottom right was showing 360 minutes instead of 6 minutes... 🙄 

![20230729182725_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/06677189-2de8-48d4-866a-f426d69873a0)
