### PR TITLE
Init: Move curator object updates to a separate job independent of W/L

### DIFF
--- a/mission/para_server_init.sqf
+++ b/mission/para_server_init.sqf
@@ -23,8 +23,12 @@ call vn_mf_fnc_server_init_backend;
 call para_s_fnc_init_whitelist;
 ["update_whitelist", para_s_fnc_init_whitelist, [], 120] call para_g_fnc_scheduler_add_job;
 
+// update curator whitelist, every 5 minutes
 call para_s_fnc_init_curators;
 ["update_curators", para_s_fnc_init_curators, [], 300] call para_g_fnc_scheduler_add_job;
+
+// update objects curators can edit, every 10 seconds
+[10] call para_s_fnc_init_update_curator_objects_job;
 
 call para_s_fnc_init_dopamine;
 ["dopamine_hit", para_s_fnc_init_dopemine, [], 300] call para_g_fnc_scheduler_add_job;

--- a/mission/para_server_init.sqf
+++ b/mission/para_server_init.sqf
@@ -28,7 +28,7 @@ call para_s_fnc_init_curators;
 ["update_curators", para_s_fnc_init_curators, [], 300] call para_g_fnc_scheduler_add_job;
 
 // update objects curators can edit, every 10 seconds
-[10] call para_s_fnc_init_update_curator_objects_job;
+[10] call para_s_fnc_init_curators_update_objects_job;
 
 call para_s_fnc_init_dopamine;
 ["dopamine_hit", para_s_fnc_init_dopemine, [], 300] call para_g_fnc_scheduler_add_job;


### PR DESCRIPTION
Aiming to reduce script execution/sleeps as the previous version (handled over in paradigm) would run this code and then `uiSleep` for 10 seconds, meaning we had up to / over 90 active SQF scripts

THIS DEPENDS ON https://github.com/Bro-Nation/Paradigm/pull/28

Please merge both of these simultaneously