### PR TITLE
Comms: Add Function key keybinds for custom comms channel mute/unmute.

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -64,6 +64,15 @@ class CfgFunctions
 			class update_channels {};
 		};
 
+		class core_teams_comms_switchers
+		{
+			file = "functions\core\teams\comms_switchers";
+			class teams_comms_switchers_onoff_air {};
+			class teams_comms_switchers_onoff_cff {};
+			class teams_comms_switchers_onoff_ground {};
+			class teams_comms_switchers_onoff {};
+		};
+
 		class core_workarounds
 		{
 			file = "functions\core\workarounds";

--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -71,6 +71,7 @@ class CfgFunctions
 			class teams_comms_switchers_onoff_cff {};
 			class teams_comms_switchers_onoff_ground {};
 			class teams_comms_switchers_onoff {};
+			class teams_comms_switchers_off_all {};
 		};
 
 		class core_workarounds

--- a/mission/config/notifications.hpp
+++ b/mission/config/notifications.hpp
@@ -1,3 +1,14 @@
+
+#define NOTIFY_COLOR_BLACK {0,0,0,1}
+#define NOTIFY_COLOR_WHITE {1,1,1,1}
+#define NOTIFY_COLOR_WHITE_DULL {0.9,0.9,0.9,1}
+#define NOTIFY_COLOR_ORANGE {0.8,0.5,0,1}
+#define NOTIFY_COLOR_RED {0.8,0.06,0,1}
+#define NOTIFY_COLOR_RED_HEAVY {1,0.3,0.2,1}
+#define NOTIFY_COLOR_GREEN {0.7,1,0.3,1}
+#define NOTIFY_COLOR_GREEN_HEAVY {0,1,0,0.6}
+
+
 class CfgNotifications
 {
 	#include "..\paradigm\Client\configs\notifications.hpp"
@@ -303,6 +314,26 @@ class CfgNotifications
 		duration = 10;
 		color[] = {1,0.3,0.2,1};
 		iconPicture = "\A3\ui_f\data\map\mapcontrol\taskIconFailed_ca.paa";
+	};
+
+	class CommsEnabled
+	{
+		title = "Comms";
+		description = "Enabled/Switched ::: %1";
+		sound = "";
+		soundClose = "";
+		priority = 9;
+		duration = 0.8;
+		color[] = NOTIFY_COLOR_WHITE_DULL;
+		iconPicture = "\A3\ui_f\data\map\markers\military\pickup_CA.paa";
+	};
+
+	class CommsDisabled : CommsEnabled
+	{
+		title = "Comms";
+		description = "Disabled ::: %1";
+		color[] = NOTIFY_COLOR_BLACK;
+		iconPicture = "\A3\ui_f\data\map\markers\military\pickup_CA.paa";
 	};
 
 	class AdminLog

--- a/mission/config/subconfigs/keys.hpp
+++ b/mission/config/subconfigs/keys.hpp
@@ -12,6 +12,7 @@ class vn_mf_keydown_escape_action
 	displayName = "";
 	access = 0;
 };
+
 class para_keydown_open_wheel_menu
 {
 	defaultKey = DIK_6;
@@ -70,7 +71,6 @@ class vn_mf_interactionOverlay_toggle
 	access = 1;
 };
 
-
 //--- Key up actions:
 class vn_mf_debug_monitor_action
 {
@@ -83,6 +83,7 @@ class vn_mf_debug_monitor_action
 	displayName = $STR_vn_mf_keybindings_debug_monitor;
 	access = 1;
 };
+
 class vn_mf_task_roster_action
 {
 	defaultKey = DIK_H;
@@ -94,6 +95,7 @@ class vn_mf_task_roster_action
 	displayName = $STR_vn_mf_keybindings_task_roster;
 	access = 1;
 };
+
 class vn_mf_ack_hint_card {
 	defaultKey = DIK_8;
 	shift = "false";
@@ -103,7 +105,8 @@ class vn_mf_ack_hint_card {
 	down = 0;
 	displayName = "Acknowledge Hint";
 	access = 1;
-}
+};
+
 class vn_mf_build_mode_action_up
 {
 	defaultKey = DIK_N;
@@ -115,6 +118,7 @@ class vn_mf_build_mode_action_up
 	displayName = $STR_vn_mf_keybindings_build_mode;
 	access = 1;
 };
+
 class vn_mf_quick_build
 {
 	defaultKey = DIK_N;
@@ -184,5 +188,17 @@ class vn_mf_channel_switcher_onoff_cff
 	function = "vn_mf_fnc_teams_comms_switchers_onoff_cff";
 	down = 0;
 	displayName = "Mute/Unmute 'CFF'";
+	access = 1;
+};
+
+class vn_mf_channel_switcher_off_all
+{
+	defaultKey = DIK_F4;
+	shift = "false";
+	ctrl = "false";
+	alt = "false";
+	function = "vn_mf_fnc_teams_comms_switchers_off_all";
+	down = 0;
+	displayName = "Mute All channels";
 	access = 1;
 };

--- a/mission/config/subconfigs/keys.hpp
+++ b/mission/config/subconfigs/keys.hpp
@@ -23,6 +23,7 @@ class para_keydown_open_wheel_menu
 	displayName = $STR_vn_mf_keybindings_selector;
 	access = 1;
 };
+/*
 class para_vote_1
 {
 	defaultKey = DIK_F1;
@@ -56,6 +57,7 @@ class para_vote_3
 	displayName = "Open Voting Menu";
 	access = 1;
 };
+*/
 class vn_mf_interactionOverlay_toggle
 {
 	defaultKey = DIK_7; // 7
@@ -146,5 +148,41 @@ class vn_mf_release_cargo
 	function = "vn_mf_fnc_release_cargo";
 	down = 0;
 	displayName = "Release Cargo (ADVSL)";
+	access = 1;
+};
+
+class vn_mf_channel_switcher_onoff_ground
+{
+	defaultKey = DIK_F1;
+	shift = "false";
+	ctrl = "false";
+	alt = "false";
+	function = "vn_mf_fnc_teams_comms_switchers_onoff_ground";
+	down = 0;
+	displayName = "Mute/Unmute 'Ground'";
+	access = 1;
+};
+
+class vn_mf_channel_switcher_onoff_air
+{
+	defaultKey = DIK_F2;
+	shift = "false";
+	ctrl = "false";
+	alt = "false";
+	function = "vn_mf_fnc_teams_comms_switchers_onoff_air";
+	down = 0;
+	displayName = "Mute/Unmute 'Air'";
+	access = 1;
+};
+
+class vn_mf_channel_switcher_onoff_cff
+{
+	defaultKey = DIK_F3;
+	shift = "false";
+	ctrl = "false";
+	alt = "false";
+	function = "vn_mf_fnc_teams_comms_switchers_onoff_cff";
+	down = 0;
+	displayName = "Mute/Unmute 'CFF'";
 	access = 1;
 };

--- a/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_off_all.sqf
+++ b/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_off_all.sqf
@@ -1,0 +1,30 @@
+/*
+    File: fn_teams_comms_switchers_off_all.sqf
+    Author: @dijksterhuis
+    Public: No
+
+    Description:
+        Switch **off** **all** player custom comms channel.
+
+        To be used with paradigm's keybinding menu, or buttons in the task roster.
+
+    Parameter(s):
+        None
+
+    Returns:
+        Nothing
+
+    Example(s):
+        call vn_mf_fnc_teams_comms_switchers_off_all;
+*/
+
+// custom channel IDs
+[1, 2, 3] apply {
+    (_x + 5) enableChannel [false, false];
+    _x radioChannelRemove [player];
+};
+
+// set channel to side
+setCurrentChannel 1;
+
+["CommsDisabled", ["Ground/Air/Call for Fire"]] call para_c_fnc_show_notification;

--- a/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff.sqf
+++ b/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff.sqf
@@ -22,20 +22,34 @@
 
 params ["_custom_channel_id", "_channel_name"];
 
-if (11 < _custom_channel_id || _custom_channel_id < 0) exitWith {
-	diag_log format ["[ERROR] Custom channel ids must be between 1 and 15: channelId=%1", _custom_channel_id];
+// safety check
+if (10 < _custom_channel_id || _custom_channel_id < 1) exitWith {
+	diag_log format ["[ERROR] Custom channel ids must be between 1 and 10 (inclusive): channelId=%1", _custom_channel_id];
 };
 
 private _global_channel_id = 15 min (6 max (_custom_channel_id + 5));
 
-private _fnc_notification = {
-	params [["_action", "err"], ["_name", "err"]];
-	[_action, [_name]] call para_c_fnc_show_notification;
+// for dac cong -- toggle the ability to hear the channel, never allow them to broadcast
+if (side player == east) exitWith {
+
+	// **always** disable ability to broadcast on the channels
+	_global_channel_id enableChannel [false, false];
+
+	// is the dc player is in the channel list?
+	if(player in ((radioChannelInfo _custom_channel_id) select 3)) then {
+		_custom_channel_id radioChannelRemove [player];
+		["CommsDisabled", [_channel_name]] call para_c_fnc_show_notification;
+
+	} else {
+		_custom_channel_id radioChannelAdd [player];
+		["CommsEnabled", [_channel_name]] call para_c_fnc_show_notification;
+	};
 };
 
-(channelEnabled _global_channel_id) params ["", "_isVoiceEnabled"];
+// standard blufor / independent
 
-if (_isVoiceEnabled) then {
+// for blufor/independent -- toggle the ability to hear the channel and to broadcast on the channel
+if ((channelEnabled _global_channel_id) select 1) then {
 	_custom_channel_id radioChannelRemove [player];
 	_global_channel_id enableChannel [false, false];
 	["CommsDisabled", [_channel_name]] call para_c_fnc_show_notification;

--- a/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff.sqf
+++ b/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff.sqf
@@ -1,0 +1,48 @@
+/*
+    File: fn_teams_comms_switchers_onoff.sqf
+    Author: @dijksterhuis
+    Public: No
+    
+    Description:
+    	Switch on/off player's custom comms channel.
+
+    	To be used with paradigm's keybinding menu, or buttons in the task roster.
+
+    	Called by other functions in this folder, which are called by the keybind presses / menu clicks.
+    
+    Parameter(s):
+		None
+    
+    Returns:
+	   	Nothing
+    
+    Example(s):
+		[3, "CFF"] call vn_mf_fnc_teams_comms_switchers_onoff;
+*/
+
+params ["_custom_channel_id", "_channel_name"];
+
+if (11 < _custom_channel_id || _custom_channel_id < 0) exitWith {
+	diag_log format ["[ERROR] Custom channel ids must be between 1 and 15: channelId=%1", _custom_channel_id];
+};
+
+private _global_channel_id = 15 min (6 max (_custom_channel_id + 5));
+
+private _fnc_notification = {
+	params [["_action", "err"], ["_name", "err"]];
+	[_action, [_name]] call para_c_fnc_show_notification;
+};
+
+(channelEnabled _global_channel_id) params ["", "_isVoiceEnabled"];
+
+if (_isVoiceEnabled) then {
+	_custom_channel_id radioChannelRemove [player];
+	_global_channel_id enableChannel [false, false];
+	["CommsDisabled", [_channel_name]] call para_c_fnc_show_notification;
+} else {
+	_custom_channel_id radioChannelAdd [player];
+	_global_channel_id enableChannel [true, true];
+	setCurrentChannel _global_channel_id;
+	["CommsEnabled", [_channel_name]] call para_c_fnc_show_notification;
+};
+

--- a/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff_air.sqf
+++ b/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff_air.sqf
@@ -1,0 +1,21 @@
+/*
+    File: fn_teams_comms_switchers_onoff_air.sqf
+    Author: @dijksterhuis
+    Public: No
+    
+    Description:
+    	Switch on/off player's custom 'Air' comms channel.
+
+    	To be used with paradigm's keybinding menu, or buttons in the task roster.
+    
+    Parameter(s):
+		None
+    
+    Returns:
+	   	Nothing
+    
+    Example(s):
+		call vn_mf_fnc_teams_comms_switchers_onoff_air
+*/
+
+[2, "Air"] call vn_mf_fnc_teams_comms_switchers_onoff

--- a/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff_cff.sqf
+++ b/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff_cff.sqf
@@ -1,0 +1,21 @@
+/*
+    File: fn_teams_comms_switchers_onoff_cff.sqf
+    Author: @dijksterhuis
+    Public: No
+    
+    Description:
+    	Switch on/off player's custom 'CFF' (Call For Fire) comms channel.
+
+    	To be used with paradigm's keybinding menu, or buttons in the task roster.
+    
+    Parameter(s):
+		None
+    
+    Returns:
+	   	Nothing
+    
+    Example(s):
+		call vn_mf_fnc_teams_comms_switchers_onoff_cff
+*/
+
+[3, "Call For Fire"] call vn_mf_fnc_teams_comms_switchers_onoff

--- a/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff_ground.sqf
+++ b/mission/functions/core/teams/comms_switchers/fn_teams_comms_switchers_onoff_ground.sqf
@@ -1,0 +1,21 @@
+/*
+    File: fn_teams_comms_switchers_onoff_ground.sqf
+    Author: @dijksterhuis
+    Public: No
+    
+    Description:
+    	Switch on/off player's custom 'Ground' comms channel.
+
+    	To be used with paradigm's keybinding menu, or buttons in the task roster.
+    
+    Parameter(s):
+		None
+    
+    Returns:
+	   	Nothing
+    
+    Example(s):
+		call vn_mf_fnc_teams_comms_switchers_onoff_ground
+*/
+
+[1, "Ground"] call vn_mf_fnc_teams_comms_switchers_onoff


### PR DESCRIPTION
Add default Mike Force keybinds to toggle specific custom comms channels, e.g. 'Ground'. If a comms channel becomes enabled/unmuted when toggled, then it's also made the active comms channel for the player.

Default keybinds for toggling each comms channel, which can be edited in the Mike Force keybind menu (press Escape > top left of screen > Keybinds)

- F1 --> Ground
- F2 --> Air
- F3 --> Call for Fire
- F4 --> Mute all custom channels

![20240610195620_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/af6d669a-6e27-4075-a82d-adbcac26b5f1)

F1-9 keys are only used for commanding AI squads in game. Currently players will also get a default arma3 scroll wheel menu for commanding AI units/groups when they press these key binds. Players can disable this default scroll wheel menu by disabling all of the `Select Unit 1` to `Select Unit 4` Function keys under Configure > Controls > Command.

![20240610162629_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/42abfc60-64d3-409a-91e1-a68bf9e0f274)

- [x] TODO: Screenshot of keybinds to disable in arma3 profile
- [ ] TODO: Video/Phone photo demo of walking while switching comms channels (JTACs rejoice!)
- [x] TODO: Add a toggle mute/unmute all custom comms channels on F4 keybind
- NOTE: Removes the voting system keybinds in the keybind menu, but we don't use the voting system anyway 🤷 
