### PR TITLE
[ADD] Random chance of traps at camp and tunnel sites.

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -26,6 +26,7 @@ class CfgFunctions
 			class check_enemy_units_alive {};
 			class player_within_radius {};
 			class check_side {};
+			class range {};
 		};
 
 		class core_init

--- a/mission/functions/core/helpers/fn_range.sqf
+++ b/mission/functions/core/helpers/fn_range.sqf
@@ -1,0 +1,26 @@
+/*
+	File: fn_generate_range_arr.sqf
+	Author: "DJ" Dijksterhuis
+	Public: No
+	
+	Description:
+		Generate simple array similar to python syntax: list(range(_start, _stop, _step))
+	
+	Parameter(s):
+		_start - start value
+		_stop - end value
+		_step - step value
+	
+	Returns:
+		Array of integers
+	
+	Example(s):
+		[1, 10, 2] call vn_mf_fnc_generate_range_arr;
+		[7, 1, -2] call vn_mf_fnc_generate_range_arr;
+*/
+
+
+params ["_start", "_stop", ["_step", 1]];
+private _ret = [];
+for "_i" from _start to _stop step _step do { _ret pushBack _i};
+_ret

--- a/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
@@ -76,6 +76,30 @@ params ["_pos"];
 			_siteStore setVariable ["aiObjectives", [[_spawnPos, 0.5, 1] call para_s_fnc_ai_obj_request_ambush]];
 		};
 
+		if (random 1 < 0.4) then {
+
+			// create a larger amount of punji traps and fewer larger bigboom mines
+			private _traps = ([1, ceil random 7] call vn_mf_fnc_range) apply {
+				createMine [
+					"vn_mine_punji_02",
+					_pos,
+					[],
+					10
+				]
+			};
+			private _mines = ([1, ceil random 3] call vn_mf_fnc_range) apply {
+				createMine [
+					selectRandom ["vn_mine_pot_range", "vn_mine_jerrycan_range"],
+					_pos,
+					[],
+					4
+				]
+			};
+			
+			// deletes the mines once the zone is completed
+			vn_site_objects append (_traps + _mines);
+		};
+
 		_siteStore setVariable ["markers", [_campMarker]];
 		_siteStore setVariable ["objectsToDestroy", _objectsToDestroy];
 	},

--- a/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
@@ -79,7 +79,7 @@ params ["_pos"];
 		if (random 1 < 0.4) then {
 
 			// create a larger amount of punji traps and fewer larger bigboom mines
-			private _traps = ([1, ceil random 7] call vn_mf_fnc_range) apply {
+			private _traps = ([4, ceil random 8] call vn_mf_fnc_range) apply {
 				createMine [
 					"vn_mine_punji_02",
 					_pos,
@@ -87,7 +87,7 @@ params ["_pos"];
 					10
 				]
 			};
-			private _mines = ([1, ceil random 3] call vn_mf_fnc_range) apply {
+			private _mines = ([1, ceil random 2] call vn_mf_fnc_range) apply {
 				createMine [
 					selectRandom ["vn_mine_pot_range", "vn_mine_jerrycan_range"],
 					_pos,

--- a/mission/functions/systems/sites/fn_sites_create_tunnel_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_tunnel_site.sqf
@@ -54,7 +54,7 @@ if(_tunnel isEqualTo 0)then {_tunnelAlpha=0};
 
 		if (random 1 < 0.5) then {
 
-			private _mines = ([3, ceil random 8] call vn_mf_fnc_range) apply {
+			private _mines = ([5, ceil random 10] call vn_mf_fnc_range) apply {
 				createMine [selectRandom _mineTypes, _pos, [], 5]
 			};
 

--- a/mission/functions/systems/sites/fn_sites_create_tunnel_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_tunnel_site.sqf
@@ -46,16 +46,10 @@ if(_tunnel isEqualTo 0)then {_tunnelAlpha=0};
 			_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend]];
 		};
 
-		private _mineTypes = [
-			"vn_mine_punji_01",
-			"vn_mine_punji_02",
-			"vn_mine_punji_03"
-		];
-
 		if (random 1 < 0.5) then {
 
-			private _mines = ([5, ceil random 10] call vn_mf_fnc_range) apply {
-				createMine [selectRandom _mineTypes, _pos, [], 5]
+			private _mines = ([3, ceil random 8] call vn_mf_fnc_range) apply {
+				createMine ["vn_mine_punji_02", _pos, [], 5]
 			};
 
 			// deletes the mines once the zone is completed

--- a/mission/functions/systems/sites/fn_sites_create_tunnel_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_tunnel_site.sqf
@@ -46,6 +46,22 @@ if(_tunnel isEqualTo 0)then {_tunnelAlpha=0};
 			_siteStore setVariable ["aiObjectives", [[_spawnPos, 1, 1] call para_s_fnc_ai_obj_request_defend]];
 		};
 
+		private _mineTypes = [
+			"vn_mine_punji_01",
+			"vn_mine_punji_02",
+			"vn_mine_punji_03"
+		];
+
+		if (random 1 < 0.5) then {
+
+			private _mines = ([3, ceil random 8] call vn_mf_fnc_range) apply {
+				createMine [selectRandom _mineTypes, _pos, [], 5]
+			};
+
+			// deletes the mines once the zone is completed
+			vn_site_objects append _mines;
+		};
+
 		_siteStore setVariable ["markers", [_tunnelMarker]];
 		_siteStore setVariable ["tunnels", _tunnels];
 		_siteStore setVariable ["vehicles", _vehicles]; 


### PR DESCRIPTION
TL;DR make sapper training useful in normal gameplay.

- Traps placed randomly in a certain radius (no control over specific position)
- All mines can be deactivated and removed by players with Explosive Specialist training + Mine Detector/Trap Kit + Toolkit

### Camps

- 40% chance of traps spawned around site
- Multiple mines/trap variants in a 10 metre radius (Min 5x / Max 10x)

### Tunnels 

- 50% chance of traps spawned around site
- Only Punji Traps (Small) in a 5 metre radius (Min 3x, Max 8x)
- Tunnels are harder to spot so fewer mines (less difficult than trapped camps)

NOTE -- this also gives folks a nice way to find the tunnels at night... look for where all the traps are on your mine detector ;)
