### PR TITLE
[SITES] Teardown sites when objects to destroy outside specified radius.

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -296,7 +296,14 @@ class CfgFunctions
 			class reveal_supply_line {};
 			class reveal_radiotap_nearest_sites {};
 		};
-		
+
+		class system_sites_utils
+		{
+			file = "functions\systems\sites\utils";
+			class sites_utils_std_teardown {};
+			class sites_utils_std_check_teardown {};
+		}
+
 		class system_supplies {
 			file = "functions\systems\supplies";
 			class action_supplies {};

--- a/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_aa_site.sqf
@@ -59,23 +59,13 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-		//Teardown when all guns destroyed
-		(_siteStore getVariable "objectsToDestroy" findIf {alive _x} == -1)
+		[_siteStore] call vn_mf_fnc_sites_utils_std_check_teardown;
 	},
 	//Teardown code
 	{
 		params ["_siteStore"];
-
-		{
-			deleteMarker _x;
-		} forEach (_siteStore getVariable "markers");
-
-		{
-			deleteVehicle _x;
-		} forEach ((_siteStore getVariable "objectsToDestroy"));
-
-		{
-			[_x] call para_s_fnc_ai_obj_finish_objective;
-		} forEach (_siteStore getVariable ["aiObjectives", []]);
+		// delete the vehicle crew then teardown everything else
+		(_siteStore getVariable "objectsToDestroy") apply {deleteVehicleCrew _x};
+		[_siteStore] call vn_mf_fnc_sites_utils_std_teardown;
 	}
 ] call vn_mf_fnc_sites_create_site;

--- a/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_artillery_site.sqf
@@ -112,23 +112,11 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-		//Teardown when all guns destroyed
-		(_siteStore getVariable "objectsToDestroy" findIf {alive _x} == -1)
+		[_siteStore] call vn_mf_fnc_sites_utils_std_check_teardown;
 	},
 	//Teardown code
 	{
 		params ["_siteStore"];
-
-		{
-			deleteMarker _x;
-		} forEach (_siteStore getVariable "markers");
-
-		{
-			deleteVehicle _x;
-		} forEach ((_siteStore getVariable "objectsToDestroy"));
-
-		{
-			[_x] call para_s_fnc_ai_obj_finish_objective;
-		} forEach (_siteStore getVariable ["aiObjectives", []]);
+		[_siteStore] call vn_mf_fnc_sites_utils_std_teardown;
 	}
 ] call vn_mf_fnc_sites_create_site;

--- a/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_camp_site.sqf
@@ -111,24 +111,11 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-		//Teardown when all guns destroyed
-		(_siteStore getVariable "objectsToDestroy" findIf {alive _x} == -1)
+		[_siteStore] call vn_mf_fnc_sites_utils_std_check_teardown;
 	},
 	//Teardown code
 	{
 		params ["_siteStore"];
-
-		{
-			deleteMarker _x;
-		} forEach (_siteStore getVariable "markers");
-
-		private _objectsToDestroy = _siteStore getVariable "objectsToDestroy";
-		{
-			deleteVehicle _x;
-		} forEach _objectsToDestroy;
-
-		{
-			[_x] call para_s_fnc_ai_obj_finish_objective;
-		} forEach (_siteStore getVariable ["aiObjectives", []]);
+		[_siteStore] call vn_mf_fnc_sites_utils_std_teardown;
 	}
 ] call vn_mf_fnc_sites_create_site;

--- a/mission/functions/systems/sites/fn_sites_create_factory.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_factory.sqf
@@ -105,19 +105,11 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-
-		(_siteStore getVariable "objectsToDestroy" findIf {alive _x} == -1)
+		[_siteStore] call vn_mf_fnc_sites_utils_std_check_teardown;
 	},
 	//Teardown code
 	{
 		params ["_siteStore"];
-
-		{
-			deleteMarker _x;
-		} forEach (_siteStore getVariable "markers");
-
-		// release AI from associated objectives
-		// note -- AI can vanish in front of players when this is executed
-		_siteStore getVariable "aiObjectives" apply {[_x] call para_s_fnc_ai_obj_finish_objective};
+		[_siteStore] call vn_mf_fnc_sites_utils_std_teardown;
 	}
 ] call vn_mf_fnc_sites_create_site;

--- a/mission/functions/systems/sites/fn_sites_create_hq.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_hq.sqf
@@ -109,26 +109,11 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-
-		(_siteStore getVariable "objectsToDestroy" findIf {alive _x} == -1)
+		[_siteStore] call vn_mf_fnc_sites_utils_std_check_teardown;
 	},
 	//Teardown code
 	{
 		params ["_siteStore"];
-
-		private _objectsToDestroy = _siteStore getVariable "objectsToDestroy";
-		private _respawnToDelete = _siteStore getVariable "respawnPointsDC";
-
-		{
-			deleteVehicle _x;
-		} forEach _objectsToDestroy;
-
-		{
-			deleteMarker _x;
-		} forEach (_siteStore getVariable "markers");
-
-		// release AI from associated objectives
-		// note -- AI can vanish in front of players when this is executed
-		_siteStore getVariable "aiObjectives" apply {[_x] call para_s_fnc_ai_obj_finish_objective};
+		[_siteStore] call vn_mf_fnc_sites_utils_std_teardown;
 	}
 ] call vn_mf_fnc_sites_create_site;

--- a/mission/functions/systems/sites/fn_sites_create_water_supply_site.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_water_supply_site.sqf
@@ -47,7 +47,7 @@ params ["_pos"];
 		_siteStore setVariable ["markers", [_supplyMarker]];
 		_siteStore setVariable ["supplys", [_tunnelWS]];
 		_siteStore setVariable ["vehicles", [_tunnelWS]]; 
-		_siteStore setVariable ["objectsToDestroy", _tunnelWS];
+		_siteStore setVariable ["objectsToDestroy", [_tunnelWS]];
 	},
 	//Teardown condition check code
 	{
@@ -57,23 +57,11 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-		//Teardown when destroyed
-		(_siteStore getVariable "supplys" findIf {alive _x} == -1)
+		[_siteStore] call vn_mf_fnc_sites_utils_std_check_teardown;
 	},
 	//Teardown code
 	{
 		params ["_siteStore"];
-
-		{
-			deleteMarker _x;
-		} forEach (_siteStore getVariable "markers");
-
-		{
-			deleteVehicle _x;
-		} forEach (_siteStore getVariable "vehicles");
-
-		{
-			[_x] call para_s_fnc_ai_obj_finish_objective;
-		} forEach (_siteStore getVariable ["aiObjectives", []]);
+		[_siteStore] call vn_mf_fnc_sites_utils_std_teardown;
 	}
 ] call vn_mf_fnc_sites_create_site;

--- a/mission/functions/systems/sites/utils/fn_sites_utils_std_check_teardown.sqf
+++ b/mission/functions/systems/sites/utils/fn_sites_utils_std_check_teardown.sqf
@@ -1,0 +1,31 @@
+/*
+	File: fn_sites_utils_std_check_teardown.sqf
+	Author: "DJ" Dijksterhuis
+	Public: No
+	
+	Description:
+		Checks if an object is within a specified radius.
+	
+	Parameter(s):
+		_siteStore - Site to check the teardown condition of.
+		_radius - [OPTIONAL] radius of search area for aliveness.
+	
+	Returns:
+		true if object is alive within radius, false otherwise
+	
+	Example(s):
+ 		[_siteStore] call vn_mf_fnc_sites_utils_std_check_teardown;
+ 		[_siteStore, 25] call vn_mf_fnc_sites_utils_std_check_teardown;
+*/
+
+params ["_siteStore", ["_radius", 50]];
+
+private _pos = getPos _siteStore;
+private _objects = _siteStore getVariable "objectsToDestroy";
+
+// every object is ALIVE WITHIN specified radius
+private _objectsAreAlive = _objects findIf {
+	(alive _x) && (count ([_x] inAreaArray [_pos, _radius, _radius, 0, false]) > 0)
+};
+
+_objectsAreAlive == -1

--- a/mission/functions/systems/sites/utils/fn_sites_utils_std_teardown.sqf
+++ b/mission/functions/systems/sites/utils/fn_sites_utils_std_teardown.sqf
@@ -1,0 +1,42 @@
+/*
+	File: fn_sites_utils_std_teardown.sqf
+	Author: "DJ" Dijksterhuis
+	Public: No
+	
+	Description:
+		Tears down a site in standardised manner.
+	
+	Parameter(s):
+		_siteStore - Site store object.
+		_markers - [OPTIONAL] Boolean whether to remove markers or not.
+		_objects - [OPTIONAL] Boolean whether to remove objects or not.
+		_ai - [OPTIONAL] Boolean whether to remove ai objectives or not.
+	
+	Returns:
+		None
+	
+	Example(s):
+ 		[_siteStore] call vn_mf_fnc_sites_utils_do_teardown;
+		[_siteStore, true, false, false] call vn_mf_fnc_sites_utils_do_teardown;
+		[_siteStore, true, true, false] call vn_mf_fnc_sites_utils_do_teardown;
+*/
+
+
+params [
+	"_siteStore", 
+	["_markers", true], 
+	["_objects", true], 
+	["_ai", true]
+];
+
+if (_markers) then {
+	((_siteStore getVariable "markers") apply {deleteMarker _x})
+};
+
+if (_objects) then {
+	((_siteStore getVariable "objectsToDestroy") apply {deleteVehicle _x})
+};
+
+if (_ai) then {
+	((_siteStore getVariable ["aiObjectives", []]) apply {[_x] call para_s_fnc_ai_obj_finish_objective})
+};


### PR DESCRIPTION
Sites could be blocked from completing becuase an AA/Arty/Crate etc. had been moved or 'yeeted' itself outside the site's immediate area -- and players were unable to find the objects.

Expands on standard teardown conditions by checking if the ALIVE objects are within a specified radius. All sites currently use a default radius of 50m.

Also refactored teardown code out into a util library. Next TODO would be to refactor the central teardown script, but want to leave it to honour future upstream changes (that file is SGD owned).