### PR TITLE
Teams: Increase player slots for Spike Team.

### DIFF
--- a/mission/config/params.hpp
+++ b/mission/config/params.hpp
@@ -228,7 +228,7 @@ class max_players_spiketeam
     title = $STR_vn_mf_max_players_spiketeam;
     values[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 35, 40, 45, 50, 99};
     texts[] = {"0 players", "1 player", "2 players", "3 players", "4 players", "5 players", "6 players", "7 players", "8 players", "9 players", "10 players", "15 players", "20 players", "25 players", "30 players", "35 players", "40 players", "45 players", "50 players", "Default (99 players)"};
-    default = 6;
+    default = 99;
 };
 
 


### PR DESCRIPTION
Not sure why Savage game design limited the number of slots available for people to play as spike team members. Early days probably thought everyone would join spike team and not do anything else, which was probably a fair assumption at the time.