### PR TITLE
VehSpawner: minor config file fixups.

### DIFF
--- a/mission/config/subconfigs/vehicle_respawn_info.hpp
+++ b/mission/config/subconfigs/vehicle_respawn_info.hpp
@@ -913,12 +913,12 @@ class spawn_point_types {
 
 	// berchesgarden extras
 	class blackhorse_grnd_transport_heavy: unlocked_grnd_transport_heavy {
-		name = "APCs/Trucks [Blackhorse]"
+		name = "APCs/Trucks [Blackhorse]";
 		lockTeams[] = LOCKED_BLACKHORSE;
 	};
 
 	class blackhorse_grnd_utility: unlocked_grnd_utility {
-		name = "Trucks (Utility/Transport) [Blackhorse]"
+		name = "Trucks (Utility/Transport) [Blackhorse]";
 		lockTeams[] = LOCKED_BLACKHORSE;
 	};
 


### PR DESCRIPTION
some missing `;` characters. doesn't break anything but could cause issues in future.