### PR TITLE
[TWEAK] Make collecting intel documents take longer.

### DIFF
--- a/mission/functions/systems/actions/fn_action_gather_intel.sqf
+++ b/mission/functions/systems/actions/fn_action_gather_intel.sqf
@@ -12,7 +12,7 @@
 	},// Code executed on completion
 	{},	// Code executed on interrupted
 	[],													// Arguments passed to the scripts as _this select 3
-	5,													// Action duration [s]
+	30,													// Action duration [s]
 	100,													// Priority
 	false,											// Remove on completion
 	false												// Show in unconscious state

--- a/mission/functions/systems/actions/fn_action_gather_intel.sqf
+++ b/mission/functions/systems/actions/fn_action_gather_intel.sqf
@@ -12,7 +12,7 @@
 	},// Code executed on completion
 	{},	// Code executed on interrupted
 	[],													// Arguments passed to the scripts as _this select 3
-	30,													// Action duration [s]
+	45,													// Action duration [s]
 	100,													// Priority
 	false,											// Remove on completion
 	false												// Show in unconscious state

--- a/mission/functions/systems/actions/fn_action_radiotap.sqf
+++ b/mission/functions/systems/actions/fn_action_radiotap.sqf
@@ -68,7 +68,7 @@ private _codeOnComplete = {
 };
 private _codeOnInterrupted = {};
 private _extraArgsArr = [];
-private _actionDurationSeconds = 20;
+private _actionDurationSeconds = 10;
 private _actionPriority = 100;
 private _actionRemoveOnComplete = false;
 private _showWhenUncon = false;

--- a/mission/functions/systems/actions/fn_action_radiotap.sqf
+++ b/mission/functions/systems/actions/fn_action_radiotap.sqf
@@ -68,7 +68,7 @@ private _codeOnComplete = {
 };
 private _codeOnInterrupted = {};
 private _extraArgsArr = [];
-private _actionDurationSeconds = 10;
+private _actionDurationSeconds = 20;
 private _actionPriority = 100;
 private _actionRemoveOnComplete = false;
 private _showWhenUncon = false;


### PR DESCRIPTION
Slow down intel gathering to make it more tense and dangerous.

Taking influence from Deus Ex (the original) where "hacking" is a passive activity (click a button and wait) .... but it is incredibly tense because your screen is blacked out and you can't see if a deadly enemy is coming around a corner behind to one shot kill you.

https://youtu.be/bgJazjz9ZsA?feature=shared&t=4379

- Gathering intel documents -- 45 seconds