### PR TITLE
[UPDATE] Reduce number of camp spawns for FPS and AI count balancing.

### DIFF
--- a/maps/altis/map_config/init.hpp
+++ b/maps/altis/map_config/init.hpp
@@ -1,6 +1,6 @@
 class map_config {
 	starting_zones[] = {"zone_sofia"};
-	max_camps_per_zone = 5;
+	max_camps_per_zone = 3;
 	max_aa_per_zone = 10;
 	max_artillery_per_zone = 3;
 	max_fortifications_per_zone = 0;	

--- a/maps/cam_lao_nam/map_config/init.hpp
+++ b/maps/cam_lao_nam/map_config/init.hpp
@@ -1,6 +1,6 @@
 class map_config {
 	starting_zones[] = {"zone_ba_ria", "zone_ban_hoang"};
-	max_camps_per_zone = 5;
+	max_camps_per_zone = 3;
 	max_aa_per_zone = 10;
 	max_artillery_per_zone = 3;
 	max_fortifications_per_zone = 0;

--- a/maps/vn_khe_sanh/map_config/init.hpp
+++ b/maps/vn_khe_sanh/map_config/init.hpp
@@ -1,5 +1,5 @@
 class map_config {
-	max_camps_per_zone = 5;
+	max_camps_per_zone = 3;
 	max_aa_per_zone = 10;
 	max_artillery_per_zone = 3;
 	max_fortifications_per_zone = 0;

--- a/maps/vn_the_bra/map_config/init.hpp
+++ b/maps/vn_the_bra/map_config/init.hpp
@@ -1,5 +1,5 @@
 class map_config {
-	max_camps_per_zone = 5;
+	max_camps_per_zone = 3;
 	max_aa_per_zone = 5;
 	max_artillery_per_zone = 4;
 	max_fortifications_per_zone = 0;


### PR DESCRIPTION
Camps are

- 35m radius (fairly large)
- second highest number of site spawns
- (on average) contain different 64 objects (mostly non-gamemode critical)
- (on average) contain 8 static weapons per site

camps are taxing for both 

- server FPS (requires redesigning / implementing) 
- total number of AI spawns