### PR TITLE
CaptureTheFlag: Fixups for the CTF task loop and add some new optional buidables

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -207,6 +207,8 @@ class CfgFunctions
 			file = "functions\systems\dac_cong";
 
 			class capture_player {};
+			class ctf_opfor_lower_flag {};
+			class ctf_bluefor_raise_flag {};
 		}
 
 		//Gameplay director, responsible for main game progression and flow.

--- a/mission/config/subconfigs/tasks/primary/tasks.hpp
+++ b/mission/config/subconfigs/tasks/primary/tasks.hpp
@@ -47,10 +47,10 @@ class capture_zone : task
 		taskdesc = "Build a landing pad so helos can land near the FOB. Emphasis on near!";
 	};
 
-	class build_latrine
+	class build_rearm_repair_refuel
 	{
-		taskname = "Build FOB Latrine";
-		taskdesc = "Build a latrine. When you gotta go, you gotta go.";
+		taskname = "Build FOB Rearm/Repair/Refuel Station";
+		taskdesc = "Build a Vehicle Rearm/Repair/Refuel location at the FOB. Possibly next to the helipad.";
 	};
 
 	class build_flag

--- a/mission/config/subconfigs/tasks/primary/tasks.hpp
+++ b/mission/config/subconfigs/tasks/primary/tasks.hpp
@@ -41,6 +41,18 @@ class capture_zone : task
 		taskdesc = "Build a respawn so we can reinforce the Forward Operating Base.";
 	};
 
+	class build_landing_pad
+	{
+		taskname = "Build FOB Landing Pad";
+		taskdesc = "Build a landing pad so helos can land near the FOB. Emphasis on near!";
+	};
+
+	class build_latrine
+	{
+		taskname = "Build FOB Latrine";
+		taskdesc = "Build a latrine. When you gotta go, you gotta go.";
+	};
+
 	class build_flag
 	{
 		taskname = "Build FOB Flag";

--- a/mission/functions/systems/actions/fn_action_lower_flag.sqf
+++ b/mission/functions/systems/actions/fn_action_lower_flag.sqf
@@ -54,7 +54,6 @@ private _conditionToProgress = "true";
 private _codeOnStart = {
 	params ["_target", "_caller", "_actionId", "_arguments"];
 	allPlayers apply {["DacCongCapturingFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
-	diag_log "YUP";
 };
 private _codeOnTick = {
 	params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];

--- a/mission/functions/systems/actions/fn_action_reraise_flag.sqf
+++ b/mission/functions/systems/actions/fn_action_reraise_flag.sqf
@@ -4,54 +4,68 @@
 	Public: No
 	
 	Description:
-		Dac Cong have lowered a mission critical flag.
-		Bluefor need to raise it to 100% again.
+		Dac Cong players have lowered a mission critical (player built)
+		flag in a base. Bluefor need to raise it to 100% again.
+
+		WARNING: This is attached to **PLAYERS**, running in **player** locality.
 
 	Parameter(s): none
 	
 	Returns:
 	
 	Example(s):
-		call vn_mf_fnc_action_capture_player;
+		call vn_mf_fnc_action_reraise_flag;
 */
 
-private _actionText = format ["<t color='#0000FF'>%1</t>", "Re-Raise The Flag"];
+private _actionText = format ["<t color='#0000FF'>%1</t>", "Raise Flag"];
 private _actionIdleIcon = "custom\holdactions\holdAction_interact_ca.paa";
 private _actionProgressIcon = "custom\holdactions\holdAction_interact_ca.paa";
 
 private _isNotOpfor = "side player == west";
 private _isInRangeOf = "player distance cursorObject < 5";
-private _isValidObjectType = "typeOf cursorObject in ['vn_flag_usa', 'vn_flag_aus', 'vn_flag_arvn', 'vn_flag_nz']";
-private _isObjectiveFlag = "(flagAnimationPhase cursorObject) != 1";
+private _validFlagsArr = "['vn_flag_usa', 'vn_flag_aus', 'vn_flag_arvn', 'vn_flag_nz']";
+private _isValidObjectType = format [
+	"typeOf cursorObject in %1",
+	_validFlagsArr
+];
+private _isObjectiveFlag = "!(isNil 'vn_mf_bn_dc_target_flag') && (cursorObject == vn_mf_bn_dc_target_flag)";
+private _isFlagLowered = "(flagAnimationPhase cursorObject) != 1";
 
+// bluefor can raise the flag only if it has been lowered
 private _conditionToShow = format [
-        "(%1 && %2 && %3 && %4)",
+        "(%1 && %2 && %3 && %4 && %5)",
         _isNotOpfor,
         _isInRangeOf,
         _isValidObjectType,
-        _isObjectiveFlag
+        _isObjectiveFlag,
+        _isFlagLowered
 ];
 
 private _conditionToProgress = "true";
 
 private _codeOnStart = {
+	params ["_target", "_caller", "_actionId", "_arguments"];
 	allPlayers apply {["BlueforRaisingFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
 };
 private _codeOnTick = {
 	params ["_target", "_caller", "_actionId", "_arguments", "_progress", "_maxProgress"];
-	private _startingFlagHeight = cursorObject getVariable ["currentHeight", flagAnimationPhase cursorObject];
-	private _newHeight = _startingFlagHeight + ((1 - _startingFlagHeight) * (_progress / _maxProgress));
-	cursorObject setFlagAnimationPhase _newHeight;
+	[vn_mf_bn_dc_target_flag, _maxProgress] remoteExec ["vn_mf_fnc_ctf_bluefor_raise_flag", 2];
 };
+
+/*
 private _codeOnComplete = {
-	cursorObject setVariable ["currentHeight", flagAnimationPhase cursorObject];
-	allPlayers apply {["BlueforRaisedFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
+	params ["_target", "_caller", "_actionId", "_arguments"];
 };
+
 private _codeOnInterrupted = {
-	cursorObject setVariable ["currentHeight", flagAnimationPhase cursorObject];
+	params ["_target", "_caller", "_actionId", "_arguments"];
 };
+*/
+
+private _codeOnComplete = {};
+private _codeOnInterrupted = {};
 private _extraArgsArr = [flagAnimationPhase cursorObject];
-private _actionDurationSeconds = 20;
+private _actionDurationSeconds = 10;
 private _actionPriority = 100;
 private _actionRemoveOnComplete = false;
 private _showWhenUncon = false;

--- a/mission/functions/systems/dac_cong/fn_ctf_bluefor_raise_flag.sqf
+++ b/mission/functions/systems/dac_cong/fn_ctf_bluefor_raise_flag.sqf
@@ -1,0 +1,36 @@
+/*
+    File: fn_ctf_bluefor_raise_flag.sqf
+    Author: "DJ" Dijksterhuis
+    Public: No
+
+    Description:
+	   TODO
+
+    Parameter(s):
+        - _target
+        - _progress
+        - _maxProgress
+
+    Returns: TODO
+
+    Example(s):
+	[_target] call vn_mf_fnc_capture_player;
+*/
+
+
+params ["_target", "_maxProgress"];
+
+diag_log format [
+    "FlagRaise: target=%1 maxProgress=%2 start=%3", 
+    _target, _maxProgress, flagAnimationPhase _target
+];
+
+private _startingFlagHeight = flagAnimationPhase _target;
+private _newHeight = _startingFlagHeight + (1 / _maxProgress);
+
+if (_newHeight >= 1) exitWith {
+    allPlayers apply {["BlueforRaisedFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
+    _target setFlagAnimationPhase 1;
+};
+
+_target setFlagAnimationPhase _newHeight;

--- a/mission/functions/systems/dac_cong/fn_ctf_bluefor_raise_flag.sqf
+++ b/mission/functions/systems/dac_cong/fn_ctf_bluefor_raise_flag.sqf
@@ -20,11 +20,6 @@
 
 params ["_target", "_maxProgress"];
 
-diag_log format [
-    "FlagRaise: target=%1 maxProgress=%2 start=%3", 
-    _target, _maxProgress, flagAnimationPhase _target
-];
-
 private _startingFlagHeight = flagAnimationPhase _target;
 private _newHeight = _startingFlagHeight + (1 / _maxProgress);
 

--- a/mission/functions/systems/dac_cong/fn_ctf_opfor_lower_flag.sqf
+++ b/mission/functions/systems/dac_cong/fn_ctf_opfor_lower_flag.sqf
@@ -1,0 +1,38 @@
+/*
+    File: fn_ctf_opfor_lower_flag.sqf
+    Author: "DJ" Dijksterhuis
+    Public: No
+
+    Description:
+	   TODO
+
+    Parameter(s):
+        - _target
+        - _progress
+        - _maxProgress
+
+    Returns: TODO
+
+    Example(s):
+	[_target] call vn_mf_fnc_capture_player;
+*/
+
+
+params ["_target", "_maxProgress"];
+
+diag_log format [
+    "FlagLower: target=%1 maxProgress=%2 start=%3", 
+    _target, _maxProgress, flagAnimationPhase _target
+];
+
+private _startingFlagHeight = flagAnimationPhase _target;
+private _newHeight = _startingFlagHeight - (1 / _maxProgress);
+
+if (_newHeight <= 0) exitWith {
+    deleteVehicle _target;
+    allPlayers apply {["DacCongCapturedFlag", []] remoteExec ["para_c_fnc_show_notification", _x]};
+};
+
+_target setFlagAnimationPhase _newHeight;
+
+

--- a/mission/functions/systems/dac_cong/fn_ctf_opfor_lower_flag.sqf
+++ b/mission/functions/systems/dac_cong/fn_ctf_opfor_lower_flag.sqf
@@ -20,11 +20,6 @@
 
 params ["_target", "_maxProgress"];
 
-diag_log format [
-    "FlagLower: target=%1 maxProgress=%2 start=%3", 
-    _target, _maxProgress, flagAnimationPhase _target
-];
-
 private _startingFlagHeight = flagAnimationPhase _target;
 private _newHeight = _startingFlagHeight - (1 / _maxProgress);
 

--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -111,8 +111,8 @@ _taskDataStore setVariable ["build_fob", {
 
         private _possibleBases = para_g_bases inAreaArray [
 		getMarkerPos (_taskDataStore getVariable "taskMarker"),
-		selectMax (getMarkerSize (_taskDataStore getVariable "taskMarker") apply {abs _x}),
-		selectMax (getMarkerSize (_taskDataStore getVariable "taskMarker") apply {abs _x}),
+		selectMax ((getMarkerSize "activeZoneCircle") apply {abs _x}),
+		selectMax ((getMarkerSize "activeZoneCircle") apply {abs _x}),
 		0
 	];
 
@@ -130,42 +130,92 @@ _taskDataStore setVariable ["build_fob", {
 		_taskDataStore setVariable ["fob", _possibleBases select 0];
 		_taskDataStore setVariable ["fob_position_2d", [_fobPos3DASL select 0, _fobPos3DASL select 1]];
 		private _nextTasks = [
-			["build_respawn", (_taskDataStore getVariable "fob_position_2d") getPos [50, 90]],
-			["build_flag", (_taskDataStore getVariable "fob_position_2d") getPos [50, 270]]
+			["build_respawn", (_taskDataStore getVariable "fob_position_2d") getPos [50, 0]],
+			["build_flag", (_taskDataStore getVariable "fob_position_2d") getPos [50, 90]],
+			["build_landing_pad", (_taskDataStore getVariable "fob_position_2d") getPos [50, 180]],
+			["build_latrine", (_taskDataStore getVariable "fob_position_2d") getPos [50, 270]]
 		];
                 ["SUCCEEDED", _nextTasks] call _fnc_finishSubtask;
         };
 }];
 
-_taskDataStore setVariable ["build_respawn", {
-	params ["_taskDataStore"];
+_taskDataStore setVariable ["_fnc_have_built_buildings", {
+	params ["_tds", "_types"];
 
 	private _candidates = nearestObjects [
-		_taskDataStore getVariable "fob_position_2d",
-		["Land_vn_guardhouse_01", "Land_vn_b_trench_bunker_01_01", "Land_vn_hootch_01_01"],
+		_tds getVariable "fob_position_2d",
+		_types,
 		para_g_max_base_radius
 	];
 
-	if !(_candidates isEqualTo []) then {
-		_taskDataStore setVariable ["flag_built", true];
+	/*
+	need to check if they are a paradigm built object!
+	otherwise the objective disappears in places like MSS leghorn
+	once FOB is built
+
+	the para_g_building variable is a simple object assigned to
+	the actual arma object, housing all the paradigm building variables.
+	*/
+
+	private _para_built_object_first_idx = _candidates findIf {not isNull (_x getVariable ["para_g_building", objNull])};
+
+	(_para_built_object_first_idx > -1)
+}];
+
+
+_taskDataStore setVariable ["build_respawn", {
+	params ["_tds"];
+
+	private _building_types = [
+		"Land_vn_guardhouse_01",
+		"Land_vn_b_trench_bunker_01_01",
+		"Land_vn_hootch_01_01"
+	];
+	private _building_exists = [_tds, _building_types] call (_tds getVariable "_fnc_have_built_buildings");
+
+	if (_building_exists) then {
+		["SUCCEEDED"] call _fnc_finishSubtask;
+	};
+}];
+
+_taskDataStore setVariable ["build_landing_pad", {
+	params ["_tds"];
+
+	private _building_types = ["Land_vn_b_helipad_01"];
+	private _building_exists = [_tds, _building_types] call (_tds getVariable "_fnc_have_built_buildings");
+
+	if (_building_exists) then {
+		["SUCCEEDED"] call _fnc_finishSubtask;
+	};
+}];
+
+_taskDataStore setVariable ["build_latrine", {
+	params ["_tds"];
+
+	private _building_types = ["Land_vn_latrine_01"];
+	private _building_exists = [_tds, _building_types] call (_tds getVariable "_fnc_have_built_buildings");
+
+	if (_building_exists) then {
 		["SUCCEEDED"] call _fnc_finishSubtask;
 	};
 }];
 
 _taskDataStore setVariable ["build_flag", {
-	params ["_taskDataStore"];
+	params ["_tds"];
 
-	private _candidates = nearestObjects [
-		_taskDataStore getVariable "fob_position_2d",
-		["vn_flag_usa", "vn_flag_aus", "vn_flag_arvn", "vn_flag_nz"],
-		para_g_max_base_radius
+	private _building_types = [
+		"vn_flag_usa",
+		"vn_flag_aus",
+		"vn_flag_arvn",
+		"vn_flag_nz"
 	];
+	private _building_exists = [_tds, _building_types] call (_tds getVariable "_fnc_have_built_buildings");
 
-	if !(_candidates isEqualTo []) then {
-		_taskDataStore setVariable ["flag_built", true];
+	if (_building_exists) then {
 		["SUCCEEDED"] call _fnc_finishSubtask;
 	};
 }];
+
 
 _taskDataStore setVariable ["AFTER_STATES_RUN", {
 	params ["_taskDataStore"];

--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -129,12 +129,14 @@ _taskDataStore setVariable ["build_fob", {
 
 		_taskDataStore setVariable ["fob", _possibleBases select 0];
 		_taskDataStore setVariable ["fob_position_2d", [_fobPos3DASL select 0, _fobPos3DASL select 1]];
+
 		private _nextTasks = [
 			["build_respawn", (_taskDataStore getVariable "fob_position_2d") getPos [50, 0]],
 			["build_flag", (_taskDataStore getVariable "fob_position_2d") getPos [50, 90]],
 			["build_landing_pad", (_taskDataStore getVariable "fob_position_2d") getPos [50, 180]],
-			["build_latrine", (_taskDataStore getVariable "fob_position_2d") getPos [50, 270]]
+			["build_rearm_resupply", (_taskDataStore getVariable "fob_position_2d") getPos [50, 270]]
 		];
+
                 ["SUCCEEDED", _nextTasks] call _fnc_finishSubtask;
         };
 }];
@@ -189,10 +191,15 @@ _taskDataStore setVariable ["build_landing_pad", {
 	};
 }];
 
-_taskDataStore setVariable ["build_latrine", {
+_taskDataStore setVariable ["build_rearm_repair_refuel", {
 	params ["_tds"];
 
-	private _building_types = ["Land_vn_latrine_01"];
+	private _building_types = [
+		"vn_b_ammobox_supply_07",
+		"vn_b_ammobox_supply_08",
+		"vn_b_ammobox_supply_09",
+		"Land_vn_usaf_fueltank_75_01"
+	];
 	private _building_exists = [_tds, _building_types] call (_tds getVariable "_fnc_have_built_buildings");
 
 	if (_building_exists) then {


### PR DESCRIPTION
Due to a mismatch in variable locality, the CTF task was not running because the `holdAction` for dac cong players was not visible. The `canLower` variable was attached to the flag object server-side, but `holdAction`s are attached to players, operating within player namespace locality.

Now, we set a single `publicVariable "vn_mf_bn_dc_target_flag"` which broadcasts the target flag to all players. THe `holdAction`s should now work.

Also included in this change:

- [TWEAKED] Flag lowering/raising during defend phase -- multiple attempts can be chained together. Total `holdAction` time over all attempts is 10 seconds.
- [ADDED] Optional FOB building tasks during capture phase -- Helo Landing Pad and a Rearm/Refuel/Repair station.
- [FIX] Searching for completed optional buildables -- non player built objects no longer count.
- [FIX] Searching for completed optional buildables -- search area for flags was error'ing out due to faulty marker variable lookup.