### PR TITLE
Reduce zone size to make capture phase fights more intense.

### DIFF
--- a/maps/altis/map_config/init.hpp
+++ b/maps/altis/map_config/init.hpp
@@ -8,7 +8,7 @@ class map_config {
 	max_water_supply_per_zone = 2;
 	max_tunnels_per_zone = 3;
 	max_vehicle_depots_per_zone = 3;
-	bn_zone_radius = 1000;
+	bn_zone_radius = 700;
 	class zones {
 		#include "zones.hpp"
 	};

--- a/maps/cam_lao_nam/map_config/init.hpp
+++ b/maps/cam_lao_nam/map_config/init.hpp
@@ -8,7 +8,7 @@ class map_config {
 	max_water_supply_per_zone = 2;
 	max_tunnels_per_zone = 3;
 	max_vehicle_depots_per_zone = 3;
-	bn_zone_radius = 1000;
+	bn_zone_radius = 700;
 	class zones {
 		#include "zones.hpp"
 	};

--- a/maps/vn_khe_sanh/map_config/init.hpp
+++ b/maps/vn_khe_sanh/map_config/init.hpp
@@ -8,7 +8,7 @@ class map_config {
 	max_water_supply_per_zone = 2;
 	max_vehicle_depots_per_zone = 3;
 	starting_zones[] = {"zone_khe_sanh", "zone_kok", "zone_french_fort"};
-	bn_zone_radius = 1000;
+	bn_zone_radius = 700;
 	class zones {
 		#include "zones.hpp"
 	};

--- a/maps/vn_the_bra/map_config/init.hpp
+++ b/maps/vn_the_bra/map_config/init.hpp
@@ -8,7 +8,7 @@ class map_config {
 	max_water_supply_per_zone = 2;
 	max_vehicle_depots_per_zone = 3;
 	starting_zones[] = {"zone_nam_phat", "zone_ban_pakha", "zone_ban_dac_maruk"};
-	bn_zone_radius = 1000;
+	bn_zone_radius = 700;
 	class zones {
 		#include "zones.hpp"
 	};


### PR DESCRIPTION
Have tested across a number of AOs with 650m radius ... this adds an extra 50m to the radius for safety (i.e. cover my own arse).

Instead of increasing the AI count, this tries to cheat and make the AOs smaller -- meaning AI density is higher per km^2.

From memory I tested these AOs and we managed to spawn **most** of sites

the problem child will be water supplies and we need some logic to handle "couldn't find a suitable location" issues

- Mu Gia Pass
- Ha Long Navy Base
- Ca Loi
- Phu Quoc
- Thud Ridge
- Bru
- Da Krong
- Hanoi
- Hai Phong
- Rung Cung
- Bam Bon

### TODO

- [ ]  handle the issue where a valid site is not found (water supplies usually) and catch the errors properly