### PR TITLE
AI: Keep shooting at incapacitated players. 🌶️ 🌶️ 🌶️ 

### DIFF
--- a/mission/eventhandlers/player/eh_Killed.sqf
+++ b/mission/eventhandlers/player/eh_Killed.sqf
@@ -29,3 +29,16 @@ params
 // disable build mode
 para_l_buildmode = nil;
 para_l_placing = false;
+
+private _type = "";
+switch ( true ) do { 
+	case (side _unit == west) : {  _type = "B_TargetSoldier"}; 
+	case (side _unit == east) : {  _type = "O_TargetSoldier"}; 
+	case (side _unit == independent) : {  _type = "I_TargetSoldier"}; 
+	default {  _type = "B_TargetSoldier" }; 
+};
+
+(attachedObjects _unit) select {typeOf _x isEqualTo _type} apply {
+    [_x] remoteExec ["detach", 2];
+    [_x] remoteExec ["deleteVehicle", 2];
+};

--- a/mission/eventhandlers/player/eh_Respawn.sqf
+++ b/mission/eventhandlers/player/eh_Respawn.sqf
@@ -34,4 +34,4 @@ _unit setVariable ["vn_mf_side", side player, true];
 // update UI
 ["vn_mf_db_thirst",1] call vn_mf_fnc_ui_update;
 
-[_unit, WEST, [0, 0, 3], 0] remoteExec ["vn_ms_fnc_attachHiddenTarget", 2];
+[_unit, side player, [0, 0, 3], 0] remoteExec ["vn_ms_fnc_attachHiddenTarget", 2];

--- a/mission/eventhandlers/player/eh_Respawn.sqf
+++ b/mission/eventhandlers/player/eh_Respawn.sqf
@@ -33,4 +33,5 @@ _unit setVariable ["vn_mf_side", side player, true];
 
 // update UI
 ["vn_mf_db_thirst",1] call vn_mf_fnc_ui_update;
-["vn_mf_db_hunger",1] call vn_mf_fnc_ui_update;
+
+[_unit, WEST, [0, 0, 3], 0] remoteExec ["vn_ms_fnc_attachHiddenTarget", 2];

--- a/mission/para_player_init_client.sqf
+++ b/mission/para_player_init_client.sqf
@@ -332,4 +332,4 @@ if hasInterface then
 
 // attach an invisible blufor soldier to the player on initial load in.
 // subsequent resets of this are handled by the Respawned playerEventHandler
-[player, WEST, [0, 0, 3], 0] remoteExec ["vn_ms_fnc_attachHiddenTarget", 2];
+[player, side player, [0, 0, 3], 0] remoteExec ["vn_ms_fnc_attachHiddenTarget", 2];

--- a/mission/para_player_init_client.sqf
+++ b/mission/para_player_init_client.sqf
@@ -330,4 +330,6 @@ if hasInterface then
 
 ["InitializePlayer", [player]] call para_c_fnc_dynamicGroups;
 
-
+// attach an invisible blufor soldier to the player on initial load in.
+// subsequent resets of this are handled by the Respawned playerEventHandler
+[player, WEST, [0, 0, 3], 0] remoteExec ["vn_ms_fnc_attachHiddenTarget", 2];


### PR DESCRIPTION
Adds an invisible target to the player model during client init using `vn_ms_fnc_attachHiddenTarget`.

Removes the hidden target when the player is killed (eventhandler).

Re-adds the hidden target again on respawn (eventhandler).

🌶️ 

![image](https://github.com/Bro-Nation/Mike-Force/assets/11841332/f4cd5c0e-e72e-43d6-9918-c74cb4259498)

![image](https://github.com/Bro-Nation/Mike-Force/assets/11841332/4468fabb-d7e4-4f2d-8ad0-de581223c57f)

dac cong get correct side added too (missed this first time round)

![20240609030458_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/ef259fd8-c30e-4bff-b7d7-1ee21d771fe0)
