### PR TITLE
Actions: Check if we can oneshot call actions init instead of scheduling

### DIFF
--- a/mission/para_player_init_client.sqf
+++ b/mission/para_player_init_client.sqf
@@ -89,7 +89,11 @@ call vn_mf_fnc_active_init;
 uiSleep 0.4;
 progressLoadingScreen 0.5;
 
-["action_manager", vn_mf_fnc_action_init, [], 5] call para_g_fnc_scheduler_add_job;
+// @dijksterhuis: we should only need to call this once? -- when the player joins?
+// only reason to keep adding actions after attach to player would be if the actions
+// are removed from player object.
+call vn_mf_fnc_action_init;
+// ["action_manager", vn_mf_fnc_action_init, [], 5] call para_g_fnc_scheduler_add_job;
 
 [parseText format["<t font='tt2020base_vn' color='#F5F2D0'>%1</t>",localize "STR_vn_mf_loading11"]] call vn_mf_fnc_update_loading_screen;
 


### PR DESCRIPTION
we should only need to call this once? -- when the player joins?

only reason to keep adding actions after attach to player would be if the actions are removed from player object.

so want to test this one server 2 to see if we can get away with the initial oneshot call.