### PR TITLE
Monitoring: Add monitoring for exta server stats and aggregated player network stats.

### DIFF
--- a/mission/functions/debug/fn_log_performance_data.sqf
+++ b/mission/functions/debug/fn_log_performance_data.sqf
@@ -19,14 +19,6 @@
 private _allPlayers = allPlayers;
 private _allUnits = allUnits;
 
-private _fnc_get_average = {
-    params ["_arr"];
-    private _av = 0;
-    _arr apply {_av = _av + _x};
-
-    _av / (count _arr)
-};
-
 private _fnc_get_sum = {
     params ["_arr"];
     private _v = 0;
@@ -34,6 +26,14 @@ private _fnc_get_sum = {
 
     _v
 };
+
+private _fnc_get_average = {
+    params ["_arr"];
+    private _sum = [_arr] call _fnc_get_sum;
+
+    _sum / (count _arr)
+};
+
 
 
 // server/headless performance

--- a/mission/functions/debug/fn_log_performance_data.sqf
+++ b/mission/functions/debug/fn_log_performance_data.sqf
@@ -14,20 +14,86 @@
 		call vn_mf_fnc_init_performance_logging
 */
 
+// common defs to avoid duplicate calls / changed data between calls
+
+private _allPlayers = allPlayers;
 private _allUnits = allUnits;
+
+private _fnc_get_average = {
+    params ["_arr"];
+    private _av = 0;
+    _arr apply {_av = _av + _x};
+
+    _av / (count _arr)
+};
+
+private _fnc_get_sum = {
+    params ["_arr"];
+    private _v = 0;
+    _arr apply {_v = _v + _x};
+
+    _v
+};
+
+
+// server/headless performance
+
+private _headlessClients = _allPlayers select {(getUserInfo _x) select 7};
+private _headlessClientsDesyncMax = "n/a";
+
+if (count _headlessClients > 0) then {
+  _headlessClientsDesyncMax = selectMax _headlessClients apply {((getUserInfo _x) select 9) select 2};
+};
+
+private _messageServer = format [
+  "Server: UptimeMinutes:%1, ServerFPSMin:%2, ServerFPSAv:%3, ActiveScripts:%4, HeadlessClients:%5, HCMaxDesync:%6",
+  diag_tickTime / 60,
+  diag_fpsMin, // minimum server FPS over the last 16 frames
+  diag_fps, // average server FPS over last 16 frames
+  [diag_activeScripts] call _fnc_get_sum, // active scripts in THIS frame
+  count _headlessClients,
+  _headlessClientsDesyncMax
+];
+
+["INFO", _messageServer] call para_g_fnc_log;
+
+// gamemode performance
+
 private _deadUnitCount = {!alive _x} count _allUnits;
 private _enemyUnitCount = {side _x == east} count _allUnits;
 private _vehicleCount = count vehicles;
 
-
-private _message = format [
-  "ServerFPS:%1, Players:%2, DeadUnits:%3, EnemyUnits:%4, AllUnits:%5, AllVehicles:%6",
-  diag_fps,
-  count allPlayers,
+private _messageGame = format [
+  "Game: Players:%1, DeadUnits:%2, EnemyUnits:%3, AllUnits:%4, AllVehicles:%5",
+  count _allPlayers,
   _deadUnitCount,
   _enemyUnitCount,
   count _allUnits,
   _vehicleCount
 ];
 
-["INFO", _message] call para_g_fnc_log;
+["INFO", _messageGame] call para_g_fnc_log;
+
+// players networking
+
+private _allPlayersNetworkData = _allPlayers select {!((getUserInfo _x) select 7)} apply {(getUserInfo _x) select 9};
+
+private _allPing = _playerNetworkData apply {_x select 0};
+private _allBandwidth = _playerNetworkData apply {_x select 1};
+private _allDesync = _playerNetworkData apply {_x select 2};
+
+private _messageNetwork = format [
+  "PlayersNetworking: PlayersCount:%1 | PlayersPing: Min%2 Mean:%3 Max:%4 | PlayersBandwidth: Min:%5 Mean:%6 Max:%7 | PlayersDesync: Min:%8 Mean:%9 Max:%10",
+  count _allPlayers,
+  selectMax _allPing,
+  [_allPing] call _fnc_get_average,
+  selectMin _allPing,
+  selectMax _allBandwidth,
+  [_allBandwidth] call _fnc_get_average,
+  selectMin _allBandwidth,
+  selectMax _allDesync,
+  [_allDesync] call _fnc_get_average,
+  selectMin _allDesync
+];
+
+["INFO", _messageNetwork] call para_g_fnc_log;

--- a/mission/functions/debug/fn_log_performance_data.sqf
+++ b/mission/functions/debug/fn_log_performance_data.sqf
@@ -2,9 +2,13 @@
     File: fn_log_performance_data.sqf
     Author: Savage Game Design
     Public: No
+    Modified By: "DJ" Dijksterhuis
 
     Description:
-    Logs a line of performance data
+      Logs a 3x lines of performance data
+        - Server performance, e.g. server FPS
+        - Gamemode statistics, e.g. AI count
+        - Player network stats, e.g. maximum player desync 
 
     Parameter(s): None
 
@@ -34,23 +38,21 @@ private _fnc_get_average = {
     _sum / (count _arr)
 };
 
-
-
 // server/headless performance
 
-private _headlessClients = _allPlayers select {(getUserInfo _x) select 7};
+private _headlessClients = _allPlayers select {(getUserInfo (getPlayerID _x)) select 7};
 private _headlessClientsDesyncMax = "n/a";
 
 if (count _headlessClients > 0) then {
-  _headlessClientsDesyncMax = selectMax _headlessClients apply {((getUserInfo _x) select 9) select 2};
+  _headlessClientsDesyncMax = selectMax _headlessClients apply {((getUserInfo (getPlayerID _x)) select 9) select 2};
 };
 
 private _messageServer = format [
-  "Server: UptimeMinutes:%1, ServerFPSMin:%2, ServerFPSAv:%3, ActiveScripts:%4, HeadlessClients:%5, HCMaxDesync:%6",
-  diag_tickTime / 60,
+  "Server: UptimeMins:%1, FPSMin:%2, FPSAv:%3, Scripts:%4, HCs:%5, HCMaxDesync:%6",
+  diag_tickTime / 60, // natural time since arma was started, not ingame time
   diag_fpsMin, // minimum server FPS over the last 16 frames
   diag_fps, // average server FPS over last 16 frames
-  [diag_activeScripts] call _fnc_get_sum, // active scripts in THIS frame
+  diag_activeScripts, // active scripts in THIS frame
   count _headlessClients,
   _headlessClientsDesyncMax
 ];
@@ -64,26 +66,27 @@ private _enemyUnitCount = {side _x == east} count _allUnits;
 private _vehicleCount = count vehicles;
 
 private _messageGame = format [
-  "Game: Players:%1, DeadUnits:%2, EnemyUnits:%3, AllUnits:%4, AllVehicles:%5",
+  "Game: Players:%1, DeadUnits:%2, EnemyUnits:%3, AllUnits:%4, AllVehicles:%5, RespawnVehQueue:%6",
   count _allPlayers,
   _deadUnitCount,
   _enemyUnitCount,
   count _allUnits,
-  _vehicleCount
+  _vehicleCount,
+  count vn_mf_spawn_points_to_respawn
 ];
 
 ["INFO", _messageGame] call para_g_fnc_log;
 
 // players networking
 
-private _allPlayersNetworkData = _allPlayers select {!((getUserInfo _x) select 7)} apply {(getUserInfo _x) select 9};
+private _playerNetworkData = _allPlayers select {!((getUserInfo (getPlayerID _x)) select 7)} apply {(getUserInfo (getPlayerID _x)) select 9};
 
 private _allPing = _playerNetworkData apply {_x select 0};
 private _allBandwidth = _playerNetworkData apply {_x select 1};
 private _allDesync = _playerNetworkData apply {_x select 2};
 
 private _messageNetwork = format [
-  "PlayersNetworking: PlayersCount:%1 | PlayersPing: Min%2 Mean:%3 Max:%4 | PlayersBandwidth: Min:%5 Mean:%6 Max:%7 | PlayersDesync: Min:%8 Mean:%9 Max:%10",
+  "PlayersNet (min/avg/max): Ping: %2/%3/%4 | Bandwidth: %5/%6/%7 | Desync: %8/%9/%10",
   count _allPlayers,
   selectMax _allPing,
   [_allPing] call _fnc_get_average,


### PR DESCRIPTION
~~Needs testing as dev'd on linux laptop and not been executed in game yet.~~ 

Tested, fixed and working

Generates logs like so:

```
... | | Server: UptimeMins:29.8413, FPSMin:14.9254, FPSAv:18.7354, Scripts:[14,0,0,1], HCs:0, HCMaxDesync:n/a"
... | | Game: Players:1, DeadUnits:0, EnemyUnits:18, AllUnits:24, AllVehicles:330, RespawnVehQueue:0"
... | | PlayersNet (min/avg/max): Ping: 0/0/0 | Bandwidth: 1.67772e+007/1.67772e+007/1.67772e+007 | Desync: 0/0/0"
```

List of stats

### Server

- Uptime in minutes (natural time, not game time)
- Minimum Server FPS over last 16 frames
- Average Server FPS over last 16 frames
- Total number of scripts currently executing in various environments
- Number of headless clients
- Max Desync value of connected Headless clients (track if has one disconnected)

### Game

Mostly as before

- Players
- DeadUnits
- EnemyUnits
- AllUnits
- AllVehicles
- RespawnVehQueue (number of vehicles awaiting respawn)
 
### PlayerNetwork

- Ping (min/avg/max)
- Bandwidth (min/avg/max)
- Desync (min/avg/max)
