### PR TITLE
VehSpawner: MACV can force recover wrecked vehicles from a spawn point.

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -169,6 +169,7 @@ class CfgFunctions
 			class action_eat_food {};
 			class action_lower_flag {};
 			class action_reraise_flag {};
+			class action_macv_force_recover_wreck {};
 		};
 
 		class system_actives {
@@ -416,6 +417,11 @@ class CfgFunctions
 			class veh_asset_setup_package_wreck_action {};
 			class veh_asset_subsystem_init {};
 			class veh_asset_unlock_vehicle {};
+		};
+		class system_vehicle_asset_manager_bn
+		{
+			file = "functions\systems\vehicle_asset_manager\bn";
+			class veh_asset_bn_macv_force_respawn {};
 		};
 
 		class system_vehicle_creation_detection

--- a/mission/functions/systems/actions/fn_action_init.sqf
+++ b/mission/functions/systems/actions/fn_action_init.sqf
@@ -34,5 +34,5 @@ if (isNil "vn_mf_actions_initialized" || vn_mf_actions_player != player) then //
 	call vn_mf_fnc_action_lower_flag;
 	call vn_mf_fnc_action_reraise_flag;
 	"vn_holdActionAdd_layer" cutText ["","PLAIN"];
+	call vn_mf_fnc_action_macv_force_recover_wreck;
 };
-

--- a/mission/functions/systems/actions/fn_action_macv_force_recover_wreck.sqf
+++ b/mission/functions/systems/actions/fn_action_macv_force_recover_wreck.sqf
@@ -1,0 +1,49 @@
+/*
+	File: fn_action_macv_force_recover_wreck.sqf
+	Author: 'DJ' Dijksterhuis
+	Public: No
+	
+	Description:
+		MACV players can walk up to a vehicle spawner sign and force recovery of a wrecked vehicle.
+	
+	Parameter(s): none
+	
+	Returns:
+	
+	Example(s):
+		call vn_mf_fnc_action_macv_force_recover_wreck;
+*/
+
+// player is macv
+// looking at a spawner sign
+// less than 3m from the sign
+// vehicle for spawn point is recorded as WRECKED client side
+
+private _conditionToShow = [
+	"([player, 'MACV'] call vn_mf_fnc_player_on_team)",
+	"(typeOf cursorTarget == 'vn_signad_sponsors_f')",
+	"(player distance cursorTarget <= 3)",
+	"(vn_mf_veh_asset_spawn_points_client get (cursorTarget getVariable 'veh_asset_spawnPointId') get 'status' get 'state' == 'WRECKED')"
+] joinString " && ";
+
+player addAction
+[
+	format [
+		"<t color='#A04406'>%1</t>",
+		"[MACV] Recover Wreck"
+	],  // title
+	{
+		params ["_target", "_caller", "_actionId", "_arguments"];
+		[cursorTarget getVariable "veh_asset_spawnPointId"] remoteExec ["vn_mf_fnc_veh_asset_bn_macv_force_respawn", 2];
+	},  // script
+	nil,  // arguments
+	1.5,  // priority
+	true,  // showWindow
+	true,  // hideOnUse
+	"",  // shortcut
+	_conditionToShow,  // condition
+	5,  // radius
+	false,  // unconscious
+	"",  // selection
+	""  // memoryPoint
+];

--- a/mission/functions/systems/vehicle_asset_manager/bn/fn_veh_asset_bn_macv_force_respawn.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/bn/fn_veh_asset_bn_macv_force_respawn.sqf
@@ -1,0 +1,29 @@
+/*
+	File: fn_veh_asset_bn_macv_force_respawn.sqf
+	Author: 'DJ' Dijksterhuis
+	Public: No
+
+	Description:
+		Forcibily, but safely, respawns a vehicle.
+
+	Parameter(s):
+		_spawnPointId - Id of spawn point [String]
+
+	Returns: nothing
+
+	Example(s): none
+*/
+
+params ["_spawnPointId"];
+
+private _spawnPoint = vn_mf_veh_asset_spawn_points get _spawnPointId;
+private _respawnType = _spawnPoint get "settings" get "respawnType";
+private _vehicle = _spawnPoint getOrDefault ["currentVehicle", objNull];
+
+if (_respawnType == "WRECK") then {
+	deleteVehicle _vehicle;
+	[_spawnPoint] call vn_mf_fnc_veh_asset_set_repairing;
+};
+if (_respawnType == "RESPAWN") then {
+	[_spawnPoint] call vn_mf_fnc_veh_asset_set_respawning;
+};


### PR DESCRIPTION
Switch to MACV

![20240602202729_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/2ac10ff5-0190-4159-99da-7980a99f345f)

Can force recovery of wrecked vehicle at spawn point sign

![20240602203644_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/64e0a4e7-20c6-410f-b708-7d3771a361a2)

switch to NZSAS

![20240602202717_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/36f70909-1bab-4cf3-9b62-0861424e0ace)

cannot recover vehicle

![20240602202720_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/c96c19cc-fefb-4672-b165-71be11b4ea46)

