### PR TITLE
[UPDATE] Remove Defend AI Obj from AA sites.

### DIFF
--- a/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
@@ -47,7 +47,7 @@ params ["_pos"];
 		_aaMarker setMarkerText "AA";
 		_aaMarker setMarkerAlpha 0;
 
-		_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend]];
+		_siteStore setVariable ["aiObjectives", []];
 		_siteStore setVariable ["markers", [_aaMarker]];
 		_siteStore setVariable ["objectsToDestroy", _objects];
 	},


### PR DESCRIPTION
These AI can't mount the AA as it is spawned crewed, they only protect it with their very puny guns (vs. a ZPU with like 4 barrels of hatred).

Also want to see whether reducing some AI objectives mitigates the "AI starvation" problem (server is struggling to spawn in tracker teams due to AI count).