### PR TITLE
Params: Increase maximum AI hard limit to 120.

### DIFF
--- a/mission/config/params.hpp
+++ b/mission/config/params.hpp
@@ -63,7 +63,7 @@ class hard_ai_limit
     title = $STR_vn_mf_param_hard_ai_limit;
     values[] = {60, 80, 100, 120, 140, 160, 180, 200};
     texts[] = {"60", "80 (recommended)", "100", "120", "140", "160", "180", "200"};
-    default = 80;
+    default = 120;
 };
 
 class hard_ai_limit_desc


### PR DESCRIPTION
woop.

max server pop = 50 

x2 enemy AI per player --> 120 hard limit should be over what we need.