### PR TITLE
Actions: Add an addaction drawing an icon on vehicle's spawn point location

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -158,6 +158,7 @@ class CfgFunctions
 		class system_actions {
 			file = "functions\systems\actions";
 			class action_init {};
+			class action_vehspawner_show_spawn_point {};
 			class action_destroy_respawn {};
 			class action_destroy_task {};
 			class action_gather_intel {};

--- a/mission/functions/systems/actions/fn_action_init.sqf
+++ b/mission/functions/systems/actions/fn_action_init.sqf
@@ -30,6 +30,7 @@ if (isNil "vn_mf_actions_initialized" || vn_mf_actions_player != player) then //
 	//call vn_mf_fnc_release_from_arrest_player;
 	call vn_mf_fnc_action_destroy_task;
 	call vn_mf_fnc_action_gather_intel;
+	call vn_mf_fnc_action_vehspawner_show_spawn_point
 	call vn_mf_fnc_action_radiotap;
 	call vn_mf_fnc_action_lower_flag;
 	call vn_mf_fnc_action_reraise_flag;

--- a/mission/functions/systems/actions/fn_action_vehspawner_show_spawn_point.sqf
+++ b/mission/functions/systems/actions/fn_action_vehspawner_show_spawn_point.sqf
@@ -1,0 +1,94 @@
+/*
+	File: fn_action_vehspawner_show_spawn_point.sqf
+	Author: 'DJ' Dijksterhuis
+	Public: No
+	
+	Description:
+		MACV players can walk up to a vehicle spawner sign and force the vehicle position back to spawn point.
+	
+	Parameter(s): none
+	
+	Returns:
+	
+	Example(s):
+		call vn_mf_fnc_action_macv_force_reset_vehicle;
+*/
+
+// player is curator
+// looking at a spawner sign
+// less than 3m from the sign
+// vehicle for spawn point is recorded as IDLE client side
+
+// private _role = assignedVehicleRole player select 0;
+
+private _conditionToShow = [
+	// player is in a vehicle
+	"(vehicle player != player)",
+	// player is the driver
+	"((assignedVehicleRole player select 0) == 'driver')",
+	// player's vehicle was created by mike force veh spawner system
+	"!(((vehicle player) getVariable ['veh_asset_spawnPointId', false]) isEqualTo false)",
+	// draw3d is not already shown in the display
+	"((player getVariable ['veh_asset_spawnPoint_draw3d_active', false]) isEqualTo false)"
+] joinString " && ";
+
+player addAction
+[
+	"Locate Vehicle's Spawn Point",  // title
+	{
+		params ["_target", "_caller", "_actionId", "_arguments"];
+		private _id = (vehicle player) getVariable ['veh_asset_spawnPointId', false];
+		private _spawnPos = vn_mf_veh_asset_spawn_points_client get _id get 'spawnLocation' get 'pos';
+		private _iconPos = [_spawnPos select 0, _spawnPos select 1, 1];  // reset z position
+
+		// stop player spamming the event handler and draw icon
+		player setVariable ["veh_asset_spawnPoint_draw3d_active", true];
+
+		// spawn so we can sleep
+		// is this needed?
+		private _scriptHandle = [getPos player, _iconPos] spawn {
+
+			private _eventHandlerId = addMissionEventHandler [
+				"draw3D",
+				{
+					drawIcon3D
+					[
+						"\A3\ui_f\data\map\markers\handdrawn\end_CA.paa",  // icon
+						[1, 1, 1, 0.6],  // color rgb-a
+						_thisArgs select 1,  // AGL position
+						1,  // width
+						1,  // height
+						0,  // angle
+						"Vehicle's Spawn Point",  // text
+						2,  // 0 - noshadow, 1 - shadow, 2 - outline
+						0.035,  // text size
+						"RobotoCondensed",  // font
+						"center",  // text align
+						true,  // drawSideArrows
+						0,  // text offset x
+						0  // text offset y
+					];
+				},
+				[_this select 0, _this select 1]
+			];
+			// wait then remove the event handler -- remove the icon from display
+			sleep 10;
+			removeMissionEventHandler ["draw3D", _eventHandlerId];
+		};
+
+		// once script is executed let player draw icon in ui again
+		waitUntil { scriptDone _scriptHandle };
+		player setVariable ["veh_asset_spawnPoint_draw3d_active", false];
+
+	},  // script
+	nil,  // arguments
+	0,  // priority -- set to 0 because not going to be needed in combat
+	false,  // showWindow
+	true,  // hideOnUse
+	"CommandingMenuSelect9",  // shortcut
+	_conditionToShow,  // condition
+	5,  // radius
+	false,  // unconscious
+	"",  // selection
+	""  // memoryPoint
+];


### PR DESCRIPTION
Currently, players need to remember exactly which spawn point they got a vehicle from if they want to swap it for another (need to swap from the exact same spawn point it was created at).

This can cause issues when there are empty spawn points.

1. Player RTBs with the vehicle, sees empty spawn point.
2. Player lands/parks their vehicle on the empty spawn point.
3. Vehicle that was spawned at that spawn point then respawns, causing an explosion.

### feature

Give players a simple utility addaction `Locate Vehicle's Spawn Point` to check where their vehicle's spawn point is located so they can return it properly.

Using the add action draws an icon (with text) on their screen for 10 seconds. And then it disappears afterwards.

Add action requires following conditions to show

- player is in a vehicle
- player is in driver role of vehicle
- vehicle was spawned by mike force spawner system
- icon has not already been drawn on the display

![20240603174622_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/dfc3ea13-ea4b-4501-877c-5b13164b13f5)
![20240603174629_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/0a1b3068-6357-4143-a572-19200cbaf7fc)
![20240603174632_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/f8526e56-244e-4f42-a391-853115198c17)
