### PR TITLE
[ADD] Periodically log stats about each AI Objectives.

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -78,6 +78,7 @@ class CfgFunctions
 			class enable_debug_monitor {};
 			class init_performance_logging {};
 			class log_performance_data {};
+			class log_ai_objective_data {};
 		};
 
 		class ui

--- a/mission/functions/debug/fn_init_performance_logging.sqf
+++ b/mission/functions/debug/fn_init_performance_logging.sqf
@@ -19,3 +19,4 @@ para_g_log_identifier = "MIKEFORCE";
 private _performanceLoggingPeriod = localNamespace getVariable ["vn_mf_performance_logging_period", 30];
 
 ["performance_logging", vn_mf_fnc_log_performance_data, [], _performanceLoggingPeriod] call para_g_fnc_scheduler_add_job;
+["ai_objective_logging", vn_mf_fnc_log_ai_objective_data, [], _performanceLoggingPeriod] call para_g_fnc_scheduler_add_job;

--- a/mission/functions/debug/fn_log_ai_objective_data.sqf
+++ b/mission/functions/debug/fn_log_ai_objective_data.sqf
@@ -1,0 +1,36 @@
+/*
+    File: fn_log_performance_data.sqf
+    Author: Savage Game Design
+    Public: No
+
+    Description:
+    Logs a line of performance data
+
+    Parameter(s): None
+
+    Returns: Nothing
+
+    Example(s):
+		call vn_mf_fnc_init_performance_logging
+*/
+
+
+["INFO", format ["Current AI Objectives:%1", count para_s_ai_obj_objectives]] call para_g_fnc_log;
+
+para_s_ai_obj_objectives apply {
+	private _msg = format [
+		"AI Obj: ID: %1, Type: %2, Priority: %3, Groups: %4, AliveUnits: %5, FixedUnitCount: %6, ScalingFactor: %7, DesiredCount: %8, SquadSize: %9, ReinforceFactor: %10, ReinforceRemain: %11",
+		_x getVariable ["id", objNull],
+		_x getVariable ["type", objNull],
+		_x getVariable ["priority", objNull],
+		count (_x getVariable ["assignedGroups", []]),
+		_x getVariable ["total_alive_units", objNull],
+		_x getVariable ["fixed_unit_count", objNull],
+		_x getVariable ["scaling_factor", objNull],
+		_x getVariable ["desired_unit_count", objNull],
+		_x getVariable ["squad_size", objNull],
+		_x getVariable ["reinforcements_factor", objNull],
+		_x getVariable ["reinforcements_remaining", objNull]
+	];
+	["INFO", _msg] call para_g_fnc_log;
+};


### PR DESCRIPTION
On top of server performance we can now inspect actual AI objectives

```
 8:20:20 "2023-9-8 7:20:20:70 | MIKEFORCE | INFO | File: vn_mf_fnc_log_ai_objective_data | Called By: vn_mf_fnc_log_ai_objective_data | | Current AI Objectives:2"
 8:20:20 "2023-9-8 7:20:20:70 | MIKEFORCE | INFO | File: vn_mf_fnc_log_ai_objective_data | Called By: vn_mf_fnc_log_ai_objective_data | | AI Obj: ID: 0, Type: ambush, Priority: 1, Groups: 7, AliveUnits: 25, FixedUnitCount: <NULL-object>, ScalingFactor: 30, DesiredCount: 30, SquadSize: 4.98141, ReinforceFactor: 30, ReinforceRemain: 1"
 8:20:20 "2023-9-8 7:20:20:70 | MIKEFORCE | INFO | File: vn_mf_fnc_log_ai_objective_data | Called By: vn_mf_fnc_log_ai_objective_data | | AI Obj: ID: 1, Type: pursue, Priority: 1, Groups: 1, AliveUnits: 1, FixedUnitCount: <NULL-object>, ScalingFactor: 1, DesiredCount: 1, SquadSize: 4, ReinforceFactor: 1, ReinforceRemain: 1"

```