### PR TITLE
[FIX] Do not spawn sites inside registered player bases (post-restart issue).

### DIFF
--- a/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
+++ b/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
@@ -95,7 +95,11 @@ private _blacklistedMapZones = vn_mf_markers_no_sites apply {
 private _playerBases = para_g_bases apply {
 	private _baseRadius = _x getVariable "para_g_base_radius";
 	[
-		getPos _x,
+		[
+			(getPos _x) select 0, 
+			(getPos _x) select 1, 
+			0
+		],
 		_baseRadius,
 		_baseRadius,
 		0,

--- a/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
+++ b/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
@@ -91,7 +91,20 @@ private _blacklistedMapZones = vn_mf_markers_no_sites apply {
 	]
 };
 
-private _blacklistedSiteAreas = _occupiedSiteAreas + _blacklistedMapZones;
+// player built FOBs
+private _playerBases = para_g_bases apply {
+	private _baseRadius = _x getVariable "para_g_base_radius";
+	[
+		getPos _x,
+		_baseRadius,
+		_baseRadius,
+		0,
+		false
+	]
+};
+
+	
+private _blacklistedSiteAreas = _occupiedSiteAreas + _blacklistedMapZones + _playerBases;
 
 private _finalPosition = [_position, 0, _radius, 0, _waterMode, 0.5, 0, _blacklistedSiteAreas, [_position, _position]] call BIS_fnc_findSafePos;
 private _radGrad = aCos ([0,0,1] vectorCos (surfaceNormal _finalPosition));


### PR DESCRIPTION
Saw an artillery site get generated inside a FOB’s walls (post restart same AO).

When I say inside the walls — assets were actually in the walls. 

Adding blue FOB area marker (`para_g_base_radius`) as an invalid spawn area.