### PR TITLE
Tasks: Capture/Counterattack rework

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -167,6 +167,8 @@ class CfgFunctions
 			class action_release_from_arrest_player {};
 			class action_drink_water {};
 			class action_eat_food {};
+			class action_lower_flag {};
+			class action_reraise_flag {};
 		};
 
 		class system_actives {

--- a/mission/config/notifications.hpp
+++ b/mission/config/notifications.hpp
@@ -313,4 +313,41 @@ class CfgNotifications
 		color[] = {0.1,0.8,0.1,1};
 		iconPicture = "\A3\ui_f\data\Map\Markers\Military\warning_ca.paa";
 	};
+
+	class DacCongCapturingFlag
+	{
+		title = "Protect The Flag!";
+		description = "Dac Cong are capturing the flag!";
+		priority = 6;
+		color[] = {1,0,0,1};
+		iconPicture = "\A3\ui_f\data\Map\Markers\Military\warning_ca.paa";
+	};
+
+	class DacCongCapturedFlag
+	{
+		title = "Protect The Flag!";
+		description = "You are failure! Dac Cong have captured the flag!";
+		priority = 6;
+		color[] = {1,0,0,1};
+		iconPicture = "\A3\ui_f\data\map\mapcontrol\taskIconFailed_ca.paa";
+	};
+
+	class BlueforRaisingFlag
+	{
+		title = "Raise The Flag!";
+		description = "Bluefor are raising the flag.";
+		priority = 6;
+		color[] = {0.2,0.3,1,1};
+		iconPicture = "\A3\ui_f\data\Map\Markers\Military\warning_ca.paa";
+	};
+
+	class BlueforRaisedFlag
+	{
+		title = "Raise The Flag!";
+		description = "Bluefor have raised the flag!";
+		priority = 6;
+		color[] = {0.2,0.3,1,1};
+		iconPicture = "\A3\ui_f\data\map\mapcontrol\taskIconFailed_ca.paa";
+	};
+
 };

--- a/mission/config/notifications.hpp
+++ b/mission/config/notifications.hpp
@@ -347,7 +347,7 @@ class CfgNotifications
 		description = "Bluefor have raised the flag!";
 		priority = 6;
 		color[] = {0.2,0.3,1,1};
-		iconPicture = "\A3\ui_f\data\map\mapcontrol\taskIconFailed_ca.paa";
+		iconPicture = "\A3\ui_f\data\map\mapcontrol\taskIconDone_ca.paa";
 	};
 
 };

--- a/mission/config/notifications.hpp
+++ b/mission/config/notifications.hpp
@@ -56,6 +56,16 @@ class CfgNotifications
 		iconPicture = "\A3\ui_f\data\Map\Markers\Military\warning_ca.paa";
 	};
 
+	class CounterAttackExtended
+	{
+		title = $STR_vn_mf_notification_title_counter_attack;
+		description = $STR_vn_mf_notification_desc_counter_attack_extended;
+		priority = 7;
+		color[] = {0.8,0.5,0,1};
+		iconPicture = "\A3\ui_f\data\Map\Markers\Military\warning_ca.paa";
+	};
+
+
 	class NewSupportRequest
 	{
 		title = $STR_vn_mf_notification_title_new_support_request;

--- a/mission/config/subconfigs/tasks/defend/tasks.hpp
+++ b/mission/config/subconfigs/tasks/defend/tasks.hpp
@@ -31,6 +31,13 @@ class defend_counterattack : task
 		taskdesc = "Hold the zone for 30 minutes, or until hostiles are eliminated.";
 	};
 
+	class defend_fob
+	{
+		taskname = "Defend the FOB";
+		taskdesc = "Defend the FOB from counterattack for 30 minutes or hostile forces are all eliminated.";
+	};
+
+
 	class defend_flag
 	{
 		taskname = "Defend the Flag";

--- a/mission/config/subconfigs/tasks/defend/tasks.hpp
+++ b/mission/config/subconfigs/tasks/defend/tasks.hpp
@@ -27,8 +27,14 @@ class defend_counterattack : task
 
 	class defend_zone
 	{
-		taskname = "Defend the Zone";
-		taskdesc = "Defend the zone until all hostiles have been eliminated.";
+		taskname = "Hold the Zone";
+		taskdesc = "Hold the zone for 30 minutes, or until hostiles are eliminated.";
+	};
+
+	class defend_flag
+	{
+		taskname = "Defend the Flag";
+		taskdesc = "Don't let the flag get taken down or we will lose the zone!";
 	};
 };
 

--- a/mission/config/subconfigs/tasks/defend/tasks.hpp
+++ b/mission/config/subconfigs/tasks/defend/tasks.hpp
@@ -34,14 +34,13 @@ class defend_counterattack : task
 	class defend_fob
 	{
 		taskname = "Defend the FOB";
-		taskdesc = "Defend the FOB from counterattack for 30 minutes or hostile forces are all eliminated.";
+		taskdesc = "Defend the FOB from counterattack for 30 minutes, or hostile forces are eliminated.";
 	};
-
 
 	class defend_flag
 	{
 		taskname = "Defend the Flag";
-		taskdesc = "Don't let the flag get taken down or we will lose the zone!";
+		taskdesc = "Don't let the flag get taken down!";
 	};
 };
 

--- a/mission/config/subconfigs/tasks/primary/tasks.hpp
+++ b/mission/config/subconfigs/tasks/primary/tasks.hpp
@@ -32,13 +32,13 @@ class capture_zone : task
 	class build_fob
 	{
 		taskname = "Build FOB";
-		taskdesc = "Build a situation room/bunker to establish a Forward Operating Base.";
+		taskdesc = "Build a situation room to establish a Forward Operating Base.";
 	};
 
 	class build_respawn
 	{
 		taskname = "Build FOB Respawn Point";
-		taskdesc = "Build a checkpoint so we can reinforce the Forward Operating Base.";
+		taskdesc = "Build a respawn so we can reinforce the Forward Operating Base.";
 	};
 
 	class build_flag

--- a/mission/config/subconfigs/tasks/primary/tasks.hpp
+++ b/mission/config/subconfigs/tasks/primary/tasks.hpp
@@ -28,6 +28,24 @@ class capture_zone : task
 		taskname = "Destroy Factory Supply Line";
 		taskdesc = "Destroy Factory supplies and the sites they're delivered to. You might find intel inside for the locations to the rest of the sites!";
 	};
+
+	class build_situation_room
+	{
+		taskname = "Build FOB Situation Room";
+		taskdesc = "Build a situation room to establish a Forward Operating Base.";
+	};
+
+	class build_respawn
+	{
+		taskname = "Build FOB Respawn Point";
+		taskdesc = "Build a checkpoint so we can reinforce the Forward Operating Base.";
+	};
+
+	class build_flag
+	{
+		taskname = "Build FOB Flag";
+		taskdesc = "Build a flag to take ownership of this Forward Operating Base.";
+	};
 };
 
 class prepare_zone : task

--- a/mission/config/subconfigs/tasks/primary/tasks.hpp
+++ b/mission/config/subconfigs/tasks/primary/tasks.hpp
@@ -29,10 +29,10 @@ class capture_zone : task
 		taskdesc = "Destroy Factory supplies and the sites they're delivered to. You might find intel inside for the locations to the rest of the sites!";
 	};
 
-	class build_situation_room
+	class build_fob
 	{
-		taskname = "Build FOB Situation Room";
-		taskdesc = "Build a situation room to establish a Forward Operating Base.";
+		taskname = "Build FOB";
+		taskdesc = "Build a situation room/bunker to establish a Forward Operating Base.";
 	};
 
 	class build_respawn

--- a/mission/functions/systems/actions/fn_action_init.sqf
+++ b/mission/functions/systems/actions/fn_action_init.sqf
@@ -31,6 +31,8 @@ if (isNil "vn_mf_actions_initialized" || vn_mf_actions_player != player) then //
 	call vn_mf_fnc_action_destroy_task;
 	call vn_mf_fnc_action_gather_intel;
 	call vn_mf_fnc_action_radiotap;
+	call vn_mf_fnc_action_lower_flag;
+	call vn_mf_fnc_action_reraise_flag;
 	"vn_holdActionAdd_layer" cutText ["","PLAIN"];
 };
 

--- a/mission/functions/systems/actions/fn_action_lower_flag.sqf
+++ b/mission/functions/systems/actions/fn_action_lower_flag.sqf
@@ -39,7 +39,7 @@ private _codeOnStart = {
 };
 private _codeOnTick = {
 	// params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
-	[cursorObject, _progress / _maxProgress, false] call BIS_fnc_animateFlag;
+	[cursorObject, (_maxProgress - _progress) / _maxProgress, false] call BIS_fnc_animateFlag;
 };
 private _codeOnComplete = {
 	// params ["_target", "_caller", "_actionId", "_arguments"];

--- a/mission/functions/systems/actions/fn_action_lower_flag.sqf
+++ b/mission/functions/systems/actions/fn_action_lower_flag.sqf
@@ -21,49 +21,36 @@ private _actionProgressIcon = "custom\holdactions\holdAction_danger_ca.paa";
 private _isOpfor = "side player == east";
 private _isInRangeOf = "player distance cursorObject < 5";
 private _isValidObjectType = "typeOf cursorObject in ['vn_flag_usa', 'vn_flag_aus', 'vn_flag_arvn', 'vn_flag_nz']";
-private _isObjectiveFlag = "(cursorObject getVariable ['canLower', false]) == true";
+private _isObjectiveFlag = "cursorObject getVariable ['canLower', false]";
 
 private _conditionToShow = format [
         "(%1 && %2 && %3 && %4)",
-        _isNotOpfor,
+        _isOpfor,
         _isInRangeOf,
         _isValidObjectType,
         _isObjectiveFlag
 ];
 
-private _conditionToProgress = _conditionToShow;
+private _conditionToProgress = "true";
 
 private _codeOnStart = {
-	// params ["_target", "_caller", "_actionId", "_arguments"];
 	allPlayers apply {["DacCongCapturingFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
 };
 private _codeOnTick = {
-	// params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
-	[cursorObject, (_maxProgress - _progress) / _maxProgress, false] call BIS_fnc_animateFlag;
+	params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
+	private _startingFlagHeight = cursorObject getVariable ["currentHeight", flagAnimationPhase cursorObject];
+	private _newHeight = _startingFlagHeight * (1 - (_progress / _maxProgress));
+	cursorObject setFlagAnimationPhase _newHeight;
 };
 private _codeOnComplete = {
-	// params ["_target", "_caller", "_actionId", "_arguments"];
 	[cursorObject] remoteExec ["deleteVehicle", 2];
 	allPlayers apply {["DacCongCapturedFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
 };
 private _codeOnInterrupted = {
-	// params ["_target", "_caller", "_actionId", "_arguments"];
-
-	/*
-	do not reset the flag -- make bluefor reraise it
-
-	if bluefor do not reraise the flag then Dac Cong
-	have a better chance of stealing it (flag is sat
-	at 50% because bluefor never re-raised it!)
-
-	this line below is here in case the above idea
-	doesn't work and I need to revert it back quickly.
-
-	[cursorObject, 1, true] call BIS_fnc_animateFlag;
-	*/
+	cursorObject setVariable ["currentHeight", flagAnimationPhase cursorObject];
 };
 private _extraArgsArr = [];
-private _actionDurationSeconds = 5;
+private _actionDurationSeconds = 20;
 private _actionPriority = 100;
 private _actionRemoveOnComplete = false;
 private _showWhenUncon = false;

--- a/mission/functions/systems/actions/fn_action_lower_flag.sqf
+++ b/mission/functions/systems/actions/fn_action_lower_flag.sqf
@@ -1,0 +1,87 @@
+/*
+	File: fn_action_lower_flag.sqf
+	Author: "DJ" dijksterhuis
+	Public: No
+	
+	Description:
+                Dac Cong players can approach a mission critical (player built) flag in a base
+                and then lower it, causing a mission objective to fail.
+	
+	Parameter(s): none
+	
+	Returns:
+	
+	Example(s):
+*/
+
+private _actionText = format ["<t color='#0000FF'>%1</t>", "Lower Enemy Flag"];
+private _actionIdleIcon = "custom\holdactions\holdAction_interact_ca.paa";
+private _actionProgressIcon = "custom\holdactions\holdAction_danger_ca.paa";
+
+private _isOpfor = "side player == east";
+private _isInRangeOf = "player distance cursorObject < 5";
+private _isValidObjectType = "typeOf cursorObject in ['vn_flag_usa', 'vn_flag_aus', 'vn_flag_arvn', 'vn_flag_nz']";
+private _isObjectiveFlag = "(cursorObject getVariable ['canLower', false]) == true";
+
+private _conditionToShow = format [
+        "(%1 && %2 && %3 && %4)",
+        _isNotOpfor,
+        _isInRangeOf,
+        _isValidObjectType,
+        _isObjectiveFlag
+];
+
+private _conditionToProgress = _conditionToShow;
+
+private _codeOnStart = {
+	// params ["_target", "_caller", "_actionId", "_arguments"];
+	allPlayers apply {["DacCongCapturingFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
+};
+private _codeOnTick = {
+	// params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
+	[cursorObject, _progress / _maxProgress, false] call BIS_fnc_animateFlag;
+};
+private _codeOnComplete = {
+	// params ["_target", "_caller", "_actionId", "_arguments"];
+	[cursorObject] remoteExec ["deleteVehicle", 2];
+	allPlayers apply {["DacCongCapturedFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
+};
+private _codeOnInterrupted = {
+	// params ["_target", "_caller", "_actionId", "_arguments"];
+
+	/*
+	do not reset the flag -- make bluefor reraise it
+
+	if bluefor do not reraise the flag then Dac Cong
+	have a better chance of stealing it (flag is sat
+	at 50% because bluefor never re-raised it!)
+
+	this line below is here in case the above idea
+	doesn't work and I need to revert it back quickly.
+
+	[cursorObject, 1, true] call BIS_fnc_animateFlag;
+	*/
+};
+private _extraArgsArr = [];
+private _actionDurationSeconds = 5;
+private _actionPriority = 100;
+private _actionRemoveOnComplete = false;
+private _showWhenUncon = false;
+
+[
+        player,
+        _actionText,
+        _actionIdleIcon,
+        _actionProgressIcon,
+        _conditionToShow,
+        _conditionToProgress,
+        _codeOnStart,
+        _codeOnTick,
+        _codeOnComplete,
+        _codeOnInterrupted,
+        _extraArgsArr,
+        _actionDurationSeconds,
+        _actionPriority,
+        _actionRemoveOnComplete,
+        _showWhenUncon
+] call BIS_fnc_holdActionAdd;

--- a/mission/functions/systems/actions/fn_action_reraise_flag.sqf
+++ b/mission/functions/systems/actions/fn_action_reraise_flag.sqf
@@ -15,13 +15,11 @@
 		call vn_mf_fnc_action_capture_player;
 */
 
-private _startingFlagHeight = flagAnimationPhase cursorObject;
-
 private _actionText = format ["<t color='#0000FF'>%1</t>", "Re-Raise The Flag"];
 private _actionIdleIcon = "custom\holdactions\holdAction_interact_ca.paa";
 private _actionProgressIcon = "custom\holdactions\holdAction_interact_ca.paa";
 
-private _isOpfor = "side player == west";
+private _isNotOpfor = "side player == west";
 private _isInRangeOf = "player distance cursorObject < 5";
 private _isValidObjectType = "typeOf cursorObject in ['vn_flag_usa', 'vn_flag_aus', 'vn_flag_arvn', 'vn_flag_nz']";
 private _isObjectiveFlag = "(flagAnimationPhase cursorObject) != 1";
@@ -34,40 +32,26 @@ private _conditionToShow = format [
         _isObjectiveFlag
 ];
 
-private _conditionToProgress = _conditionToShow;
+private _conditionToProgress = "true";
 
 private _codeOnStart = {
-	// params ["_target", "_caller", "_actionId", "_arguments"];
-	// allPlayers apply {["DacCongCapturingFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
-};
-7private _codeOnTick = {
-	// params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
-	// max progress always 24
-	// divide by 25 so we can remove the attached flag on completion rhater than at end of progress
 	allPlayers apply {["BlueforRaisingFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
-
-	// (progress * (1 - currHeight)) + currHeight
-	private _newFlagPos = (1 - _startingFlagHeight) * (_progress / _maxProgress)) + _startingFlagHeight;
-	[cursorObject, _newFlagPos, false] call BIS_fnc_animateFlag;
+};
+private _codeOnTick = {
+	params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
+	private _startingFlagHeight = cursorObject getVariable ["currentHeight", flagAnimationPhase cursorObject];
+	private _newHeight = _startingFlagHeight + ((1 - _startingFlagHeight) * (_progress / _maxProgress));
+	cursorObject setFlagAnimationPhase _newHeight;
 };
 private _codeOnComplete = {
-	// params ["_target", "_caller", "_actionId", "_arguments"];
-	// will this work?
+	cursorObject setVariable ["currentHeight", flagAnimationPhase cursorObject];
 	allPlayers apply {["BlueforRaisedFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
 };
 private _codeOnInterrupted = {
-	// params ["_target", "_caller", "_actionId", "_arguments"];
-
-	/*
-	do nothing -- bluefor have raised to a certain height
-	so that's where the flag stays now.
-
-	line below is only if we need to revert back to not doing this
-	[cursorObject, _startingFlagHeight, true] call BIS_fnc_animateFlag;
-	*/
+	cursorObject setVariable ["currentHeight", flagAnimationPhase cursorObject];
 };
-private _extraArgsArr = [];
-private _actionDurationSeconds = 5;
+private _extraArgsArr = [flagAnimationPhase cursorObject];
+private _actionDurationSeconds = 20;
 private _actionPriority = 100;
 private _actionRemoveOnComplete = false;
 private _showWhenUncon = false;

--- a/mission/functions/systems/actions/fn_action_reraise_flag.sqf
+++ b/mission/functions/systems/actions/fn_action_reraise_flag.sqf
@@ -1,0 +1,91 @@
+/*
+	File: fn_action_reraise_flag.sqf
+	Author: "DJ" dijksterhuis
+	Public: No
+	
+	Description:
+		Dac Cong have lowered a mission critical flag.
+		Bluefor need to raise it to 100% again.
+
+	Parameter(s): none
+	
+	Returns:
+	
+	Example(s):
+		call vn_mf_fnc_action_capture_player;
+*/
+
+private _startingFlagHeight = flagAnimationPhase cursorObject;
+
+private _actionText = format ["<t color='#0000FF'>%1</t>", "Re-Raise The Flag"];
+private _actionIdleIcon = "custom\holdactions\holdAction_interact_ca.paa";
+private _actionProgressIcon = "custom\holdactions\holdAction_interact_ca.paa";
+
+private _isOpfor = "side player == west";
+private _isInRangeOf = "player distance cursorObject < 5";
+private _isValidObjectType = "typeOf cursorObject in ['vn_flag_usa', 'vn_flag_aus', 'vn_flag_arvn', 'vn_flag_nz']";
+private _isObjectiveFlag = "(flagAnimationPhase cursorObject) != 1";
+
+private _conditionToShow = format [
+        "(%1 && %2 && %3 && %4)",
+        _isNotOpfor,
+        _isInRangeOf,
+        _isValidObjectType,
+        _isObjectiveFlag
+];
+
+private _conditionToProgress = _conditionToShow;
+
+private _codeOnStart = {
+	// params ["_target", "_caller", "_actionId", "_arguments"];
+	// allPlayers apply {["DacCongCapturingFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
+};
+7private _codeOnTick = {
+	// params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
+	// max progress always 24
+	// divide by 25 so we can remove the attached flag on completion rhater than at end of progress
+	allPlayers apply {["BlueforRaisingFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
+
+	// (progress * (1 - currHeight)) + currHeight
+	private _newFlagPos = (1 - _startingFlagHeight) * (_progress / _maxProgress)) + _startingFlagHeight;
+	[cursorObject, _newFlagPos, false] call BIS_fnc_animateFlag;
+};
+private _codeOnComplete = {
+	// params ["_target", "_caller", "_actionId", "_arguments"];
+	// will this work?
+	allPlayers apply {["BlueforRaisedFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
+};
+private _codeOnInterrupted = {
+	// params ["_target", "_caller", "_actionId", "_arguments"];
+
+	/*
+	do nothing -- bluefor have raised to a certain height
+	so that's where the flag stays now.
+
+	line below is only if we need to revert back to not doing this
+	[cursorObject, _startingFlagHeight, true] call BIS_fnc_animateFlag;
+	*/
+};
+private _extraArgsArr = [];
+private _actionDurationSeconds = 5;
+private _actionPriority = 100;
+private _actionRemoveOnComplete = false;
+private _showWhenUncon = false;
+
+[
+        player,
+        _actionText,
+        _actionIdleIcon,
+        _actionProgressIcon,
+        _conditionToShow,
+        _conditionToProgress,
+        _codeOnStart,
+        _codeOnTick,
+        _codeOnComplete,
+        _codeOnInterrupted,
+        _extraArgsArr,
+        _actionDurationSeconds,
+        _actionPriority,
+        _actionRemoveOnComplete,
+        _showWhenUncon
+] call BIS_fnc_holdActionAdd;

--- a/mission/functions/systems/director/fn_director_process_active_zone.sqf
+++ b/mission/functions/systems/director/fn_director_process_active_zone.sqf
@@ -78,6 +78,17 @@ if (_taskIsCompleted) then {
 
 	if (_currentState isEqualTo "counterattack") exitWith {
 
+		if (_taskResult isEqualTo "FAILED") exitWith {
+
+			["INFO", format ["Zone '%1' defend against counterattack failed, restarting 'counterattack' phase", _zone]] call para_g_fnc_log;
+
+			private _counterattackReTask = ((["defend_counterattack", _zone, [["prepTime", 180]]] call vn_mf_fnc_task_create) # 1);
+			_zoneInfo set ["state", "counterattack"];
+			_zoneInfo set ["currentTask", _counterattackReTask];
+		};
+
+		// the counterattacked was defended against successfully
+
 		// delete DC spawns etc.
 		{
 		    private _marker = _x # 0;
@@ -92,21 +103,6 @@ if (_taskIsCompleted) then {
 		    deleteVehicle _x;
 		} forEach vn_site_objects;
 
-		if (_taskResult isEqualTo "FAILED") exitWith {
-
-			/*
-			TODO -- this is probably going to cause us problems with site generation
-			and might require a new intermediate phase to ask players to leave the AO.
-			*/
-
-			["INFO", format ["Zone '%1' defend against counterattack failed, moving to 'prepare' phase", _zone]] call para_g_fnc_log;
-			// private _zoneData = mf_s_zones select (mf_s_zones findIf {_zone isEqualTo (_x select struct_zone_m_marker)});
-			// [[_zoneData]] call vn_mf_fnc_sites_generate;
-
-			private _prepareTask = ((["prepare_zone", _zone] call vn_mf_fnc_task_create) # 1);
-			_zoneInfo set ["state", "prepare"];
-			_zoneInfo set ["currentTask", _prepareTask];
-		};
 
 		["INFO", format ["Zone '%1' counterattack successfully defended against, completing zone", _zone]] call para_g_fnc_log;
 		// Task is finished, and hasn't failed

--- a/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
+++ b/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
@@ -22,11 +22,23 @@
 
 params ["_taskDataStore"];
 
+/*
+Constants
+_taskDataStore setVariable ["holdDuration", 60 * 30];
+_taskDataStore setVariable ["failureTime", 5 * 60];
+*/
+
+
+/*
+Initialise the task
+
+Parameter: _taskDataStore (_tds), with prep_time set as a Variable.
+*/
 _taskDataStore setVariable ["INIT", {
-	params ["_taskDataStore"];
+	params ["_tds"];
 
 	//Required parameters
-	private _marker = _taskDataStore getVariable "taskMarker";
+	private _marker = _tds getVariable "taskMarker";
 	private _markerPos = getMarkerPos _marker;
 
 	/*
@@ -34,7 +46,7 @@ _taskDataStore setVariable ["INIT", {
 	private _hqs = (localNamespace getVariable ["sites_hq", []]) inAreaArray _marker;
 	*/
 
-	private _prepTime = _taskDataStore getVariable ["prepTime", 0];
+	private _prepTime = _tds getVariable ["prepTime", 0];
 
 	_marker setMarkerColor "ColorYellow";
 	_marker setMarkerBrush "DiagGrid";
@@ -55,22 +67,31 @@ _taskDataStore setVariable ["INIT", {
 
 	// search for candidate FOBs within the zone's area.
 	private _base_search_area = [_markerPos, _areaSize select 0, _areaSize select 1, 0, false];
-	private _candidate_bases_to_attack = para_g_bases inAreaArray _base_search_area apply { [ _x getVariable "para_g_current_supplies", _x] };
+	private _candidate_bases_to_attack = para_g_bases inAreaArray _base_search_area apply {
+		[_x getVariable "para_g_current_supplies", _x]
+	};
 	_candidate_bases_to_attack sort false;
 
 	// candidate FOBs exist
 	if ((count _candidate_bases_to_attack) > 0) then {
 
-		diag_log format ["Counterattack: Co-Ordinates of FOBs within range of counter attack: %1", _candidate_bases_to_attack apply {getPos (_x # 1)}];
+		diag_log format [
+			"Counterattack: Co-Ordinates of FOBs within range of counter attack: %1", 
+			_candidate_bases_to_attack apply {getPos (_x # 1)}
+		];
 
 		// get the first FOB from the sorted array
 		private _base_to_attack = (_candidate_bases_to_attack # 0 ) # 1;
-		diag_log format ["Counterattack: Co-Ordinates of selected FOB: %1", _base_to_attack];
-
 		// overwrite the default attack position
 		_attackPos = getPos _base_to_attack;
+		_areaSize = [para_g_max_base_radius, para_g_max_base_radius];
 
-		_taskDataStore setVariable ["fob_exists", true];
+		diag_log format [
+			"Counterattack: Suitable FOB for attacking discovered: %1",
+			_attackPos
+		];
+
+		_tds setVariable ["fob_exists", true];
 
 		// nearest objects might be buggy
 
@@ -82,18 +103,25 @@ _taskDataStore setVariable ["INIT", {
 
 		if (count _possibleFlags > 0) then {
 			private _flag = _possibleFlags select 0;
-			_taskDataStore setVariable ["flag", _flag];
-			_taskDataStore setVariable ["flag_exists", true];
+			_tds setVariable ["flag", _flag];
+			_tds setVariable ["flag_exists", true];
+			diag_log format [
+				"Counterattack: Suitable flag discovered: %1",
+				getPos _flag
+			];
 		};
 
 	};
 
-	diag_log format ["Counterattack: Co-ordinates for counter attack target: %1", _attackPos];
+	diag_log format [
+		"Counterattack: Co-ordinates for counter attack target: %1",
+		_attackPos
+	];
 
-	private _attackTime = serverTime + (_taskDataStore getVariable ["prepTime", 0]);
-	_taskDataStore setVariable ["attackTime", _attackTime];
-	_taskDataStore setVariable ["attackPos", _attackPos];
-	_taskDataStore setVariable ["attackAreaSize", _areaSize];
+	private _attackTime = serverTime + (_tds getVariable ["prepTime", 0]);
+	_tds setVariable ["attackTime", _attackTime];
+	_tds setVariable ["attackPos", _attackPos];
+	_tds setVariable ["attackAreaSize", _areaSize];
 
 	if (_prepTime > 0) then 
 	{
@@ -105,68 +133,129 @@ _taskDataStore setVariable ["INIT", {
 	[[["prepare_zone", _markerPos]]] call _fnc_initialSubtasks;
 }];
 
+
+_taskDataStore setVariable ["_fnc_create_circle_area", {
+	params ["_tds"];
+
+	private _pos = _tds getVariable "attackPos";
+	private _radius = (_tds getVariable ["attackAreaSize", [100, 100]]) select 0;
+
+	// custom BN: yellow circle around the AO
+	private _areaMarker = createMarker ["activeDefendCircle", _pos];
+	_areaMarker setMarkerShape "ELLIPSE";
+	_areaMarker setMarkerSize [_radius, _radius];
+	_areaMarker setMarkerAlpha 1;
+	_areaMarker setMarkerBrush "Border";
+	_areaMarker setMarkerColor "ColorRed";
+
+	_tds setVariable ["CircleAreaMarkerName", "activeDefendCircle"];
+
+}];
+
+/*
+Prepare the zone -- get everything ready for the counter-attack phase
+
+Parameter: _taskDataStore (_tds)
+*/
 _taskDataStore setVariable ["prepare_zone", {
-	params ["_taskDataStore"];
+	params ["_tds"];
 
-	if (_taskDataStore getVariable "attackTime" > serverTime) exitWith {};
+	// set up the attack objective on the first tick so the AI have 
+	// time to make it to the FOB
 
-	["CounterAttackImminent", []] remoteExec ["para_c_fnc_show_notification", 0];
+	// this means they can arrive to the FOB early.
+	// but that's fine, it will keep people on their toes.
+	if (isNull (_tds getVariable ["attackObjective", objNull])) exitWith {
+
+		private _scalingFactor = _tds getVariable ["attackDifficulty", 5];
+		private _reinforcementsFactor = 5;
+
+		private _attackObjective = [
+			_tds getVariable "attackPos",
+			_scalingFactor,
+			_reinforcementsFactor
+		] call para_s_fnc_ai_obj_request_attack;
+
+		_tds setVariable ["attackObjective", _attackObjective];
+
+	};
+
+	if (_tds getVariable "attackTime" > serverTime) exitWith {};
+
+	["CounterAttackImminent"] remoteExec ["para_c_fnc_show_notification", 0];
 	[] call vn_mf_fnc_timerOverlay_removeGlobalTimer;
 	["Counter Attack Imminent", serverTime + 180, true] call vn_mf_fnc_timerOverlay_setGlobalTimer;
 
-	//Default to X waves.
-	private _baseMultiplier = 5;//PLACEHOLDER VALUE
-	//Add a wave for each camp in our origin zone.
-	private _infantryMultiplier = _baseMultiplier;
+	_tds setVariable ["startTime", serverTime];
 
-	/*
-	add the "attack" objective to the AI objectives task system.
+	// set up the next task(s)
+	// one of "defend_flag + defend_fob" or "defend_fob" or "defend_zone".
 
-	attackDifficulty determines how large to make the AI groups that attack this objective,
-	but it is never set as a variable on this player task so it will only use the default setting provided below.
-	*/
-	private _attackObjective = [
-		_taskDataStore getVariable "attackPos",
-		//Difficulty 2, unless specified otherwise.
-		_taskDataStore getVariable ["attackDifficulty", 4],
-		_infantryMultiplier
-	] call para_s_fnc_ai_obj_request_attack;
+	if (
+		(_tds getVariable ["flag_exists", false]) 
+		&& (_tds getVariable ["fob_exists", false])
+	) exitWith {
 
-	_taskDataStore setVariable ["attackObjective", _attackObjective];
-	_taskDataStore setVariable ["startTime", serverTime];
+		// used in the players action to check if players are looking at the right flag.
+		// we set it now so the flag cannot be lowered during the prepare counterattack phase
+		// but can be lowered during the upcoming defned thr flag phase
+		(_tds getVariable "flag") setVariable ["canLower", true];
 
-	private _nextSubTasks = [];
+		[_tds] call (_tds getVariable "_fnc_create_circle_area");
 
-	if (_taskDataStore getVariable ["fob_exists", false]) then {
-		_nextSubTasks pushBack ["defend_fob", _taskDataStore getVariable "attackPos"];
-		if (_taskDataStore getVariable ["flag_exists", false]) then {
-			_nextSubTasks pushBack ["defend_flag",  getPos (_taskDataStore getVariable "flag")];
-		};
-	} else {
-		_nextSubTasks pushBack ["defend_zone", _taskDataStore getVariable "attackPos"];
+		[
+			"SUCCEEDED", 
+			[
+				["defend_fob", _tds getVariable "attackPos"],
+				["defend_flag", getPos (_tds getVariable "flag")]
+			]
+		] call _fnc_finishSubtask;
 	};
 
-	["SUCCEEDED", _nextSubTasks] call _fnc_finishSubtask;
+	if (_tds getVariable ["fob_exists", false]) exitWith {
+
+		[_tds] call (_tds getVariable "_fnc_create_circle_area");
+
+		[
+			"SUCCEEDED", 
+			[["defend_fob", _tds getVariable "attackPos"]]
+		] call _fnc_finishSubtask;
+	};
+
+	[_tds] call (_tds getVariable "_fnc_create_circle_area");
+
+
+	// no other options left
+	// chuck some AI in the zone and hope they bump into players
+	[
+		"SUCCEEDED", 
+		[["defend_zone", _tds getVariable "attackPos"]]
+	] call _fnc_finishSubtask;
 }];
 
-_taskDataStore setVariable ["defend_zone", {
-	params ["_taskDataStore"];
+/*
+Method to Check if the AI are overruning the area etc.
 
-	private _attackPos = _taskDataStore getVariable "attackPos";
-	private _areaSize = _taskDataStore getVariable "attackAreaSize";
+Parameters: _tasDataStore (_tds)
+*/
+_taskDataStore setVariable ["_fnc_check_ai_failure_condition", {
+	params ["_tds"];
+
+	private _attackPos = _tds getVariable "attackPos";
+	private _areaSize = _tds getVariable "attackAreaSize";
 	private _areaDescriptor = [_attackPos, _areaSize select 0, _areaSize select 1, 0, false];
 
 	//Side check - downed players don't count. Nor do players in aircraft. Ground vehicles are fair game.
-	private _alivePlayersInZone = 
-		allPlayers inAreaArray _areaDescriptor
-		select {alive _x && (side _x == west || side _x == independent) && !(vehicle _x isKindOf "Air") && !(_x getVariable ["vn_revive_incapacitated", false])};
+	private _alivePlayersInZone = allPlayers inAreaArray _areaDescriptor 
+		select {
+			alive _x 
+			&& (side _x == west || side _x == independent) 
+			&& !(vehicle _x isKindOf "Air") 
+			&& !(_x getVariable ["vn_revive_incapacitated", false])
+		};
 
-	private _aliveEnemyInZone = 
-		allUnits inAreaArray _areaDescriptor 
-		select {alive _x && side _x == east};
-
-	private _enemyZoneHeldTime = _taskDataStore getVariable "enemyZoneHeldTime";
-	private _lastCheck = _taskDataStore getVariable "lastCheck";
+	private _enemyZoneHeldTime = _tds getVariable "enemyZoneHeldTime";
+	private _lastCheck = _tds getVariable "lastCheck";
 	//Enemy hold the zone if no living players.
 	private _enemyHoldZone = count _alivePlayersInZone == 0;
 
@@ -181,98 +270,132 @@ _taskDataStore setVariable ["defend_zone", {
 			_enemyZoneHeldTime = _enemyZoneHeldTime + (serverTime - _lastCheck);
 			_lastCheck = serverTime;
 		};
-		_taskDataStore setVariable ["enemyZoneHeldTime", _enemyZoneHeldTime];
-		_taskDataStore setVariable ["lastCheck", _lastCheck];
+		_tds setVariable ["enemyZoneHeldTime", _enemyZoneHeldTime];
+		_tds setVariable ["lastCheck", _lastCheck];
 	} else {
-		_taskDataStore setVariable ["enemyZoneHeldTime", 0];
+		_tds setVariable ["enemyZoneHeldTime", 0];
 		_lastCheck = serverTime;
-		_taskDataStore setVariable ["lastCheck", _lastCheck];
+		_tds setVariable ["lastCheck", _lastCheck];
 	};
 
-	private _startTime = _taskDataStore getVariable "startTime";
+	private _startTime = _tds getVariable "startTime";
 
-	private _zone = _taskDataStore getVariable "taskMarker";
-	private _garrisonStrength = _taskDataStore getVariable ["attackObjective", objNull] getVariable ["reinforcements_remaining", 0];
-
-	//Zone has been held long enough, or they've killed enough attackers for the AI objective to complete.
+	//Zone has been held long enough, or they've killed enough attackers for the
+	// AI objective to complete.
 	if (
-		serverTime - _startTime > (_taskDataStore getVariable ["holdDuration", 60 * 30]) 
-		|| isNull (_taskDataStore getVariable "attackObjective") ) exitWith 
-	{ //exitWith here to prevent a tie causing the zone to turn green but have new tasks for its capture spawn
-		_taskDataStore setVariable ["zoneDefended", true];
-
-		["SUCCEEDED"] call _fnc_finishSubtask;
+		serverTime - _startTime > (_tds getVariable ["holdDuration", 60 * 30]) 
+		|| isNull (_tds getVariable "attackObjective")
+	) exitWith {
+		"SUCCESS"
 	};
 
 	//Enemy hold the zone for X seconds, we've failed
 	if (
-		_enemyHoldZone &&
-		{_enemyZoneHeldTime > (_taskDataStore getVariable ["failureTime", 5 * 60])}
-	) then {
-		["CounterAttackLost", ["", [_zone] call vn_mf_fnc_zone_marker_to_name]] remoteExec ["para_c_fnc_show_notification", 0];
+		_enemyHoldZone
+		&& {_enemyZoneHeldTime > (_tds getVariable ["failureTime", 5 * 60])}
+	) exitWith {
+		"FAILED"
+	};
+
+	// still going
+	"ACTIVE"
+}];
+
+
+/* 
+no one built a FOB, so AI are just going to move to the centre of the zone
+
+parameters: _taskDataStore (_tds)
+*/
+_taskDataStore setVariable ["defend_zone", {
+	params ["_tds"];
+
+	private _status = [_tds] call (_tds getVariable "_fnc_check_ai_failure_condition");
+
+	if (_status == "FAILED") exitWith {
+		["CounterAttackExtended"] remoteExec ["para_c_fnc_show_notification", 0];
 		["FAILED"] call _fnc_finishSubtask;
 		["FAILED"] call _fnc_finishTask;
 	};
+
+	if (_status == "SUCCESS") exitWith {
+		_tds setVariable ["zoneDefended", true];
+		["SUCCEEDED"] call _fnc_finishSubtask;
+	};
 }];
 
-// this is just a duplicate of defend base, but using different configs for titles
-// TODO: Need to test this is failing correectly as dsoesn;t look like it is
+/* 
+just a duplicate of defend base, but using different config title
+
+parameters: _taskDataStore (_tds)
+*/
 _taskDataStore setVariable ["defend_fob", {
-	[_taskDataStore] call (_taskDataStore getVariable "defend_fob");
+	params ["_tds"];
+
+	private _status = [_tds] call (_tds getVariable "_fnc_check_ai_failure_condition");
+
+	if (_status == "FAILED") exitWith {
+		["CounterAttackExtended"] remoteExec ["para_c_fnc_show_notification", 0];
+		["FAILED"] call _fnc_finishSubtask;
+		["FAILED"] call _fnc_finishTask;
+	};
+
+	if (_status == "SUCCESS") exitWith {
+		_tds setVariable ["zoneDefended", true];
+		["SUCCEEDED"] call _fnc_finishSubtask;
+	};
 }];
 
-_taskDataStore setVariable ["defend_flag", {
-	params ["_taskDataStore"];
+/*
+Add the flag objective as a possible failure condition
+while also tracking the same AI objective chance as before
 
-	private _flag = _taskDataStore getVariable "flag";
-	private _startTime = _taskDataStore getVariable "startTime";
+parameters: _taskDataStore (_tds)
+*/
+_taskDataStore setVariable ["defend_flag", {
+	params ["_tds"];
+	private _flag = _tds getVariable "flag";
+	private _status = [_tds] call (_tds getVariable "_fnc_check_ai_failure_condition");
 
 	/*
-	failure -- flag objected has been deleteVehicle'd
+	failure -- flag object has been deleteVehicle'd
 
 	occurs when either 
 	- Dac Cong full lowered the flag through the action
 	- the flag has been hammered out of existence (Bluefor tried to be clever)
-
-	TODO: How to deal with trolls hammering away the flag?
 	*/
 
 	if (isNull _flag) exitWith {
-		private _zone = _taskDataStore getVariable "taskMarker";
-		["CounterAttackLost", ["", [_zone] call vn_mf_fnc_zone_marker_to_name]] remoteExec ["para_c_fnc_show_notification", 0];
+		["CounterAttackExtended"] remoteExec ["para_c_fnc_show_notification", 0];
 		["FAILED"] call _fnc_finishSubtask;
 		["FAILED"] call _fnc_finishTask;
 	};
 
-	// used in the players action to check if players are looking at the right flag.
-	// otherwise any flag could be lowered/raised and trigger a notification
-	// this sets the variable on every tick, but that's fine for now and avoids people
-	// removing the flag too early.
-	_flag setVariable ["canLower", true];
-
 	// finished -- successful defence
 	// (30 minutes passed or AI objective has been wiped out)
-	if (
-		serverTime - _startTime > (_taskDataStore getVariable ["holdDuration", 60 * 30])
-		|| isNull (_taskDataStore getVariable "attackObjective")
-	) exitWith {
-                _taskDataStore setVariable ["flagDefended", true];
-                ["SUCCEEDED"] call _fnc_finishSubtask;
+
+	if (_status == "SUCCESS") exitWith {
+		_tds setVariable ["flagDefended", true];
+		["SUCCEEDED"] call _fnc_finishSubtask;
 	};
 }];
 
 _taskDataStore setVariable ["AFTER_STATES_RUN", {
-	params ["_taskDataStore"];
-
+	params ["_tds"];
 	if (
-		_taskDataStore getVariable ["zoneDefended", false]
-		&& _taskDataStore getVariable ["flagDefended", false]
+		_tds getVariable ["zoneDefended", false]
+		|| _tds getVariable ["flagDefended", false]
 	) then {
 		["SUCCEEDED"] call _fnc_finishTask;
 	};
 }];
 
 _taskDataStore setVariable ["FINISH", {
-	params ["_taskDataStore"];
-	[_taskDataStore getVariable "attackObjective"] call para_s_fnc_ai_obj_finish_objective;
+	params ["_tds"];
+	[_tds getVariable "attackObjective"] call para_s_fnc_ai_obj_finish_objective;
+	deleteMarker (_tds getVariable ["CircleAreaMarkerName", "activeDefendCircle"]);
+
+	if !(isNull (_tds getVariable ["flag", objNull])) then {
+		(_tds getVariable "flag") setVariable ["canLower", false];
+	};
 }];

--- a/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
+++ b/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
@@ -79,7 +79,7 @@ _taskDataStore setVariable ["INIT", {
 		if (count _possibleFlags > 0) then {
 			private _flag = _possibleFlags select 0;
 			// used in the player action to check if DC are looking at the right flag.
-			_flag setVaraible ["canLower", true];
+			_flag setVariable ["canLower", true];
 			_taskDataStore setVariable ["flag", _flag];
 		};
 

--- a/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
+++ b/mission/functions/tasks/defend/fn_task_defend_counterattack.sqf
@@ -24,9 +24,9 @@ params ["_taskDataStore"];
 
 /*
 Constants
+*/
 _taskDataStore setVariable ["holdDuration", 60 * 30];
 _taskDataStore setVariable ["failureTime", 5 * 60];
-*/
 
 
 /*

--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -53,7 +53,13 @@ _taskDataStore setVariable ["INIT", {
 	_taskDataStore setVariable ["hq_sites_destroyed", false];
 	_taskDataStore setVariable ["factory_sites_destroyed", false];
 
-	[[["destroy_hq_sites", _zonePosition], ["destroy_factory_sites", _zonePosition]]] call _fnc_initialSubtasks;
+	private _initialTasks = [
+		["destroy_hq_sites", [(_zonePosition # 0) - 100, _zonePosition # 1, 0]],
+		["destroy_factory_sites", [(_zonePosition # 0) + 100, _zonePosition # 1, 0]],
+		["build_situation_room", [_zonePosition # 0, (_zonePosition # 1) - 100 , 0]]
+	];
+
+	[_initialTasks] call _fnc_initialSubtasks;
 }];
 
 _taskDataStore setVariable ["destroy_hq_sites", {
@@ -98,6 +104,57 @@ _taskDataStore setVariable ["destroy_factory_sites", {
 		_taskDataStore setVariable ["factory_sites_destroyed", true];
 		["SUCCEEDED"] call _fnc_finishSubtask;
 	};
+}];
+
+_taskDataStore setVariable ["build_situation_room", {
+        params ["_taskDataStore"];
+
+        private _possibleBases = para_g_bases inAreaArray [
+		getMarkerPos (_taskDataStore getVariable "taskMarker"),
+		selectMax (getMarkerSize (_taskDataStore getVariable "taskMarker") apply {abs _x}),
+		selectMax (getMarkerSize (_taskDataStore getVariable "taskMarker") apply {abs _x}),
+		0
+	];
+
+        if !(_possibleBases isEqualTo []) then {
+		_taskDataStore setVariable ["fob_built", true];
+		_taskDataStore setVariable ["fob_position", getPos (_possibleBases select 0)];
+		private _nextTasks = [
+			["build_respawn", getPos (_possibleBases select 0)],
+			["build_flag", getPos (_possibleBases select 0)]
+		];
+                ["SUCCEEDED", _nextTasks] call _fnc_finishSubtask;
+        };
+}];
+
+_taskDataStore setVariable ["build_respawn", {
+        params ["_taskDataStore"];
+
+        private _possibleRespawns = nearestObjects [
+		_taskDataStore getVariable "fob_position",
+		["Land_vn_guardhouse_01", "Land_vn_b_trench_bunker_01_01", "Land_vn_hootch_01_01"],
+		200
+	];
+
+        if !(_possibleBases isEqualTo []) then {
+		_taskDataStore setVariable ["respawn_built", true];
+                ["SUCCEEDED"] call _fnc_finishSubtask;
+        };
+}];
+
+_taskDataStore setVariable ["build_flag", {
+        params ["_taskDataStore"];
+
+        private _possibleRespawns = nearestObjects [
+		_taskDataStore getVariable "fob_position",
+		["vn_flag_usa", "vn_flag_aus", "vn_flag_arvn", "vn_flag_nz"],
+		200
+	];
+
+        if !(_possibleBases isEqualTo []) then {
+		_taskDataStore setVariable ["flag_built", true];
+                ["SUCCEEDED"] call _fnc_finishSubtask;
+        };
 }];
 
 _taskDataStore setVariable ["AFTER_STATES_RUN", {

--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -56,7 +56,7 @@ _taskDataStore setVariable ["INIT", {
 	private _initialTasks = [
 		["destroy_hq_sites", _zonePosition getPos [100, 0]],
 		["destroy_factory_sites", _zonePosition getPos [100, 90]],
-		["build_situation_room", _zonePosition getPos [100, 180]]
+		["build_fob", _zonePosition getPos [100, 180]]
 	];
 
 	[_initialTasks] call _fnc_initialSubtasks;
@@ -106,7 +106,7 @@ _taskDataStore setVariable ["destroy_factory_sites", {
 	};
 }];
 
-_taskDataStore setVariable ["build_situation_room", {
+_taskDataStore setVariable ["build_fob", {
         params ["_taskDataStore"];
 
         private _possibleBases = para_g_bases inAreaArray [

--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -126,43 +126,45 @@ _taskDataStore setVariable ["build_fob", {
 		so use 2D positions instead for later nearestObjects
 		*/
 		private _fobPos3DASL = getPos (_possibleBases select 0);
+
+		_taskDataStore setVariable ["fob", _possibleBases select 0];
 		_taskDataStore setVariable ["fob_position_2d", [_fobPos3DASL select 0, _fobPos3DASL select 1]];
 		private _nextTasks = [
-			["build_respawn", (_taskDataStore getVariable "fob_position") getPos [50, 90]],
-			["build_flag", (_taskDataStore getVariable "fob_position") getPos [50, 270]]
+			["build_respawn", (_taskDataStore getVariable "fob_position_2d") getPos [50, 90]],
+			["build_flag", (_taskDataStore getVariable "fob_position_2d") getPos [50, 270]]
 		];
                 ["SUCCEEDED", _nextTasks] call _fnc_finishSubtask;
         };
 }];
 
 _taskDataStore setVariable ["build_respawn", {
-        params ["_taskDataStore"];
+	params ["_taskDataStore"];
 
-        private _possibleRespawns = nearestObjects [
+	private _candidates = nearestObjects [
 		_taskDataStore getVariable "fob_position_2d",
 		["Land_vn_guardhouse_01", "Land_vn_b_trench_bunker_01_01", "Land_vn_hootch_01_01"],
 		para_g_max_base_radius
 	];
 
-        if !(_possibleRespawns isEqualTo []) then {
-		_taskDataStore setVariable ["respawn_built", true];
-                ["SUCCEEDED"] call _fnc_finishSubtask;
-        };
+	if !(_candidates isEqualTo []) then {
+		_taskDataStore setVariable ["flag_built", true];
+		["SUCCEEDED"] call _fnc_finishSubtask;
+	};
 }];
 
 _taskDataStore setVariable ["build_flag", {
-        params ["_taskDataStore"];
+	params ["_taskDataStore"];
 
-        private _possibleFlags = nearestObjects [
+	private _candidates = nearestObjects [
 		_taskDataStore getVariable "fob_position_2d",
 		["vn_flag_usa", "vn_flag_aus", "vn_flag_arvn", "vn_flag_nz"],
 		para_g_max_base_radius
 	];
 
-        if !(_possibleFlags isEqualTo []) then {
+	if !(_candidates isEqualTo []) then {
 		_taskDataStore setVariable ["flag_built", true];
-                ["SUCCEEDED"] call _fnc_finishSubtask;
-        };
+		["SUCCEEDED"] call _fnc_finishSubtask;
+	};
 }];
 
 _taskDataStore setVariable ["AFTER_STATES_RUN", {

--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -118,7 +118,15 @@ _taskDataStore setVariable ["build_situation_room", {
 
         if !(_possibleBases isEqualTo []) then {
 		_taskDataStore setVariable ["fob_built", true];
-		_taskDataStore setVariable ["fob_position", getPos (_possibleBases select 0)];
+		/*
+		for some reason the AGL conversion for FOB positions
+		places them 200m AGL.... which is greater than the
+		maximum radius of bases...
+
+		so use 2D positions instead for later nearestObjects
+		*/
+		private _fobPos3DASL = getPos (_possibleBases select 0);
+		_taskDataStore setVariable ["fob_position_2d", [_fobPos3DASL select 0, _fobPos3DASL select 1]];
 		private _nextTasks = [
 			["build_respawn", (_taskDataStore getVariable "fob_position") getPos [50, 90]],
 			["build_flag", (_taskDataStore getVariable "fob_position") getPos [50, 270]]
@@ -131,12 +139,12 @@ _taskDataStore setVariable ["build_respawn", {
         params ["_taskDataStore"];
 
         private _possibleRespawns = nearestObjects [
-		_taskDataStore getVariable "fob_position",
+		_taskDataStore getVariable "fob_position_2d",
 		["Land_vn_guardhouse_01", "Land_vn_b_trench_bunker_01_01", "Land_vn_hootch_01_01"],
-		200
+		para_g_max_base_radius
 	];
 
-        if !(_possibleBases isEqualTo []) then {
+        if !(_possibleRespawns isEqualTo []) then {
 		_taskDataStore setVariable ["respawn_built", true];
                 ["SUCCEEDED"] call _fnc_finishSubtask;
         };
@@ -145,13 +153,13 @@ _taskDataStore setVariable ["build_respawn", {
 _taskDataStore setVariable ["build_flag", {
         params ["_taskDataStore"];
 
-        private _possibleRespawns = nearestObjects [
-		_taskDataStore getVariable "fob_position",
+        private _possibleFlags = nearestObjects [
+		_taskDataStore getVariable "fob_position_2d",
 		["vn_flag_usa", "vn_flag_aus", "vn_flag_arvn", "vn_flag_nz"],
-		200
+		para_g_max_base_radius
 	];
 
-        if !(_possibleBases isEqualTo []) then {
+        if !(_possibleFlags isEqualTo []) then {
 		_taskDataStore setVariable ["flag_built", true];
                 ["SUCCEEDED"] call _fnc_finishSubtask;
         };

--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -54,9 +54,9 @@ _taskDataStore setVariable ["INIT", {
 	_taskDataStore setVariable ["factory_sites_destroyed", false];
 
 	private _initialTasks = [
-		["destroy_hq_sites", [(_zonePosition # 0) - 100, _zonePosition # 1, 0]],
-		["destroy_factory_sites", [(_zonePosition # 0) + 100, _zonePosition # 1, 0]],
-		["build_situation_room", [_zonePosition # 0, (_zonePosition # 1) - 100 , 0]]
+		["destroy_hq_sites", _zonePosition getPos [100, 0]],
+		["destroy_factory_sites", _zonePosition getPos [100, 90]],
+		["build_situation_room", _zonePosition getPos [100, 180]]
 	];
 
 	[_initialTasks] call _fnc_initialSubtasks;
@@ -120,8 +120,8 @@ _taskDataStore setVariable ["build_situation_room", {
 		_taskDataStore setVariable ["fob_built", true];
 		_taskDataStore setVariable ["fob_position", getPos (_possibleBases select 0)];
 		private _nextTasks = [
-			["build_respawn", getPos (_possibleBases select 0)],
-			["build_flag", getPos (_possibleBases select 0)]
+			["build_respawn", (_taskDataStore getVariable "fob_position") getPos [50, 90]],
+			["build_flag", (_taskDataStore getVariable "fob_position") getPos [50, 270]]
 		];
                 ["SUCCEEDED", _nextTasks] call _fnc_finishSubtask;
         };

--- a/mission/stringtable.xml
+++ b/mission/stringtable.xml
@@ -722,6 +722,10 @@
         <Original>The enemy counter-attack was successful. Zone %1 has been lost.</Original>
         <English>The enemy counter-attack was successful. Zone %1 has been lost.</English>
       </Key>
+      <Key ID="STR_vn_mf_notification_desc_counter_attack_extended">
+        <Original>Enemy counter-attack is succeeding. Timer extended!</Original>
+        <English>Enemy counter-attack is succeeding. Timer extended!</English>
+      </Key>
       <Key ID="STR_vn_mf_notification_desc_no_sandbag">
         <Original>No sandbags in inventory</Original>
         <English>No sandbags in inventory</English>


### PR DESCRIPTION
### Tasks / Mission flow

#### Capture
- ADDED: Optional construction tasks
  - Build FOB (Situation Room)
  - Build Respawn inside FOB area
  - Build Flag inside FOB area
- CHANGED: Moved subtask markers around to make remaining subtasks more obvious on map

#### Defend
- ADDED: New task to Defend The Flag from being lowered/removed (requires a flag inside a FOB)
- ADDED: Red map outer marker around the area that bluefor needs to hold
- CHANGE: Split Defend the Zone task into: 
  - Hold the Zone (active when no FOB built)
  - Defend the FOB (active when is FOB built)
- CHANGE: Failing counter attack now just restarts the counter attack phase instead of the whole AO
- CHANGE: AI Objective is now spawned during the "Prepare for Attack" subtask to give AI a chance to travel to the FOB

### Actions

- "Lower the flag" during counter attack -- 20 second duration (Dac Cong only)
- "Raise the flag" during counter attack -- 20 second duration (Bluefor only, when flag height < 100%)