### PR TITLE
[ADD/FIX] Add photo camera saving module, fix marine base flags and lights.

### DIFF
--- a/maps/cam_lao_nam/mission.sqm
+++ b/maps/cam_lao_nam/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=585;
 	class ItemIDProvider
 	{
-		nextID=15596;
+		nextID=15601;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=16780;
+		nextID=16882;
 	};
 	class Camera
 	{
-		pos[]={16266.591,25.176546,6517.8989};
-		dir[]={0.050837524,-0.53980702,0.84025621};
-		up[]={0.032600299,0.84178674,0.53882533};
-		aside[]={0.99817848,-7.3836418e-008,-0.060391955};
+		pos[]={16067.038,34.059639,7639.9814};
+		dir[]={0.62476665,-0.73814911,0.25460356};
+		up[]={0.6837188,0.67445886,0.27862865};
+		aside[]={0.37738833,-3.2733078e-007,-0.92606497};
 	};
 };
 binarizationWanted=0;
@@ -600,8 +600,8 @@ class CustomAttributes
 		name="Multiplayer";
 		class Attribute0
 		{
-			property="SharedObjectives";
-			expression="if (isMultiplayer) then {[_value] spawn bis_fnc_sharedObjectives;};";
+			property="ReviveRequiredItems";
+			expression="false";
 			class Value
 			{
 				class data
@@ -651,8 +651,8 @@ class CustomAttributes
 		};
 		class Attribute4
 		{
-			property="ReviveRequiredItems";
-			expression="false";
+			property="SharedObjectives";
+			expression="if (isMultiplayer) then {[_value] spawn bis_fnc_sharedObjectives;};";
 			class Value
 			{
 				class data
@@ -721,7 +721,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=1576;
+		items=1581;
 		class Item0
 		{
 			dataType="Marker";
@@ -19240,6 +19240,7 @@ class Mission
 				angles[]={0,1.7210692,0};
 			};
 			side="Empty";
+			flags=4;
 			class Attributes
 			{
 				init="[this, [""MACV"",""3rdMEU"",""QuarterHorse"",""DacCong""]]call vn_mf_fnc_lock_vehicle_to_teams;";
@@ -19247,7 +19248,7 @@ class Mission
 			};
 			id=6204;
 			type="vn_b_army_static_m101_02";
-			atlOffset=0.51599121;
+			atlOffset=0.11679077;
 		};
 		class Item458
 		{
@@ -48442,6 +48443,7 @@ class Mission
 			};
 			id=13798;
 			type="vn_o_armor_pt76a_01_pl";
+			atlOffset=0.0071144104;
 		};
 		class Item1073
 		{
@@ -48460,7 +48462,7 @@ class Mission
 			};
 			id=13799;
 			type="vn_o_armor_pt76a_01_pl";
-			atlOffset=-0.00064277649;
+			atlOffset=4.7683716e-006;
 		};
 		class Item1074
 		{
@@ -80909,6 +80911,7 @@ class Mission
 				angles[]={0.0010995574,3.1344018,6.2334433};
 			};
 			side="Empty";
+			flags=4;
 			class Attributes
 			{
 				init="[this, [""MACV"",""3rdMEU"",""QuarterHorse"",""DacCong""]]call vn_mf_fnc_lock_vehicle_to_teams;";
@@ -80916,7 +80919,7 @@ class Mission
 			};
 			id=15345;
 			type="vn_b_air_ch47_03_01";
-			atlOffset=0.27529907;
+			atlOffset=0.0091247559;
 		};
 		class Item1510
 		{
@@ -85466,7 +85469,7 @@ class Mission
 			};
 			id=15558;
 			type="vn_b_air_uh1d_04_09";
-			atlOffset=4.3163528;
+			atlOffset=4.4036255;
 		};
 		class Item1565
 		{
@@ -85647,6 +85650,90 @@ class Mission
 			id=15595;
 			type="vn_module_photo_camera_enable_screenshots";
 			atlOffset=88.788994;
+		};
+		class Item1576
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={16040.733,20.612495,7623.2563};
+				angles[]={0,0.7788927,-0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=15596;
+			type="Land_vn_lampshabby_f_dir_normal";
+			atlOffset=1.9073486e-006;
+		};
+		class Item1577
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={16031.633,19.678709,7645.8682};
+				angles[]={0,1.5268568,-0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=15597;
+			type="Land_vn_lampshabby_f_dir_normal";
+			atlOffset=1.9073486e-006;
+		};
+		class Item1578
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={16075.604,20.822031,7637.4482};
+				angles[]={0,6.2734199,-0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=15598;
+			type="Land_vn_lampshabby_f_dir_normal";
+			atlOffset=1.9073486e-006;
+		};
+		class Item1579
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={16093.228,21.178429,7648.0366};
+				angles[]={0,4.2948442,-0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=15599;
+			type="Land_vn_lampshabby_f_dir_normal";
+		};
+		class Item1580
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={16074.695,20.663406,7661.0571};
+				angles[]={0,2.7624586,-0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=15600;
+			type="Land_vn_lampshabby_f_dir_normal";
+			atlOffset=1.9073486e-006;
 		};
 	};
 	class Connections

--- a/maps/cam_lao_nam/mission.sqm
+++ b/maps/cam_lao_nam/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=585;
 	class ItemIDProvider
 	{
-		nextID=15593;
+		nextID=15596;
 	};
 	class MarkerIDProvider
 	{
@@ -16,7 +16,7 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=16678;
+		nextID=16780;
 	};
 	class Camera
 	{
@@ -600,8 +600,8 @@ class CustomAttributes
 		name="Multiplayer";
 		class Attribute0
 		{
-			property="ReviveRequiredItems";
-			expression="false";
+			property="SharedObjectives";
+			expression="if (isMultiplayer) then {[_value] spawn bis_fnc_sharedObjectives;};";
 			class Value
 			{
 				class data
@@ -651,8 +651,8 @@ class CustomAttributes
 		};
 		class Attribute4
 		{
-			property="SharedObjectives";
-			expression="if (isMultiplayer) then {[_value] spawn bis_fnc_sharedObjectives;};";
+			property="ReviveRequiredItems";
+			expression="false";
 			class Value
 			{
 				class data
@@ -669,6 +669,19 @@ class CustomAttributes
 		name="Scenario";
 		class Attribute0
 		{
+			property="cba_settings_hasSettingsFile";
+			expression="false";
+			class Value
+			{
+				class data
+				{
+					singleType="BOOL";
+					value=1;
+				};
+			};
+		};
+		class Attribute1
+		{
 			property="EnableDebugConsole";
 			expression="true";
 			class Value
@@ -680,7 +693,7 @@ class CustomAttributes
 				};
 			};
 		};
-		nAttributes=1;
+		nAttributes=2;
 	};
 };
 class Mission
@@ -708,7 +721,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=1575;
+		items=1576;
 		class Item0
 		{
 			dataType="Marker";
@@ -13516,7 +13529,7 @@ class Mission
 			};
 			id=4330;
 			type="Land_Billboard_03_aan_F";
-			atlOffset=0.027000427;
+			atlOffset=0.026999474;
 		};
 		class Item312
 		{
@@ -16352,7 +16365,7 @@ class Mission
 				class Attribute0
 				{
 					property="groupID";
-					expression="_this setGroupID [_value];";
+					expression=" if (isNil 'CBA_fnc_setCallsign') then { _this setGroupID [_value]; } else { [_this, _value] call CBA_fnc_setCallsign; }; ";
 					class Value
 					{
 						class data
@@ -19227,7 +19240,6 @@ class Mission
 				angles[]={0,1.7210692,0};
 			};
 			side="Empty";
-			flags=4;
 			class Attributes
 			{
 				init="[this, [""MACV"",""3rdMEU"",""QuarterHorse"",""DacCong""]]call vn_mf_fnc_lock_vehicle_to_teams;";
@@ -19235,7 +19247,7 @@ class Mission
 			};
 			id=6204;
 			type="vn_b_army_static_m101_02";
-			atlOffset=0.11679077;
+			atlOffset=0.51599121;
 		};
 		class Item458
 		{
@@ -48430,7 +48442,6 @@ class Mission
 			};
 			id=13798;
 			type="vn_o_armor_pt76a_01_pl";
-			atlOffset=0.0071144104;
 		};
 		class Item1073
 		{
@@ -48449,7 +48460,7 @@ class Mission
 			};
 			id=13799;
 			type="vn_o_armor_pt76a_01_pl";
-			atlOffset=4.7683716e-006;
+			atlOffset=-0.00064277649;
 		};
 		class Item1074
 		{
@@ -80898,7 +80909,6 @@ class Mission
 				angles[]={0.0010995574,3.1344018,6.2334433};
 			};
 			side="Empty";
-			flags=4;
 			class Attributes
 			{
 				init="[this, [""MACV"",""3rdMEU"",""QuarterHorse"",""DacCong""]]call vn_mf_fnc_lock_vehicle_to_teams;";
@@ -80906,7 +80916,7 @@ class Mission
 			};
 			id=15345;
 			type="vn_b_air_ch47_03_01";
-			atlOffset=0.0091247559;
+			atlOffset=0.27529907;
 		};
 		class Item1510
 		{
@@ -85456,7 +85466,7 @@ class Mission
 			};
 			id=15558;
 			type="vn_b_air_uh1d_04_09";
-			atlOffset=4.4036255;
+			atlOffset=4.3163528;
 		};
 		class Item1565
 		{
@@ -85625,6 +85635,18 @@ class Mission
 			};
 			id=15592;
 			type="Land_Billboard_03_aan_F";
+			atlOffset=-9.5367432e-007;
+		};
+		class Item1575
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={20839.418,-6.1035156e-005,4102.6992};
+			};
+			id=15595;
+			type="vn_module_photo_camera_enable_screenshots";
+			atlOffset=88.788994;
 		};
 	};
 	class Connections


### PR DESCRIPTION
- Photos taken with the SOG camera will now land in the user's `C:\Users\<USERNAME>\Documents\<RELEVANT ARMA PROFILE FOLDER>\Screenshots\vn_photoCamera`
- Added 6 lamps at the Marine base so they can see at night