### PR TITLE
Tasks: Reduce capture zone marker alpha to make it easier to read map + markers

### DIFF
--- a/mission/functions/tasks/primary/fn_task_pri_capture.sqf
+++ b/mission/functions/tasks/primary/fn_task_pri_capture.sqf
@@ -36,6 +36,7 @@ _taskDataStore setVariable ["INIT", {
 	// change the zone's hexagon colour and shading
 	_zone setMarkerColor "ColorRed";
 	_zone setMarkerBrush "DiagGrid";
+	_zone setMarkerAlpha 0.45;
 
 	private _areaMarkerSize = vn_mf_bn_s_zone_radius + 100;
 


### PR DESCRIPTION
capture pahse alpha determines the counterattack phase alpha as well. 

TODO
- [ ] MAYBE/MAYBE NOT hook the zone marker color/alpha changes up as part of the `mission/functions/core/ui/zone_marker/` & `zoneMarkerTypes.hpp` system (players can mouse hover over zones to see information about the zone)
- [ ] Explicitly change marker alpha during counterattack as well, in case some decides to change the alpha there later? or rely on zone marker system as above?


![20240704223519_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/4a9fb181-40dd-4bce-b409-3cce44fc5a90)
![20240704223530_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/5e9df34a-263b-44d6-b203-9f8632c5324b)
![20240704223644_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/c37406fb-5b6b-4381-b633-4c0efdde5f9a)
![20240704223654_1](https://github.com/Bro-Nation/Mike-Force/assets/11841332/eb60aa5c-e49c-4fc5-9ccf-e27664200135)
