### PR TITLE
[FIXUP] Malformed AI objectives (sites may not clean up correctly)

### DIFF
--- a/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
@@ -47,7 +47,7 @@ params ["_pos"];
 		_aaMarker setMarkerText "AA";
 		_aaMarker setMarkerAlpha 0;
 
-		_siteStore setVariable ["aiObjectives", [_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend];
+		_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend]];
 		_siteStore setVariable ["markers", [_aaMarker]];
 		_siteStore setVariable ["objectsToDestroy", _objects];
 	},

--- a/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
@@ -100,7 +100,7 @@ params ["_pos"];
 		};
 
 		_staticWeaponsOther apply {[_x, true] call para_s_fnc_enable_dynamic_sim};
-		_siteStore setVariable ["aiObjectives", [_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend];
+		_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend]];
 		_siteStore setVariable ["markers", [_artilleryMarker]];
 		_siteStore setVariable ["objectsToDestroy", _objectsToDestroy];
 	},

--- a/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
@@ -68,7 +68,7 @@ params ["_pos"];
 		private _staticWeapons = _campObjs select {_x isKindOf "StaticWeapon"};
 		_staticWeapons apply {[_x, true] call para_s_fnc_enable_dynamic_sim};
 
-		_siteStore setVariable ["aiObjectives", [_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend];
+		_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend]];
 		_siteStore setVariable ["markers", [_campMarker]];
 		_siteStore setVariable ["objectsToDestroy", _objectsToDestroy];
 	},

--- a/mission/functions/systems/sites/fn_sites_create_radar.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_radar.sqf
@@ -63,7 +63,7 @@ params ["_pos"];
 
 		_staticWeapons apply {[_x, true] call para_s_fnc_enable_dynamic_sim};
 
-		_siteStore setVariable ["aiObjectives", [_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend];
+		_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend]];
 		_siteStore setVariable ["markers", [_radarMarker]];
 		_siteStore setVariable ["objectsToDestroy", _objectsToDestroy];
 	},


### PR DESCRIPTION
Needed
```
_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend]];
```

instead of

```
_siteStore setVariable ["aiObjectives", [_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend];
```

Missing the enclosing `[]` --> `aiObjectives` needs to be an array of arrays