### PR TITLE
Sites add new camp compositions

### DIFF
--- a/maps/cam_lao_nam/map_config/init.hpp
+++ b/maps/cam_lao_nam/map_config/init.hpp
@@ -1,6 +1,6 @@
 class map_config {
 	starting_zones[] = {"zone_ba_ria", "zone_ban_hoang"};
-	max_camps_per_zone = 3;
+	max_camps_per_zone = 9;
 	max_aa_per_zone = 10;
 	max_artillery_per_zone = 3;
 	max_fortifications_per_zone = 0;

--- a/maps/vn_khe_sanh/map_config/init.hpp
+++ b/maps/vn_khe_sanh/map_config/init.hpp
@@ -1,5 +1,5 @@
 class map_config {
-	max_camps_per_zone = 3;
+	max_camps_per_zone = 9;
 	max_aa_per_zone = 10;
 	max_artillery_per_zone = 3;
 	max_fortifications_per_zone = 0;

--- a/maps/vn_the_bra/map_config/init.hpp
+++ b/maps/vn_the_bra/map_config/init.hpp
@@ -1,5 +1,5 @@
 class map_config {
-	max_camps_per_zone = 3;
+	max_camps_per_zone = 6;
 	max_aa_per_zone = 5;
 	max_artillery_per_zone = 4;
 	max_fortifications_per_zone = 0;

--- a/mission/functions/systems/sites/fn_create_camp_buildings.sqf
+++ b/mission/functions/systems/sites/fn_create_camp_buildings.sqf
@@ -17,7 +17,7 @@
 
 params ["_position"];
 
-vn_mf_camp_compositions_default = [
+vn_mf_camp_site_compositions_v1 = [
 	[
 		["vn_o_prop_t102e_01",[3.60205,1.41553,0.864996],43.9,1,0,[0,0],"","",false,false], 
 		["Land_WoodenTable_small_F",[3.64111,1.52979,0],224.926,1,0,[0,0],"","",false,false], 
@@ -394,7 +394,7 @@ vn_mf_camp_compositions_default = [
 	]
 ];
 
-vn_mf_camp_compositions = [
+vn_mf_camp_site_compositions_v2 = [
 	[
 	["vn_o_nva_static_sgm_low_02",[-1.52588,-0.194824,-0.0751295],283.212,1,0,[0,0],"","",false,false], 
 	["vn_fireplace_burning_f",[1.87695,-0.872559,-4.76837e-007],0,1,0,[0,0],"","",false,false], 
@@ -728,17 +728,141 @@ vn_mf_camp_compositions = [
 ]
 ];
 
-private _site_objs = [selectRandom vn_mf_camp_compositions, 0.7] call vn_mf_fnc_sites_objmapper_dynamic_grass;
+vn_mf_camp_site_compositions_v3 = [
+	/*
+	Land_vn_pavn_weapons_stack1 varients
+	*/
 
-{
+	// has no campfire
+	[
+		["Land_vn_o_shelter_06",[0.258789,1.2998,0],270.318,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[-1.33398,2.93555,0],247.678,1,0,[0,0],"","",true,false], 
+		["vn_o_prop_t884_01",[0.292969,-3.95068,-0.000703335],359.974,1,0,[0.926653,0.043989],"","",true,false], 
+		["Land_vn_o_shelter_06",[-2.52246,-3.23389,0],163.946,1,0,[0,-0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[2.89014,3.41016,0],108.015,1,0,[0,-0],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[2.15869,-3.41455,0.044529],180.238,1,0,[2.46404,-4.35736],"","",true,false]
+	],
+	[
+		["Land_vn_o_shelter_06",[-0.579102,1.47607,0],270.318,1,0,[0,0],"","",true,false], 
+		["vn_o_prop_t884_01",[-0.289551,-3.66748,-0.00075531],359.968,1,0,[0.904449,0.00292902],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[-2.17188,3.11182,0],247.678,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[2.05225,3.58643,0],108.015,1,0,[0,-0],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[1.32178,-3.23633,0.0430574],180.315,1,0.103549,[2.39703,-4.27401],"","",true,false]
+	],
+	// with unlit campfires
+	[
+		["vn_o_prop_t884_01",[-0.868652,2.29199,-0.000768661],359.925,1,0,[0.905595,0.0025392],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[3.58789,0.672363,-0.0200133],90.779,1,0.12162,[-0.785575,-0.0728572],"","",true,false], 
+		["Land_vn_o_shelter_01",[-3.6875,0.754883,0],0,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[1.64404,-3.67578,0],148.221,1,0,[0,-0],"","",true,false], 
+		["Land_vn_campfire_f",[-4.28516,1.25635,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[1.74707,5.26953,0],16.3519,1,0,[0,0],"","",true,false]
+	],
+	[
+		["vn_o_prop_t884_01",[0.69043,-0.509766,-0.00075531],359.969,1,0,[0.904449,0.00292889],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[-1.18115,0.943359,-0.0200458],290.772,1,0.0777321,[-0.788556,-0.0708576],"","",true,false], 
+		["Land_vn_o_shelter_06",[-2.39941,-2.11377,0],110.294,1,0,[0,-0],"","",true,false], 
+		["Land_vn_o_shelter_06",[3.14893,-0.355957,0],177.713,1,0,[0,-0],"","",true,false], 
+		["Land_vn_campfire_f",[0.816406,-3.27588,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[-2.99951,1.61914,0],201.04,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[0.758789,3.55371,0],125.213,1,0,[0,-0],"","",true,false]
+	],
+	[
+		["Land_vn_campfire_f",[0.397461,0.512207,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["vn_o_prop_t884_01",[-1.2749,1.39355,-0.00075531],359.968,1,0,[0.904458,0.00292898],"","",true,false], 
+		["Land_vn_o_shelter_06",[-1.80078,-1.83496,0],301.7,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[-2.68604,1.30713,0],201.04,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[1.59961,2.93945,0],125.213,1,0,[0,-0],"","",true,false], 
+		["Land_vn_o_shelter_06",[2.93164,-1.83008,0],219.886,1,0,[0,0],"","",true,false]
+	],
+	[
+		["Land_vn_pavn_weapons_stack1",[1.48975,-0.964844,-0.0199876],90.78,1,0.104103,[-0.781418,-0.0784438],"","",true,false], 
+		["vn_o_prop_t884_01",[-2.6084,-0.19043,-0.00075531],359.968,1,0,[0.904453,0.00292905],"","",true,false], 
+		["Land_vn_o_shelter_04",[-0.525879,2.83301,0],45.7491,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[-2.19482,-2.46094,0],59.8888,1,0,[0,0],"","",true,false], 
+		["Land_vn_campfire_f",[0.581543,-4.8125,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[-4.74219,0.20459,0],349.734,1,0,[0,0],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[4.97803,1.18164,-0.0200596],90.8542,1,0.0964033,[-0.792407,-0.0653819],"","",true,false]
+	],
+	[
+		["vn_o_prop_t884_01",[-0.1875,1.63232,-0.00075531],359.968,1,0,[0.904449,0.00292899],"","",true,false], 
+		["Land_vn_o_shelter_06",[-2.18848,-0.776367,0],230.991,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[2.45068,-0.227051,0],112.483,1,0,[0,-0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[1.67822,2.19824,0],108.015,1,0,[0,-0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[-2.54883,1.18359,0],226.591,1,0,[0,0],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[0.398926,-2.86084,-0.0200272],90.7465,1,0.122781,[-0.787538,-0.0710506],"","",true,false]
+	],
+	[
+		["Land_vn_campfire_f",[0.285645,0.709473,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["vn_o_prop_t884_01",[2.21094,1.47363,-0.00075531],359.968,1,0,[0.90444,0.00292899],"","",true,false], 
+		["Land_vn_o_shelter_06",[1.8999,-1.82568,0],327.824,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[-2.93311,-0.317383,0],48.6475,1,0,[0,0],"","",true,false]
+	],
+	[
+		["Land_vn_campfire_f",[0.121582,-1.07129,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["vn_o_prop_t884_01",[1.87988,-0.0776367,-0.00075531],359.968,1,0,[0.904449,0.00292901],"","",true,false], 
+		["Land_vn_o_shelter_06",[-3.20996,-1.70264,0],48.6475,1,0,[0,0],"","",true,false],
+		["Land_vn_pavn_weapons_stack1",[3,1,0],48.6475,1,0,[0,0],"","",true,false]
+	],
+	// with burning campfires
+	[
+		["vn_o_prop_t884_01",[-0.868652,2.29199,-0.000768661],359.925,1,0,[0.905595,0.0025392],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[3.58789,0.672363,-0.0200133],90.779,1,0.12162,[-0.785575,-0.0728572],"","",true,false], 
+		["Land_vn_o_shelter_01",[-3.6875,0.754883,0],0,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[1.64404,-3.67578,0],148.221,1,0,[0,-0],"","",true,false], 
+		["vn_campfire_burning_f",[-4.28516,1.25635,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[1.74707,5.26953,0],16.3519,1,0,[0,0],"","",true,false]
+	],
+	[
+		["vn_o_prop_t884_01",[0.69043,-0.509766,-0.00075531],359.969,1,0,[0.904449,0.00292889],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[-1.18115,0.943359,-0.0200458],290.772,1,0.0777321,[-0.788556,-0.0708576],"","",true,false], 
+		["Land_vn_o_shelter_06",[-2.39941,-2.11377,0],110.294,1,0,[0,-0],"","",true,false], 
+		["Land_vn_o_shelter_06",[3.14893,-0.355957,0],177.713,1,0,[0,-0],"","",true,false], 
+		["vn_campfire_burning_f",[0.816406,-3.27588,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[-2.99951,1.61914,0],201.04,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[0.758789,3.55371,0],125.213,1,0,[0,-0],"","",true,false]
+	],
+	[
+		["vn_campfire_burning_f",[0.397461,0.512207,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["vn_o_prop_t884_01",[-1.2749,1.39355,-0.00075531],359.968,1,0,[0.904458,0.00292898],"","",true,false], 
+		["Land_vn_o_shelter_06",[-1.80078,-1.83496,0],301.7,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[-2.68604,1.30713,0],201.04,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[1.59961,2.93945,0],125.213,1,0,[0,-0],"","",true,false], 
+		["Land_vn_o_shelter_06",[2.93164,-1.83008,0],219.886,1,0,[0,0],"","",true,false]
+	],
+	[
+		["Land_vn_pavn_weapons_stack1",[1.48975,-0.964844,-0.0199876],90.78,1,0.104103,[-0.781418,-0.0784438],"","",true,false], 
+		["vn_o_prop_t884_01",[-2.6084,-0.19043,-0.00075531],359.968,1,0,[0.904453,0.00292905],"","",true,false], 
+		["Land_vn_o_shelter_04",[-0.525879,2.83301,0],45.7491,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[-2.19482,-2.46094,0],59.8888,1,0,[0,0],"","",true,false], 
+		["vn_campfire_burning_f",[0.581543,-4.8125,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[-4.74219,0.20459,0],349.734,1,0,[0,0],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[4.97803,1.18164,-0.0200596],90.8542,1,0.0964033,[-0.792407,-0.0653819],"","",true,false]
+	],
+	[
+		["vn_o_prop_t884_01",[-0.1875,1.63232,-0.00075531],359.968,1,0,[0.904449,0.00292899],"","",true,false], 
+		["Land_vn_o_shelter_06",[-2.18848,-0.776367,0],230.991,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[2.45068,-0.227051,0],112.483,1,0,[0,-0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[1.67822,2.19824,0],108.015,1,0,[0,-0],"","",true,false], 
+		["Land_vn_o_wallfoliage_01",[-2.54883,1.18359,0],226.591,1,0,[0,0],"","",true,false], 
+		["Land_vn_pavn_weapons_stack1",[0.398926,-2.86084,-0.0200272],90.7465,1,0.122781,[-0.787538,-0.0710506],"","",true,false]
+	],
+	[
+		["vn_campfire_burning_f",[0.285645,0.709473,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["vn_o_prop_t884_01",[2.21094,1.47363,-0.00075531],359.968,1,0,[0.90444,0.00292899],"","",true,false], 
+		["Land_vn_o_shelter_06",[1.8999,-1.82568,0],327.824,1,0,[0,0],"","",true,false], 
+		["Land_vn_o_shelter_06",[-2.93311,-0.317383,0],48.6475,1,0,[0,0],"","",true,false]
+	],
+	[
+		["vn_campfire_burning_f",[0.121582,-1.07129,0.0299988],0,1,0,[0,0],"","",true,false], 
+		["vn_o_prop_t884_01",[1.87988,-0.0776367,-0.00075531],359.968,1,0,[0.904449,0.00292901],"","",true,false], 
+		["Land_vn_o_shelter_06",[-3.20996,-1.70264,0],48.6475,1,0,[0,0],"","",true,false],
+		["Land_vn_pavn_weapons_stack1",[3,1,0],48.6475,1,0,[0,0],"","",true,false]
+	]
+];
 
-	if (_x isKindOf "StaticWeapon") then {
-		_x allowDamage false;
-		_x setPos [getPos _x # 0, getPos _x # 1, 0];
-		_x setVectorUp (surfaceNormal getPos _x);
-		_x allowDamage true;
-	};
-	
-} forEach _site_objs;
+
+private _randAngle = [1, 360] call BIS_fnc_randomInt;
+private _site_objs = [_position, _randAngle, selectRandom vn_mf_camp_site_compositions_v3, 0] call BIS_fnc_objectsMapper;
 
 _site_objs

--- a/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
@@ -69,10 +69,11 @@ params ["_pos"];
 		_staticWeapons apply {[_x, true] call para_s_fnc_enable_dynamic_sim};
 
 		// 30% chance to spawn an ambush
+		// @dijksterhuis: we don't assign AI to every camp site to save AI budget on other assignments
+		// like tracker teams or factory/HQ/arty sites. 
+		// also reduce the scaling factor (affects how many AI should be assigned to this specific location)
 		if (random 1 < 0.3) then {
-			_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_ambush]];
-		} else {
-			_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend]];
+			_siteStore setVariable ["aiObjectives", [[_spawnPos, 0.5, 1] call para_s_fnc_ai_obj_request_ambush]];
 		};
 
 		_siteStore setVariable ["markers", [_campMarker]];

--- a/mission/functions/systems/sites/fn_sites_generate.sqf
+++ b/mission/functions/systems/sites/fn_sites_generate.sqf
@@ -38,10 +38,10 @@ private _hqPosition = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObj
 // 	[_radar, _zone] call vn_mf_fnc_sites_create_radar;
 // };
 
-for "_i" from 1 to (1 + ceil random (vn_mf_s_max_camps_per_zone - 1)) do
+for "_i" from 1 to (3 + ceil random (vn_mf_s_max_camps_per_zone - 1)) do
 {
 	//[_zoneData] call vn_mf_fnc_sites_create_camp;
-	private _campSite = [_center, vn_mf_bn_s_zone_radius, 0, 35, 8, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+	private _campSite = [_center, vn_mf_bn_s_zone_radius, 0, 8, 15, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 	[_campSite, _zone] call vn_mf_fnc_sites_create_camp_site;
 };
 


### PR DESCRIPTION
Discussed in discord and have green light

----

### Camp site rework

- Switch out camp site compositions for much simpler and smaller variants
- Increase maximum number of camp sites that can be spawned in (depends on map)
- Set minimum number of camp sites that are always spawned in to 3x
- Set camp sites to be AI ambush locations only
- Reduce amount of AI being explicitly to camp sites 
  - 30% chance of AI assignment to a camp site
  - reduced scaling factor (and hopefully squad size as a result)

Not going to post many obvious photos of the sites .... but a big hint is that they look more like classic mike force ....

#### Rationale for the changes

- Reduce number of objects spawned in AO (improve server performance)
- Reduce static objective AI count and lean more on the harass system (hopefully more tracker teams in the AO)
- Faster for Dev Team to iterate on smaller site compositions (i did these in an hour, next week could have more!)
- Easier to find suitable spawn locations for sites (smaller, fewer assets)
- Harder for people to find
- More sites for more in game groups

https://github.com/Bro-Nation/Mike-Force/pull/235

![20230922175813_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/884fa1f8-1fab-417b-946a-2cb2cfb004cc)

![20230922175748_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/4b1e074b-8243-4eba-bb82-f5460da1e950)

![20230922175654_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/f86fdc8f-48af-40a3-bfa7-4140bdff333d)

