### PR TITLE
Intel: Reduce addAction duration due to undocumented time limit.

### DIFF
--- a/mission/functions/systems/actions/fn_action_gather_intel.sqf
+++ b/mission/functions/systems/actions/fn_action_gather_intel.sqf
@@ -12,7 +12,7 @@
 	},// Code executed on completion
 	{},	// Code executed on interrupted
 	[],													// Arguments passed to the scripts as _this select 3
-	45,													// Action duration [s]
+	15,													// Action duration [s]
 	100,													// Priority
 	false,											// Remove on completion
 	false												// Show in unconscious state


### PR DESCRIPTION
Reducing time back down until I can review the suggested workaround as it uses undocumented functionality.

> Seems like holdactions created by BIS_fnc_holdActionAdd fades out if the hold duration is longer than ~15 seconds. Might be tied to a difficulty setting.

https://feedback.bistudio.com/T155638