### PR TITLE
[FIXUP] Defend objective AI should crew statics if available 

### DIFF
--- a/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
@@ -85,9 +85,8 @@ params ["_pos"];
 		_artilleryMarker setMarkerText "Arty";
 		_artilleryMarker setMarkerAlpha 0;
 
-		private _objectives = [];
+		_objectsToDestroy apply {
 
-		{
 			// Disable weapon dissassembly as statics aren't deleted properly
 			// when disassembled, breaking the site/mission.
 			[_x, true] call para_s_fnc_enable_dynamic_sim;
@@ -98,20 +97,10 @@ params ["_pos"];
 			[_x, ["DacCong"]] call vn_mf_fnc_lock_vehicle_to_teams;
 			vn_mf_dc_assets pushBack _x;
 
-			// get replenishable AI crews for mortars/art objects
-			_objectives pushBack ([_x] call para_s_fnc_ai_obj_request_crew);
+		};
 
-		} forEach _objectsToDestroy;
-
-		// other static weapons setup
-		{
-			[_x, true] call para_s_fnc_enable_dynamic_sim;
-			_objectives pushBack ([_x] call para_s_fnc_ai_obj_request_crew);
-		} forEach _staticWeaponsOther;
-
-		_objectives pushBack ([_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend);
-
-		_siteStore setVariable ["aiObjectives", _objectives];
+		_staticWeaponsOther apply {[_x, true] call para_s_fnc_enable_dynamic_sim};
+		_siteStore setVariable ["aiObjectives", [_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend];
 		_siteStore setVariable ["markers", [_artilleryMarker]];
 		_siteStore setVariable ["objectsToDestroy", _objectsToDestroy];
 	},

--- a/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
@@ -39,11 +39,25 @@ params ["_pos"];
 
 		vn_site_objects append _campObjs;
 
-		private _objectsToDestroy = _campObjs select {typeOf _x in ["Land_vn_o_shelter_06", "Land_vn_pavn_launchers", "vn_b_ammobox_01", "Land_vn_pavn_weapons_wide", "Land_vn_pavn_weapons_cache", "Land_vn_pavn_ammo", "Land_vn_pavn_weapons_stack1", "Land_vn_pavn_weapons_stack2", "Land_vn_pavn_weapons_stack3", "vn_b_ammobox_full_02", "vn_o_ammobox_wpn_04", "vn_o_ammobox_full_03", "vn_o_ammobox_full_07", "vn_o_ammobox_full_06", "StaticWeapon"]};
+		private _campObjectiveTypes = [
+			"Land_vn_o_shelter_06",
+			"Land_vn_pavn_launchers",
+			"vn_b_ammobox_01",
+			"Land_vn_pavn_weapons_wide",
+			"Land_vn_pavn_weapons_cache",
+			"Land_vn_pavn_ammo",
+			"Land_vn_pavn_weapons_stack1",
+			"Land_vn_pavn_weapons_stack2",
+			"Land_vn_pavn_weapons_stack3",
+			"vn_b_ammobox_full_02",
+			"vn_o_ammobox_wpn_04",
+			"vn_o_ammobox_full_03",
+			"vn_o_ammobox_full_07",
+			"vn_o_ammobox_full_06"
+		];
 
-		{
-			[_x, true] call para_s_fnc_enable_dynamic_sim;
-		} forEach _objectsToDestroy;
+		private _objectsToDestroy = _campObjs select {typeOf _x in _campObjectiveTypes};
+		_objectsToDestroy apply {[_x, true] call para_s_fnc_enable_dynamic_sim};
 
 		private _markerPos = _spawnPos getPos [10 + random 20, random 360];
 		private _campMarker = createMarker [format ["Camp_%1", _siteId], _markerPos];
@@ -51,20 +65,10 @@ params ["_pos"];
 		_campMarker setMarkerText "Camp";
 		_campMarker setMarkerAlpha 0;
 
-		private _staticWeapons = _campObjs select {
-			_x isKindOf "StaticWeapon";
-		};
+		private _staticWeapons = _campObjs select {_x isKindOf "StaticWeapon"};
+		_staticWeapons apply {[_x, true] call para_s_fnc_enable_dynamic_sim};
 
-		private _objectives = [];
-
-		{
-			[_x, true] call para_s_fnc_enable_dynamic_sim;
-			_objectives pushBack ([_x] call para_s_fnc_ai_obj_request_crew);
-		} forEach _staticWeapons;
-
-		_objectives pushBack ([_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend);
-
-		_siteStore setVariable ["aiObjectives", _objectives];
+		_siteStore setVariable ["aiObjectives", [_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend];
 		_siteStore setVariable ["markers", [_campMarker]];
 		_siteStore setVariable ["objectsToDestroy", _objectsToDestroy];
 	},

--- a/mission/functions/systems/sites/fn_sites_create_factory.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_factory.sqf
@@ -72,10 +72,10 @@ params ["_pos"];
 		vn_dc_adhoc_respawns pushBack [_factoryRespawnMarker, _respawnID];
 
 		private _guns = _factoryObjects select {_x isKindOf "StaticWeapon"};
+		
+		// 2x ai objectives to replace other factory / hq AI that never get freed in task system
 		private _objectives = [];
-		{
-			_objectives pushBack ([_x] call para_s_fnc_ai_obj_request_crew);
-		} forEach _guns;
+		_objectives pushBack ([_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend);
 		_objectives pushBack ([_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend);
 
 		_siteStore setVariable ["aiObjectives", _objectives];

--- a/mission/functions/systems/sites/fn_sites_create_factory.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_factory.sqf
@@ -32,7 +32,6 @@ params ["_pos"];
 		missionNamespace getVariable ["current_factory", _siteStore];
 
 		private _factoryObjects = [_spawnPos] call vn_mf_fnc_create_factory_buildings;
-		private _objectsToDestroy = _factoryObjects select {typeOf _x == "Land_vn_wf_vehicle_service_point_east"};
 		private _intel = _factoryObjects select {typeOf _x == "Land_Map_unfolded_Malden_F"};
 		missionNamespace setVariable ["factory_intel", _intel];
 		missionNamespace setVariable ["factoryPosition", _pos];
@@ -40,19 +39,34 @@ params ["_pos"];
 		_intel call vn_mf_fnc_action_gather_intel;
 		private _currentVehicles = vehicles;
 
-		{
-			if(_x isKindOf "Building" || _x isKindOf "House" || typeOf _x in ["Land_Map_unfolded_Malden_F", "Land_vn_wf_vehicle_service_point_east", "Land_vn_fuel_tank_stairs", "Land_Net_Fence_Gate_F"] || _x isKindOf "StaticWeapon" || _x isKindOf "LandVehicle" || _x isKindOf "Air") then {
+		vn_site_objects append _factoryObjects;
+
+		private _objectTypesToDestroy = ["Land_vn_wf_vehicle_service_point_east"];
+		
+		private _objectTypesForDynamicSim = [
+			"Land_Map_unfolded_Malden_F",
+			"Land_vn_wf_vehicle_service_point_east",
+			"Land_vn_fuel_tank_stairs",
+			"Land_Net_Fence_Gate_F"
+		];
+
+		private _fnc_dynSimKindOfChecker = {
+			params ["_object"];
+			(_x isKindOf "StaticWeapon" || _x isKindOf "Building" || _x isKindOf "House" || _x isKindOf "LandVehicle" || _x isKindOf "Air")
+		};
+
+		_factoryObjects apply {
+			if(typeOf _x in _objectTypesToDestroy + _objectTypesForDynamicSim || [_x] call _fnc_dynSimKindOfChecker) then {
 				[_x, true] call para_s_fnc_enable_dynamic_sim;
 			};
+		};
 
+		_factoryObjects apply {
 			if (_x in _currentVehicles) then {
 				[_x, ["DacCong"]] call vn_mf_fnc_lock_vehicle_to_teams;
 				vn_mf_dc_assets pushBack _x;
 			};
-
-		} forEach _factoryObjects;
-
-		vn_site_objects append _factoryObjects;
+		};
 
 		//Create a factory marker.
 		private _markerPos = _spawnPos getPos [20 + random 30, random 360];
@@ -70,19 +84,18 @@ params ["_pos"];
 		_respawnObj setVariable ["vn_respawn", [_factoryRespawnMarker, _respawnID]];
 	
 		vn_dc_adhoc_respawns pushBack [_factoryRespawnMarker, _respawnID];
-
-		private _guns = _factoryObjects select {_x isKindOf "StaticWeapon"};
 		
 		// 2x ai objectives to replace other factory / hq AI that never get freed in task system
-		private _objectives = [];
-		_objectives pushBack ([_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend);
-		_objectives pushBack ([_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend);
+		private _objectives = [
+			[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend,
+			[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend
+		];
 
 		_siteStore setVariable ["aiObjectives", _objectives];
 		_siteStore setVariable ["markers", [_factoryMarker]];
-		_siteStore setVariable ["staticGuns", _guns];
+		_siteStore setVariable ["staticGuns", _factoryObjects select {_x isKindOf "StaticWeapon"}];
 		_siteStore setVariable ["vehicles", _factoryObjects]; 
-		_siteStore setVariable ["objectsToDestroy", _objectsToDestroy];
+		_siteStore setVariable ["objectsToDestroy", _factoryObjects select {typeOf _x in _objectTypesToDestroy}];
 	},
 	//Teardown condition check code
 	{
@@ -98,8 +111,6 @@ params ["_pos"];
 	//Teardown code
 	{
 		params ["_siteStore"];
-
-		private _objectsToDestroy = _siteStore getVariable "objectsToDestroy";
 
 		{
 			deleteMarker _x;

--- a/mission/functions/systems/sites/fn_sites_create_hq.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_hq.sqf
@@ -73,10 +73,12 @@ params ["_pos"];
 		missionNamespace setVariable ["hqPosition", _pos];
 
 		private _objectsToDestroy = _hqObjects select {typeOf _x in _objectTypesToDestroy};
-	
-		private _objectives = [];
-		_objectives pushBack ([_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend);
-		_objectives pushBack ([_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend);
+
+		// 2x ai objectives to replace other factory / hq AI that never get freed in task system
+		private _objectives = [
+			[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend,
+			[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend
+		];
 
 		//Create a HQ marker.
 		private _markerPos = _spawnPos getPos [20 + random 30, random 360];

--- a/mission/functions/systems/sites/fn_sites_create_radar.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_radar.sqf
@@ -30,8 +30,7 @@ params ["_pos"];
 		private _spawnPos = _sitePos;
 
 		private _radarObjs = [_spawnPos] call vn_mf_fnc_create_radar_buildings;
-		private _createdThings = _radarObjs select 0;
-
+		
 		{
 			if(_x isKindOf "StaticWeapon" || _x isKindOf "LandVehicle" || _x isKindOf "Air" || typeOf _x in ['Land_Net_Fence_Gate_F'] || _x isKindOf "Building") then {
 				[_x, true] call para_s_fnc_enable_dynamic_sim;
@@ -62,16 +61,9 @@ params ["_pos"];
 			_x isKindOf "StaticWeapon" && !(typeof _x == "vn_o_static_rsna75") && !(typeof _x == "vn_sa2");
 		};
 
-		private _objectives = [];
+		_staticWeapons apply {[_x, true] call para_s_fnc_enable_dynamic_sim};
 
-		{
-			[_x, true] call para_s_fnc_enable_dynamic_sim;
-			_objectives pushBack ([_x] call para_s_fnc_ai_obj_request_crew);
-		} forEach _staticWeapons;
-
-		_objectives pushBack ([_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend);
-
-		_siteStore setVariable ["aiObjectives", _objectives];
+		_siteStore setVariable ["aiObjectives", [_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend];
 		_siteStore setVariable ["markers", [_radarMarker]];
 		_siteStore setVariable ["objectsToDestroy", _objectsToDestroy];
 	},

--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -48,12 +48,7 @@ _taskDataStore setVariable ["INIT", {
 	_areaMarker setMarkerColor "ColorYellow";
 
 	private _hqPosition = missionNamespace getVariable ["hqPosition", _zoneposition];
-	private _defendHqObj = [_hqPosition, 1, 1] call para_s_fnc_ai_obj_request_defend;
-
 	private _factoryPosition = missionNamespace getVariable ["factoryPosition", _zoneposition];
-	private _defendFactoryObj = [_factoryPosition, 1, 1] call para_s_fnc_ai_obj_request_defend;
-
-	_taskDataStore setVariable ["aiObjectives", [_defendHqObj, _defendFactoryObj]];
 	_taskDataStore setVariable ["startTime", serverTime];
 	_taskDataStore setVariable ["hq_sites_destroyed", false];
 	_taskDataStore setVariable ["factory_sites_destroyed", false];
@@ -118,5 +113,4 @@ _taskDataStore setVariable ["AFTER_STATES_RUN", {
 
 _taskDataStore setVariable ["FINISH", {
 	deleteMarker "activeZoneCircle";
-	_taskDataStore getVariable "aiObjectives" apply {[_x] call para_s_fnc_ai_obj_finish_objective};
 }];


### PR DESCRIPTION
Main change:

Switch the AI objectives in sites to only the "defend" objective -- they **should** mount the statics if statics are available and will auto scale to player count better (I think I just chose the wrong script way back when / didn't quite understand how the defend vs. crewing script works).

Other Changes:

- Remove the AI objectives from the "capture" task logic -- these AI would be continuously assigned to the HQ and Factory sites as long as the red phase is active (whether the HQ/Factory are live or not)

- General clean up to make scripts a bit easier to read eg. make `_objectiveTypesToDestroy` a variable to search against