### PR TITLE
VehSpawner: hotfix race condition causing duplicate vehicle spawns.

### DIFF
--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_respawn.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_respawn.sqf
@@ -26,6 +26,11 @@ if (!isClass (configFile >> "CfgVehicles" >> _classToSpawn)) exitWith {
 	diag_log format ["VN MikeForce: [ERROR] Unable to respawn vehicle, class %1 is invalid", _classToSpawn];
 };
 
+// @dijksterhuis: TODO tidy up.
+if ((_spawnPoint get "bn_is_respawning_count") > 0) exitWith {
+	diag_log format ["VehAssetRespawn: Duplicate vehicle respawn request. Skipping this respawn request."];
+};
+
 private _vehicle = objNull;
 private _oldVehicle = _spawnPoint getOrDefault ["currentVehicle", objNull];
 
@@ -62,3 +67,4 @@ if (getNumber (configfile >> "CfgVehicles" >> _classToSpawn >> "isUAV") > 0 && c
 
 [_spawnPoint, _vehicle] call vn_mf_fnc_veh_asset_assign_vehicle_to_spawn_point;
 
+_spawnPoint set ["bn_is_respawning_count", 0];

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_respawn.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_respawn.sqf
@@ -28,7 +28,11 @@ if (!isClass (configFile >> "CfgVehicles" >> _classToSpawn)) exitWith {
 
 // @dijksterhuis: TODO tidy up.
 if ((_spawnPoint get "bn_is_respawning_count") > 0) exitWith {
-	diag_log format ["VehAssetRespawn: Duplicate vehicle respawn request. Skipping this respawn request."];
+	diag_log format [
+		"VehAssetRespawn: Skipping duplicate vehicle respawn request: spawnPointId=%1 count=%2", 
+		_spawnPoint get "id", 
+		_spawnPoint get "bn_is_respawning_count"
+	];
 };
 
 private _vehicle = objNull;

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_respawn_job.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_respawn_job.sqf
@@ -18,6 +18,13 @@ if (vn_mf_spawn_points_to_respawn isEqualTo []) exitWith {};
 private _spawnPointId = vn_mf_spawn_points_to_respawn deleteAt 0;
 private _spawnPoint = vn_mf_veh_asset_spawn_points get _spawnPointId;
 
+// @dijksterhuis: See asset respawn job for why this needs to exist! (race condition hotfix).
+if (_spawnPoint getOrDefault ["bn_is_respawning_count", -1] < 0) then {
+	_spawnPoint set ["bn_is_respawning_count", 0];
+} else {
+	_spawnPoint set ["bn_is_respawning_count", (_spawnPoint get "bn_is_respawning_count") + 1];
+};
+
 if (isNil "_spawnPoint") exitWith {};
 
 [_spawnPoint] spawn vn_mf_fnc_veh_asset_respawn;


### PR DESCRIPTION
When the server is lagging, it is possible for multiple respawn executions to spawn, causing duplicate vehicle creation on the same spawn point and big explosions.

This change adds a count to the number of times the spawn point is being requested for respawn. 

Essentially, only pay attention to the first request. Ignore all others.