### PR TITLE
Monitoring: Fixup 

### DIFF
--- a/mission/functions/debug/fn_log_performance_data.sqf
+++ b/mission/functions/debug/fn_log_performance_data.sqf
@@ -36,27 +36,23 @@ private _fnc_get_average = {
   private _sum = [_arr] call _fnc_get_sum;
   private _c = count _arr;
 
-  if (c == 0) exitWith {nil};
+  if (_c == 0) exitWith {selectMax []}; // hack: returns <null>
   _sum / _c
 };
 
 // server/headless performance
 
 private _headlessClients = _allPlayers select {(getUserInfo (getPlayerID _x)) select 7};
-private _headlessClientsDesyncs = [];
-
-if (count _headlessClients > 0) then {
-  _headlessClientsDesyncs = _headlessClients apply {((getUserInfo (getPlayerID _x)) select 9) select 2};
-};
+private _headlessClientsDesyncs = _headlessClients apply {((getUserInfo (getPlayerID _x)) select 9) select 2};
 
 private _messageServer = format [
-  "Server: UptimeMins:%1, FPSMin:%2, FPSAv:%3, Scripts:%4, HCs:%5, HCMaxDesync:%6",
+  "Server: UptimeMins:%1, FPSMin:%2, FPSAv:%3, Scripts:%4, HCs:%5, HCsDesync:%6",
   diag_tickTime / 60, // natural time since arma was started, not ingame time
   diag_fpsMin, // minimum server FPS over the last 16 frames
   diag_fps, // average server FPS over last 16 frames
   diag_activeScripts, // active scripts in THIS frame
-  count _headlessClients,
-  _headlessClientsDesyncs
+  _headlessClients,
+  _headlessClientsDesyncs // a value above 0 means that the HC has disconnected
 ];
 
 ["INFO", _messageServer] call para_g_fnc_log;

--- a/mission/functions/debug/fn_log_performance_data.sqf
+++ b/mission/functions/debug/fn_log_performance_data.sqf
@@ -24,27 +24,29 @@ private _allPlayers = allPlayers;
 private _allUnits = allUnits;
 
 private _fnc_get_sum = {
-    params ["_arr"];
-    private _v = 0;
-    _arr apply {_v = _v + _x};
-
-    _v
+  params ["_arr"];
+  private _v = 0;
+  _arr apply {_v = _v + _x};
+  _v
 };
 
 private _fnc_get_average = {
-    params ["_arr"];
-    private _sum = [_arr] call _fnc_get_sum;
+  params ["_arr"];
 
-    _sum / (count _arr)
+  private _sum = [_arr] call _fnc_get_sum;
+  private _c = count _arr;
+
+  if (c == 0) exitWith {nil};
+  _sum / _c
 };
 
 // server/headless performance
 
 private _headlessClients = _allPlayers select {(getUserInfo (getPlayerID _x)) select 7};
-private _headlessClientsDesyncMax = "n/a";
+private _headlessClientsDesyncs = [];
 
 if (count _headlessClients > 0) then {
-  _headlessClientsDesyncMax = selectMax _headlessClients apply {((getUserInfo (getPlayerID _x)) select 9) select 2};
+  _headlessClientsDesyncs = _headlessClients apply {((getUserInfo (getPlayerID _x)) select 9) select 2};
 };
 
 private _messageServer = format [
@@ -54,7 +56,7 @@ private _messageServer = format [
   diag_fps, // average server FPS over last 16 frames
   diag_activeScripts, // active scripts in THIS frame
   count _headlessClients,
-  _headlessClientsDesyncMax
+  _headlessClientsDesyncs
 ];
 
 ["INFO", _messageServer] call para_g_fnc_log;


### PR DESCRIPTION
- div/zero error when 0 players in avg calc
- selectMax getting annoyed about object vs. array (no idea why it was an object?)

- ensure similar type to other logging lines on empty array escape for avg

- make headless monitoring more robust (just return the filtered arrays)