### PR TITLE
[SITES] Improved search for terrain objects to hide.

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -295,6 +295,7 @@ class CfgFunctions
 
 			class reveal_supply_line {};
 			class reveal_radiotap_nearest_sites {};
+			class sites_hide_unsafe_terrain_objects {};
 		};
 		
 		class system_supplies {

--- a/mission/functions/systems/sites/fn_sites_generate.sqf
+++ b/mission/functions/systems/sites/fn_sites_generate.sqf
@@ -19,17 +19,17 @@ params ["_zone"];
 
 private _zoneData = [_zone] call vn_mf_fnc_zones_load_zone;
 private _allTerrainObjects = 	["TREE", "HIDE", "WATERTOWER", "BUSH", "SMALL TREE", "ROCK", "ROCKS", "STACK", "FOUNTAIN", "RUIN", "TOURISM", "CHURCH", "CHAPEL", "BUILDING", "HOUSE", "FUELSTATION", "HOSPITAL", "FORTRESS", "BUNKER", "FENCE", "WALL"];
-private _unnaturalObjects = 	["HIDE", "WATERTOWER", "STACK", "FOUNTAIN", "RUIN", "TOURISM", "CHURCH", "CHAPEL", "BUILDING", "HOUSE", "FUELSTATION", "HOSPITAL", "FORTRESS", "BUNKER", "FENCE", "WALL"];
+private _unnaturalObjects = 	["ROCK", "ROCKS", "HIDE", "WATERTOWER", "STACK", "FOUNTAIN", "RUIN", "TOURISM", "CHURCH", "CHAPEL", "BUILDING", "HOUSE", "FUELSTATION", "HOSPITAL", "FORTRESS", "BUNKER", "FENCE", "WALL"];
 private _center = markerPos (_zoneData select struct_zone_m_marker);
 private _size = markerSize (_zoneData select struct_zone_m_marker);
 private _sizeX = _size select 0;
 
 //Create zone factory
-private _factoryPosition = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+private _factoryPosition = [_center, vn_mf_bn_s_zone_radius, 0, 35, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 [_factoryPosition, _zone] call vn_mf_fnc_sites_create_factory;
 
 //Create zone HQ
-private _hqPosition = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+private _hqPosition = [_center, vn_mf_bn_s_zone_radius, 0, 35, 5, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
 [_hqPosition, _zone] call vn_mf_fnc_sites_create_hq;
 
 // for "_i" from 1 to (1 + ceil random (vn_mf_s_max_radars_per_zone - 1)) do
@@ -41,7 +41,7 @@ private _hqPosition = [_center, vn_mf_bn_s_zone_radius, 0, 55, 5, _allTerrainObj
 for "_i" from 1 to (3 + ceil random (vn_mf_s_max_camps_per_zone - 1)) do
 {
 	//[_zoneData] call vn_mf_fnc_sites_create_camp;
-	private _campSite = [_center, vn_mf_bn_s_zone_radius, 0, 8, 15, _allTerrainObjects] call vn_mf_fnc_sites_get_safe_location;
+	private _campSite = [_center, vn_mf_bn_s_zone_radius, 0, 8, 15, _unnaturalObjects] call vn_mf_fnc_sites_get_safe_location;
 	[_campSite, _zone] call vn_mf_fnc_sites_create_camp_site;
 };
 

--- a/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
+++ b/mission/functions/systems/sites/fn_sites_get_safe_location.sqf
@@ -132,12 +132,7 @@ if (_finalPosition isEqualTo [0, 0, 0]) then {
 	_finalPosition = _position getPos [random _radius, random 360];
 };
 
-if(!(_terrainObjects isEqualTo [])) then 
-{
-	{
-		_x hideObjectGlobal true;
-	} forEach (nearestTerrainObjects [_finalPosition, _terrainObjects, _gradientRadius, false, true]);
-};
+[_finalPosition, _gradientRadius, _terrainObjects] call vn_mf_fnc_sites_hide_unsafe_terrain_objects;
 
 _finalPosition = _finalPosition + [0];
 _finalPosition;

--- a/mission/functions/systems/sites/fn_sites_hide_unsafe_terrain_objects.sqf
+++ b/mission/functions/systems/sites/fn_sites_hide_unsafe_terrain_objects.sqf
@@ -1,0 +1,104 @@
+/*
+	File: fn_sites_get_unsafe_terrain_objects.sqf
+	Author: "DJ" Dijksterhuis"
+	Public: No
+	
+	Description:
+		
+	
+	Parameter(s):
+		
+	
+	Returns:
+		
+	
+	Example(s):
+		
+*/
+
+private _debug = false;
+
+params ["_sitePos", "_siteRadius", ["_terrainTypesArr", ["ROCK", "ROCKS", "HIDE"]]];
+
+// get the first object only to avoid a nested for loop over every site object
+// (leave the terrain object search radius high to capture everything nearby).
+private _nearbyTerrainObjs = nearestTerrainObjects [
+	_sitePos,
+	_terrainTypesArr,
+	vn_mf_sites_minimum_distance_between_sites,
+	false,
+	true
+];
+
+if (_debug) then {
+	private _markerName = format ["maker-site-%1", [0, 10000] call BIS_fnc_randomInt];
+	private _marker = createMarker [_markerName, _sitePos];
+	_marker setMarkerAlpha 1;
+	_marker setMarkerShape "ELLIPSE";
+	_marker setMarkerSize [_siteRadius, _siteRadius];
+	_marker setMarkerBrush "Border";
+	_marker setMarkerColor "ColorGreen";
+
+};
+
+_nearbyTerrainObjs apply {
+
+	// use a bounding box to work out the terrain object's radius from maximum x/y dimension.
+	// https://community.bistudio.com/wiki/boundingBoxReal
+
+	private _bbr = boundingBoxReal _x;
+	private _maxXRadius = abs (((_bbr select 0) select 1) - ((_bbr select 1) select 1));
+	private _maxYRadius = abs (((_bbr select 0) select 0) - ((_bbr select 1) select 0));
+
+	private _maxDimensionRadius = (_maxXRadius max _maxYRadius) / 2;
+
+	/*
+	can now work out maximum size of the terrain object
+	work out if the site intersects with the maximum dimension of the terrain object
+
+	NOTE: For some reason we have to divide siteRadius by 2 to get this correct.
+	Otherwise we remove terrain objects that do not intersect with the site's area.
+	*/
+
+	private _areaArr = [
+		getPos _x, 
+		_maxDimensionRadius + (_siteRadius / 2), 
+		_maxDimensionRadius + (_siteRadius / 2),  
+		0, 
+		true
+	];
+
+	if (_sitePos inArea _areaArr) then {
+		diag_log format ["Hiding terrain object: obj=%1 pos=%2", _x, getPos _x];
+		_x hideObjectGlobal true;
+
+		/*
+		rocks can have bushes placed on top of them.
+		removing the rocks alone leaves the bushes stranded in mid air
+		which looks janky as hell.
+		so we need to remove any terrain objects on top of this terrain object.
+		*/
+		private _additionalObjects = nearestTerrainObjects [
+			getPos _x,
+			[], 
+			_maxDimensionRadius,
+			false,
+			true
+		];
+		_additionalObjects apply {_x hideObjectGlobal true};
+
+		if (_debug) then {
+			private _markerName = format ["marker-terrain-object-%1", _x];
+			private _marker = createMarker [_markerName, getPos _x];
+			_marker setMarkerAlpha 1;
+			_marker setMarkerShape "ELLIPSE";
+			_marker setMarkerSize [_maxDimensionRadius, _maxDimensionRadius];
+			_marker setMarkerBrush "Border";
+
+			_marker setMarkerColor "ColorRed";
+
+		};
+
+	};
+};
+


### PR DESCRIPTION
`nearestTerrainObjects` searches for object centrepoints within a specified area.

This is problematic as it will not exclude larger objects like rocks or buildings whose centrepoint is not within the area, but they extend over into the area.

We need to search for objects whose area intersects with the site's area, and then remove them if they are present.

So... bounding boxes on the terrain objects!

![20231227003929_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/0e17d6c8-e547-4337-9efd-237aaf9c7885)


![20231227004325_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/65ba0be9-69b4-4b60-90ef-6bdfc01ea969)
