### PR TITLE
Teams: Fix role selection at duty officer menus.

### DIFF
--- a/mission/config/notifications.hpp
+++ b/mission/config/notifications.hpp
@@ -144,7 +144,7 @@ class CfgNotifications
 	class TrainingFailedOneTraitPerTeam
 	{
 		title = $STR_vn_mf_notification_title_training;
-		description = $STR_vn_mf_onetraitperteam;
+		description = "%1 is limited to %2 player(s) with this role and %3 player(s) already have it.";
 		priority = 8;
 
 		color[] = {1,0.3,0.2,1};
@@ -155,6 +155,16 @@ class CfgNotifications
 	{
 		title = $STR_vn_mf_notification_title_training;
 		description = $STR_vn_mf_onetraitperplayer;
+		priority = 8;
+
+		color[] = {1,0.3,0.2,1};
+		iconPicture = "\A3\ui_f\data\map\mapcontrol\taskIconFailed_ca.paa";
+	};
+
+	class TrainingFailedTeamNotAllowedTrait
+	{
+		title = $STR_vn_mf_notification_title_training;
+		description = "%1 is not allowed to select this role.";
 		priority = 8;
 
 		color[] = {1,0.3,0.2,1};

--- a/mission/config/subconfigs/teams.hpp
+++ b/mission/config/subconfigs/teams.hpp
@@ -1,4 +1,105 @@
 // limits and vanilla/custom trait values
+
+/*
+
+// this is used in A LOT of places as a look up. Choose the name wisely.
+class TeamName
+{
+    // long display name in the UI
+    name = "Mike Force [Infantry]";
+
+    // Picture shown in the UI
+    icon = "\vn\ui_f_vietnam\ui\taskroster\img\logos\Logo_MikeForce_HL.paa";
+
+    // short display name in the UI
+    shortname = "Mike Force";
+
+    // default unit players load in with
+    unit = "vn_b_men_army_01";
+
+    // color shown as on map
+    color = "ColorBlue";
+
+    // RGBA values for color... not sure where this is used.
+    colorRGBA[] = {0, 0, 1, 1};
+
+    // description text shown in the UI
+    description = "Sweep and clear areas; assault objectives and defend friendly positions.";
+
+    // how many players can take these roles at a duty officer
+    class rolelimits
+    {
+        medic = 40;
+        engineer = 40;
+        explosiveSpecialist = 10;
+        vn_artillery = 0;
+    };
+
+    // default traits that get assigned to the player when switching to this team
+    // for information on base game traits, see here:
+    // https://community.bistudio.com/wiki/setUnitTrait
+    class defaultTraits
+    {
+        // A lower value means the unit is harder to spot by AI
+        camouflageCoef = 0.8;
+
+        // A lower value means the unit is harder to hear by AI
+        audibleCoef = 0.6;
+
+        // Equipment weight multiplier affecting fatigue and stamina
+        // The higher the value for the loadCoef the less stamina a unit has.
+        // Negative values will dramatically increase the stamina actually to
+        // a point where it extends the stamina bar.
+        loadCoef = 1;
+
+        // Ability to partially repair vehicles with toolkit
+        // Can also use the paradigm building system
+        engineer = false;
+
+        // Ability to defuse mines with toolkit
+        explosiveSpecialist = false;
+
+        // Ability to treat self and others with medikit
+        // Can also withstand without any firstaid kits
+        medic = false;
+
+        // Ability to hack enemy and frendly drones
+        // not used in Mike Force, but required for scripting purposes
+        UAVHacker = false;
+
+        // can use the SOG PF artillery/air support module.
+        // We've diabled this in bro nation as it causes gameplay issues.
+        // do not enable for anyone
+        vn_artillery = false;
+
+        // whether tracker teams should be sent out to harass these players
+        harassable = true;
+
+        // can use the scout feature to find sites in base Mike Force
+        // for bro-nation, can use the scout function to find the intel at
+        // HQ/Factory sites
+        // site scouting is ignored for bro-nation, as the feature is over
+        // powered.
+        scout = true;
+
+        // can use the scout feature to find multiple sites in base Mike Force
+        // ignored for bro-nation, the scout feature is over powered.
+        scoutMultiple = true;
+
+        // players can building objects via paradigm build system in 3 hits
+        // instead of 5.
+        // players can destroy objects via paradigm build system in 3 hits
+        // instead of 5.
+        increasedBuildRate = false;
+    };
+
+    //Function Calls on team Join.
+    // not used.
+    onJoin = "";
+    onLeave = "";
+};
+*/
+
 class MikeForce
 {
     name = "Mike Force [Infantry]";

--- a/mission/functions/core/teams/fn_force_team_change.sqf
+++ b/mission/functions/core/teams/fn_force_team_change.sqf
@@ -40,7 +40,6 @@ publicVariable _playerGroup;
 _player setVariable ["vn_mf_db_player_group", _team, true];
 private _nextPlayerTeamArray = missionNamespace getVariable [_team, []];
 _nextPlayerTeamArray pushBackUnique _player;
-
 /*
   @dijksterhuis commenting out line below as it just causes script errors 
   (no-one from SGD responded to my discord post about it).
@@ -53,6 +52,7 @@ _nextPlayerTeamArray pushBackUnique _player;
 	[] call vn_mf_fnc_task_refresh_tasks_client;
 	[] call vn_mf_fnc_tr_overview_team_update;
 	[] call vn_mf_fnc_update_channels;
+	[] call vn_mf_fnc_apply_unit_traits;
+	[] call vn_mf_fnc_action_trait;
+	// reset the available actions on the client
 }] remoteExec ["spawn", _player];
-
-[] remoteExecCall ["vn_mf_fnc_apply_unit_traits", _player];

--- a/mission/functions/systems/traits/fn_action_trait.sqf
+++ b/mission/functions/systems/traits/fn_action_trait.sqf
@@ -25,7 +25,12 @@ private _allTraits = "true" configClasses (missionConfigFile >> "Gamemode" >> "T
 private _airSupport = ["enable_air_support", 1] call BIS_fnc_getParamValue;
 private _artySupport = ["enable_arty_support", 1] call BIS_fnc_getParamValue;
 {
+
 	private _agent = _x;
+	// reset any existing client-side wheel menu options
+	// doing this means we can reload the wheel menu with the correct roles
+	// once a player changes team etc.
+	_agent setVariable ["para_wheel_menu_dyn_actions", []];
 	{
         private _traitConfig = _x; 
         private _trait = configName _traitConfig;

--- a/mission/functions/systems/traits/fn_settrait.sqf
+++ b/mission/functions/systems/traits/fn_settrait.sqf
@@ -42,7 +42,8 @@ if !(vn_mf_duty_officers inAreaArray [getPos _player, 20, 20, 0, false, 20] isEq
 	private _group_ID = _player getVariable ["vn_mf_db_player_group", "FAILED"];
 	// check if group is over limit for trait
 	private _limit = getNumber (missionConfigFile >> "gamemode" >> "teams" >> _group_ID >> "rolelimits" >> _trait);
-	private _allowed = (count (_selected_traits select {_x getVariable ["vn_mf_db_player_group", "FAILED"] isEqualTo _group_ID}) < _limit);
+	private _count = count (_selected_traits select {_x getVariable ["vn_mf_db_player_group", "FAILED"] isEqualTo _group_ID});
+	private _allowed = _count < _limit;
 
 	_player_current_trait = _player getVariable ["vn_mf_dyn_trait_set", ""];
 
@@ -104,7 +105,13 @@ if !(vn_mf_duty_officers inAreaArray [getPos _player, 20, 20, 0, false, 20] isEq
 	}
 	else
 	{
-		{["TrainingFailedOneTraitPerTeam"] call para_c_fnc_show_notification} remoteExecCall ["call",_player];
+		private _teamName = getText (missionConfigFile >> "gamemode" >> "teams" >> _group_ID >> "shortname");
+		if (_limit < 1) then {
+			["TrainingFailedTeamNotAllowedTrait", [_teamName]] remoteExecCall ["para_c_fnc_show_notification", _player];
+		} else {
+			private _args = [_teamName, format ["%1", _limit], format ["%1", _count]];
+			["TrainingFailedOneTraitPerTeam", _args] remoteExecCall ["para_c_fnc_show_notification", _player];
+		};
 	};
 
 	[_trait,_allowed] call BIS_fnc_log;

--- a/mission/functions/systems/traits/fn_settrait.sqf
+++ b/mission/functions/systems/traits/fn_settrait.sqf
@@ -108,4 +108,7 @@ if !(vn_mf_duty_officers inAreaArray [getPos _player, 20, 20, 0, false, 20] isEq
 	};
 
 	[_trait,_allowed] call BIS_fnc_log;
+
+	// reset the duty officer wheel menu on the client
+	[] remoteExecCall ["vn_mf_fnc_action_trait",_player];
 };

--- a/mission/para_player_init_client.sqf
+++ b/mission/para_player_init_client.sqf
@@ -134,9 +134,6 @@ progressLoadingScreen 1.0;
 //Setup teleporters
 call vn_mf_fnc_action_teleport;
 
-call vn_mf_fnc_apply_unit_traits;
-
-call vn_mf_fnc_action_trait;
 [parseText format["<t font='tt2020base_vn' color='#F5F2D0'>%1</t>",localize "STR_vn_mf_loading10"]] call vn_mf_fnc_update_loading_screen;
 
 // apply health effects


### PR DESCRIPTION
### Bug

Switching teams does not add/remove the available roles in the duty officer wheel menu
- Mike Force -> ANZAC -- players can still select all roles
- ANZAC -> Mike Force -- players cannot select any roles

### Fix

Because the wheel menu is added client side, we can clear the wheel menu actions added to the duty officers when a palyer switches teams and then add them again.

## Additional

I've also improved role selection for folks in public teams 
- the wheel menu no longer shows any roles players already have assigned
- error notifications provide more detail as to why they cannot select a role (`$teamName` isn't allowed the role / `$x` players in `$teamName` have the role already, but the limit for this role and team is `$y`)

----

### screenshots of bugfix

![20240611020249_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/6fa1b38c-8970-48f1-8a83-4124052e5ee7)

![20240611020237_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/a976f982-9cfd-4db1-aa78-e9133488eb42)

![20240611020255_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/4da63f30-ce17-4d36-ad40-a8ff76bdabe8)

![20240611020300_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/550f4914-6a17-4e43-b13c-cb83383bd2a6)

----

### screenshots of role selection as public player hiding active roles


![20240611045516_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/c69b9369-d3d8-44ca-b8a3-9a81c0650ba3)

![20240611045519_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/27824733-7b92-4fef-9bbc-39867eec37e3)

### screenshots of message feedback improvements

![20240611045353_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/9d943b96-2f4d-4dea-8774-5fca5096eee3)

![20240611045314_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/f4f056b8-1917-4d9e-99c2-2d17c3068862)



