### PR TITLE
Actions: DacCong respawns were not able to be destroyed.

### DIFF
--- a/mission/functions/systems/actions/fn_action_destroy_respawn.sqf
+++ b/mission/functions/systems/actions/fn_action_destroy_respawn.sqf
@@ -25,7 +25,7 @@
 	{},	// Code executed when action starts
 	{},	// Code executed on every progress tick
 	{
-		[cursorObject, player] remoteExec ["vn_mf_fnc_destroy_task", 2];
+		[cursorObject, player] remoteExec ["vn_mf_fnc_sites_remoteactions_destroy_task", 2];
 	},// Code executed on completion
 	{},	// Code executed on interrupted
 	[],													// Arguments passed to the scripts as _this select 3


### PR DESCRIPTION
I missed updating this script when refactoring the sites code in #322 