### PR TITLE
VehSpawner: StaticWeapon spawners could get locked by advanced logistic's inventory system.

### DIFF
--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_process_spawn_point.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_process_spawn_point.sqf
@@ -54,6 +54,40 @@ if (!alive _vehicle && !((_spawnPoint get "status" get "state") in ["RESPAWNING"
 	};
 };
 
+/*
+@dijksterhuis: static weapon advanced logistics'd check
+
+`log_inventory_loaded` and `log_inventory_loaded_vehicle` are set by the
+advanced logistics module when the object is loaded into vehicle
+
+-----
+
+A note on static weapon wrecks...
+
+logistics'd vehicles are hidden and attached to player who loaded them.
+setting the vehicles to a wreck status won't work as markers etc. will be
+tracking an invisible object on the player.
+
+need to delete the vehicle to force a repair job.
+
+TODO: "unload" the statics out of the vehicle then set them to wrecked?
+*/
+if (
+	_vehicle getVariable ["log_inventory_loaded", false]
+	&& !alive (_vehicle getVariable ["log_inventory_loaded_vehicle", objNull])
+	&& !((_spawnPoint get "status" get "state") in ["RESPAWNING", "REPAIRING"])
+) then {
+	if (_respawnType == "WRECK") exitWith {
+		deleteVehicle _vehicle;
+		[_spawnPoint] call vn_mf_fnc_veh_asset_set_wrecked;
+	};
+
+	if (_respawnType == "RESPAWN") exitWith {
+		[_spawnPoint, _settings get "time"] call vn_mf_fnc_veh_asset_set_respawning;
+	};
+};
+
+
 if (!canMove _vehicle) then {
 	if ((_spawnPoint get "status" get "state") in ["ACTIVE", "IDLE"]) then {
 		[_spawnPoint] call vn_mf_fnc_veh_asset_set_disabled;


### PR DESCRIPTION
This one was fun. No-one has reported this yet, but it will happen at some point.

---

1. Get a static weapon from a spawner point
2. Load static weapon into a vehicle via advanced logistics
3. Static weapon object is hidden and attached to the player
4. Blow up or delete the vehicle "containing" the static weapon
5. Static weapon object is still attached to the player, and is still hidden.
6. Spawner cannot respawn the static weapon because it is technically still alive ---> Spawner is soft locked.

----

The advanced logistics module sets two variables when something is loaded into a vehicle

- `log_inventory_loaded`  --> boolean: object has been "loaded" into a container vehicle
- `log_inventory_loaded_vehicle` ---> object: container vehicle that the object was loaded into

So, we needed to add an extra state machine check for anything that can be loaded into a vehicle with advanced logstsics

- is spawned object loaded into a container vehicle
- is the container vehicle dead
- is the spawn point not yet respawning the spawned object

if all true, then we do these

- if wreck configured --> delete spawned object and to wrecked state --> this should immediately send it to repair.
- if respawn configured --> set to respawn state --> respawn job will delete the spawned object for us.