### PR TITLE
Maintenance: Tweaks for server performance plus documentation improvements

### DIFF
--- a/mission/functions/core/fn_save_time_elapsed.sqf
+++ b/mission/functions/core/fn_save_time_elapsed.sqf
@@ -37,8 +37,6 @@ publicVariable "para_g_totalgametime";
 
 // do ttl check on db
 ["TTLCHECK"] call para_s_fnc_profile_db;
-// force db save periodically
-["SAVE"] call para_s_fnc_profile_db;
 
 // update internal counter
 vn_mf_lastticktime = _ticktime;

--- a/mission/functions/systems/sysmsg/fn_sysmsg_print_admin.sqf
+++ b/mission/functions/systems/sysmsg/fn_sysmsg_print_admin.sqf
@@ -1,5 +1,23 @@
+/*
+    File: fn_sysmsg_print_admin.sqf
+    Author: 'DJ' Dijksterhuis
+    Public: No
+
+    Description:
+        Send some random pre-defined message to all players over system chat.
+
+        These are all admin specific messages like server rules etc.
+
+    Parameter(s): None
+
+    Returns: nothing
+
+    Example(s):
+        call vn_mf_fnc_sysmsg_print_admin;
+*/
+
+
 private _admin_messages = [
-    "Events: We regularly host events and custom missions on multiple servers. See the events tab on discord: discord.gg/bro-nation",
     "Servers: We usually have a selection of custom Mike Force servers. Past missions: 1986 Cold War; WW2; Star Wars; Halo; Warhammer 40k. discord.gg/bro-nation",
     "Server Restarts: Every 6 hours: 00:00, 06:00, 12:00, 18:00 EST.",
     "Server Rule 1: Trolling will not be tolerated.",
@@ -11,7 +29,5 @@ private _admin_messages = [
 ];
 
 private _msg = format ["%1", selectRandom _admin_messages];
-
-{
-    [_msg] remoteExec ["systemChat", _x]
-} forEach allPlayers;
+// don't care about client order -- send and forget with rECall
+[_msg] remoteExecCall ["systemChat", -2];

--- a/mission/functions/systems/sysmsg/fn_sysmsg_print_others.sqf
+++ b/mission/functions/systems/sysmsg/fn_sysmsg_print_others.sqf
@@ -1,35 +1,57 @@
+/*
+    File: fn_sysmsg_print_others.sqf
+    Author: 'DJ' Dijksterhuis
+    Public: No
+
+    Description:
+        Send some random pre-defined helper message to all players over system chat.
+
+        NOTE: I've disabled a bunch of these as I'm a bit suspicious that the large
+        array passed to `selectRandom` might be slowing down the command when
+        there's a lot of jobs executing on the server.
+
+    Parameter(s): None
+
+    Returns: nothing
+
+    Example(s):
+        Call vn_mf_fnc_sysmsg_print_others;
+*/
+
+
 private _other_messages = [
-    // wlus
-    "UDT: Before there were SEALs, there was UDT.",
-    "UDT: Pioneers in underwater demolition, closed-circuit diving, combat swimming, and midget submarine (dry and wet submersible) operations.",
-    "Tiger Force: The complete destruction of the enemy.",
-    "Tiger Force: Long Range Reconnaissance Patrol comprised of 45 Paratroopers from the 1st Battalion 327th Infantry Regiment of the 101st Airborne.",
-    "Marines: Footmobile, airborne and mechanized infantry, brown water surface warfare and spec ops.",
-    "Marines: Tribute to the US 1st Marine Division, being deployed under the same name in South Vietnam during the Vietnam war.",
-    "Military Police: Tribute unit for the 716th Military Police Battalion focusing on action in combat and in a garrison role.",
-    "Military Police: Like to help others? Want to save the day? Sign up today to the most active RP Unit on Bro Nations today!",
-    "NZ-SAS: New Zealand and Australian themed Small Unit Tactics (SUT) Offshoot of the SAS.",
-    "NZ-SAS: 1,200 patrols; 492 enemey confirmed killed; 11 prisoners captured. All for one KIA and one MIA.",
-    "Satan's Angels: Advanced air superiority squadron providing Close Air Support (CAS) and Air Superiority.",
-    "Muskets: Close Air Support (CAS) using a variety of attack helicopters, plus troop transportation, sling loading and logistics, aerial recon and wreck recovery.",
-    "ARVN Rangers: Light infantry unit, now grown into a bigger capable fighting force with different elements.",
-    "ARVN Rangers: The Vietnamese Rangers, commonly known as the ARVN Rangers, were the light infantry of the Army of the Republic of Vietnam.",
-    "Black Horse: We are the Blackhorse Troopers, the finest in the land, we fight for right and use our might to free our fellow man.",
-    "Black Horse: 11th Armored Cavalry Regiment is a multi-component combat brigade with a special emphasis on combat engineering, armored warfare, and firesupport.",
-    "633rd CSG: A tribute unit to the USAF unit of the same name stationed at Pleiku Airbase.",
-    "633rd CSG: Support functions with a focus on aviation support and logistics.",
-    "633rd CSG: We do what others don't want to do or are deemed dangerous.",
-    "7th Cav: Air cavalry based unit that focuses on rapid and mobile assaults, using Heuy's, Chinhooks, and Cayuse's with the occasional use of mechanized infantry.",
-    "7th Cav: We are the jack of all trades and Master of one, that being Air Assault.",
-    "7th Cav: We get called in to be the Spearhead of an assault or the Reinforcements for one.",
-    // bn specific
+    "Events: We regularly host events and custom missions on multiple servers. See the events tab on discord: discord.gg/bro-nation",
+    // --- wlus
+    // "UDT: Before there were SEALs, there was UDT.",
+    // "UDT: Pioneers in underwater demolition, closed-circuit diving, combat swimming, and midget submarine (dry and wet submersible) operations.",
+    // "Tiger Force: The complete destruction of the enemy.",
+    // "Tiger Force: Long Range Reconnaissance Patrol comprised of 45 Paratroopers from the 1st Battalion 327th Infantry Regiment of the 101st Airborne.",
+    // "Marines: Footmobile, airborne and mechanized infantry, brown water surface warfare and spec ops.",
+    // "Marines: Tribute to the US 1st Marine Division, being deployed under the same name in South Vietnam during the Vietnam war.",
+    // "Military Police: Tribute unit for the 716th Military Police Battalion focusing on action in combat and in a garrison role.",
+    // "Military Police: Like to help others? Want to save the day? Sign up today to the most active RP Unit on Bro Nations today!",
+    // "NZ-SAS: New Zealand and Australian themed Small Unit Tactics (SUT) Offshoot of the SAS.",
+    // "NZ-SAS: 1,200 patrols; 492 enemey confirmed killed; 11 prisoners captured. All for one KIA and one MIA.",
+    // "Satan's Angels: Advanced air superiority squadron providing Close Air Support (CAS) and Air Superiority.",
+    // "Muskets: Close Air Support (CAS) using a variety of attack helicopters, plus troop transportation, sling loading and logistics, aerial recon and wreck recovery.",
+    // "ARVN Rangers: Light infantry unit, now grown into a bigger capable fighting force with different elements.",
+    // "ARVN Rangers: The Vietnamese Rangers, commonly known as the ARVN Rangers, were the light infantry of the Army of the Republic of Vietnam.",
+    // "Black Horse: We are the Blackhorse Troopers, the finest in the land, we fight for right and use our might to free our fellow man.",
+    // "Black Horse: 11th Armored Cavalry Regiment is a multi-component combat brigade with a special emphasis on combat engineering, armored warfare, and firesupport.",
+    // "633rd CSG: A tribute unit to the USAF unit of the same name stationed at Pleiku Airbase.",
+    // "633rd CSG: Support functions with a focus on aviation support and logistics.",
+    // "633rd CSG: We do what others don't want to do or are deemed dangerous.",
+    // "7th Cav: Air cavalry based unit that focuses on rapid and mobile assaults, using Heuy's, Chinhooks, and Cayuse's with the occasional use of mechanized infantry.",
+    // "7th Cav: We are the jack of all trades and Master of one, that being Air Assault.",
+    // "7th Cav: We get called in to be the Spearhead of an assault or the Reinforcements for one.",
+    // --- bn specific
     "Dac Cong: Been captured? Try to escape the tunnels and get rescued. Respawning is for cowards!",
-    "Dac Cong: Been captured? Escape and grab a shovel... You're going to need it.",
+    // "Dac Cong: Been captured? Escape and grab a shovel... You're going to need it.",
     "Dac Cong: Been captured? Only give them your name, rank and player UID.",
     "Dac Cong: OPFOR's jungle warefare experts. Grab a battle buddy and watch each other's back!",
-    "Dac Cong: 'Go home GI. You no welcome here. You invader. Stinky GI.'",
+    // "Dac Cong: 'Go home GI. You no welcome here. You invader. Stinky GI.'",
     "Dac Cong: Gia Lam and Dac Cong HQ are off limits, except when curators announce a special mission for Gia Lam, and only Gia Lam.",
-    "Dac Cong: Prepare for an emotionally difficult experience when Dac Cong are unleashed. WU-TANG!",
+    // "Dac Cong: Prepare for an emotionally difficult experience when Dac Cong are unleashed. WU-TANG!",
     "Dac Cong: Capture Dac Cong players to take them out of the game longer. Ask MP / WLU bros to interrogate them at the MP base!",
     "Fire Missions: Example of good map marking text for a CAS fire mission: CAS - WHISKEY - NAPALM - EAST/WEST.",
     "Fire Missions: Example of good map marking text for an Arty fire mission: ART - ECHO - WP - WTL.",
@@ -38,21 +60,21 @@ private _other_messages = [
     "CAS: Why CAS whitelisting? Because people were toxic in the past. Now the toys are locked away.",
     "CAS: Whitelisted to prevent toxic behaviour.",
     "CAS: With great power comes great responsibility... Which is why all CAS is whitelisted.",
-    "Charlie Brown: Anyone with *popular support* can step up and lead an AO (unless they have already done so in the last 24 hours).",
-    "Charlie Brown: Remember that everything should be a request, not an order, and we're all here to have fun.",
-    "Charlie Brown: It's only after you've stepped outside your comfort zone that you begin to change, grow, and transform.",
-    "Training: Bros with 06 and above in their name are Senior Instructor qualified. They can teach you about Mines and JTAC calls.",
-    "Training: Bros with 05 and above in their name are Instructor qualified. They can teach you about Patrolling, Combat Comms, Engineering and Parachuting.",
+    // "Charlie Brown: Anyone with *popular support* can step up and lead an AO (unless they have already done so in the last 24 hours).",
+    // "Charlie Brown: Remember that everything should be a request, not an order, and we're all here to have fun.",
+    // "Charlie Brown: It's only after you've stepped outside your comfort zone that you begin to change, grow, and transform.",
+    // "Training: Bros with 06 and above in their name are Senior Instructor qualified. They can teach you about Mines and JTAC calls.",
+    // "Training: Bros with 05 and above in their name are Instructor qualified. They can teach you about Patrolling, Combat Comms, Engineering and Parachuting.",
     "Training: Voluntary public training sessions are regularly hosted on discord: discord.gg/bro-nation",
     "Training: No training is required to play on the server(s), but some whitelisted units may require you complete trainings before you can join their ranks.",
     "WLUs: Whitelisted Units are groups of like-minded Bros that regularly play Arma together.",
     "WLUs: Join the discord if you want to apply to a Whitelisted Unit: discord.gg/bro-nation",
     "PID: Sorry goes a long way, especially if you just friendly fired a fellow bro!",
     "PID: Positively identify (PID) your targets. Check your map *before* you shoot!",
-    "Map: There is (usually) a legend somewhere on map explaining all the markings around the main base.",
+    // "Map: There is (usually) a legend somewhere on map explaining all the markings around the main base.",
     "Map: Please mark any mines you place on map in side channel. It's just the right thing to do.",
     "Map: Deleting important map markings without permission can be considered toxic/trolling behaviour.",
-    // gamemode hints
+    // --- gamemode hints
     "Duty Officer: Get specialist roles like Engineer, Explosives or Medic by walking up to a duty officer and pressing the 6 key.",
     "Duty Officer: Switch between teams by walking up to a duty officer, pressing Alt + H and selecting from the top row of images.",
     "Key Binds: Change Mike Force specific key binds by pressing Esc and opening the GAMEMODE KEYBINDS menu (top left).",
@@ -61,15 +83,15 @@ private _other_messages = [
     "Building: (Step 1) Get shovel and sandbags (Step 2) place structure from build menu (N key) (Step 3) hit structure with shovel several times (Step 4) add sandbags with 6 key (Step 5) bask in combat engineer glory.",
     "Building: Supply your buildings with sandbags or supply crates. Use the 6 wheel menu to add the resources when looking at the structure.",
     "Building: Grab a machete and clear out some foliage so you can see Charlie coming.",
-    "Support Request: In the Alt + H menu you can create missions for Green Hornets to deliver critical supplies.",
-    "Support Request: In the Alt + H menu you can create missions for Spike Team to destroy an objective.",
+    // "Support Request: In the Alt + H menu you can create missions for Green Hornets to deliver critical supplies.",
+    // "Support Request: In the Alt + H menu you can create missions for Spike Team to destroy an objective.",
     "Comms: Be clear, concise and confident.",
     "Comms: You can mute specific players. Open your Map and go to the 'Players' tab. Click the speaker icon next to their name to mute/unmute.",
-    "Comms: Side channel is text only, but everyone can see it. Perfect for fire mission requests.",
-    "Comms: Use the '.' key to switch between comms channels. Not everything needs to be said over Ground channel.",
-    "Comms: Use the '/' key to send a text message on a comms channel (press 'Enter' to send your text message).",
+    // "Comms: Side channel is text only, but everyone can see it. Perfect for fire mission requests.",
+    // "Comms: Use the '.' key to switch between comms channels. Not everything needs to be said over Ground channel.",
+    // "Comms: Use the '/' key to send a text message on a comms channel (press 'Enter' to send your text message).",
     "Comms: Direct channel for bros in your immediate vicinity. Vehicle channel when in a vehicle. Side channel for everyone (text only).",
-    "Comms: Mute/Unmute some channels by pressing Alt + H and clicking the icons in the top left of the window.",
+    // "Comms: Mute/Unmute some channels by pressing Alt + H and clicking the icons in the top left of the window.",
     "Comms: Create isolated comms groups using the Dynamic Group menu ('U' key). Invite other Bros to join and communicate over the Group channel.",
     "Intel: Avoid calling Fire Missions or using Willie Pete on HQ/Factory sites until you've got the intel.",
     "Intel: The HQ/Factory sites have an intel document which can reveal other site locations.",
@@ -86,18 +108,18 @@ private _other_messages = [
     "Camps: Watch out for traps at campsites ...",
     "Camps: Mine Detectors have a 15m detection radius while Trap Kits only have a 5m detection radius. Morale of the story: use Mine Detectors!",
     "Camps: Always remember to turn on your Mine Detector before you step off!",
-    // misc
-    "Be a bro.",
-    "Be a bro, be like John the GI.",
-    "It is only a game.",
-    "When in doubt, apologize and move on with your life.",
-    "Never step off without your Mine Detector.",
-    "ACAV, best Cav.",
-    "Spike team, best team."
+    // --- misc
+    // "Be a bro.",
+    // "Be a bro, be like John the GI.",
+    // "It is only a game.",
+    // "When in doubt, apologize and move on with your life.",
+    // "Never step off without your Mine Detector.",
+    // "ACAV, best Cav.",
+    // "Spike team, best team."
 ];
 
 private _msg = format ["%1", selectRandom _other_messages];
+// don't care about client order -- send and forget with rECall
+[_msg] remoteExecCall ["systemChat", -2];
 
-{
-    [_msg] remoteExec ["systemChat", _x]
-} forEach allPlayers;
+nil;

--- a/mission/functions/systems/sysmsg/fn_sysmsg_print_others.sqf
+++ b/mission/functions/systems/sysmsg/fn_sysmsg_print_others.sqf
@@ -107,7 +107,7 @@ private _other_messages = [
     "Radio Tap: Wiretapping radio sets at sites can now reveal all AO sites. But the locations are less accurate than the intel.",
     "Camps: Watch out for traps at campsites ...",
     "Camps: Mine Detectors have a 15m detection radius while Trap Kits only have a 5m detection radius. Morale of the story: use Mine Detectors!",
-    "Camps: Always remember to turn on your Mine Detector before you step off!",
+    "Camps: Always remember to turn on your Mine Detector before you step off!"
     // --- misc
     // "Be a bro.",
     // "Be a bro, be like John the GI.",

--- a/mission/functions/systems/zones/fn_zones_init.sqf
+++ b/mission/functions/systems/zones/fn_zones_init.sqf
@@ -74,6 +74,8 @@ mf_s_zone_first_task = "prepare_zone";
 
 vn_mf_completedZones = ["GET", "completed_zones", []] call para_s_fnc_profile_db select 1; publicVariable "vn_mf_completedZones";
 
-["zone_manager", vn_mf_fnc_zones_manager_job, [], 30] call para_g_fnc_scheduler_add_job;
+// @dijksterhuis: disabled this as we're now saving the zone state to
+// server's profile namespace whenever we update the zone.
+// ["zone_manager", vn_mf_fnc_zones_manager_job, [], 30] call para_g_fnc_scheduler_add_job;
 
 ["Zone initialisation complete"] call BIS_fnc_log;

--- a/mission/para_server_init.sqf
+++ b/mission/para_server_init.sqf
@@ -17,26 +17,133 @@
         use_paradigm_init = 1;
 */
 
+/*
+=========================================================================================
+init: `para_s_fnc_curator_init_eh`
+=========================================================================================
+Creates the event handlers to monitor what Zeuses are doing. Whether they've connected,
+disconnected, entered the zeus interface, exited the zeus interface, etc.
+
+If any of those event handlers are triggered, a line gets written to the log file with
+the player's name and UID etc.
+=========================================================================================
+*/
+
 call para_s_fnc_curator_init_eh;
 
+/*
+=========================================================================================
+init: `vn_mf_fnc_server_init_backend`
+=========================================================================================
+WARNING: YOU WILL NOT HAVE THIS DURING LOCAL DEVELOPMENT. This always generates an error
+when running locally. It's a server-side only mod.
+
+I don't actually know what this does.
+
+TODO: Check on server what this is.
+=========================================================================================
+*/
+
 call vn_mf_fnc_server_init_backend;
+
+/*
+=========================================================================================
+job: `restart_messages`
+=========================================================================================
+WARNING: YOU WILL NOT HAVE THIS DURING LOCAL DEVELOPMENT. This always generates an error
+when running locally. It's a server-side only mod.
+
+Every minute check if we need to send out a restart message.
+=========================================================================================
+*/
+
 ["restart_messages", vn_mf_fnc_server_process_restart, [], 60] call para_g_fnc_scheduler_add_job;
+
+/*
+=========================================================================================
+job: `update_whitelist`
+=========================================================================================
+Sets up the Bro-Nation whitelisting for teams. Reads from the backend MySQL database via
+extDB3 and loads the player UIDs into a `publicVariable` so we can check whether a player
+can join a specific team or not.
+=========================================================================================
+*/
 
 call para_s_fnc_init_whitelist;
 ["update_whitelist", para_s_fnc_init_whitelist, [], 120] call para_g_fnc_scheduler_add_job;
 
-// update curator whitelist, every 5 minutes
+/*
+=========================================================================================
+job: `update_curators`
+=========================================================================================
+Update the curator whitelist every 5 minutes. Reads from the backend MySQL database via
+extDB3 and loads the player UIDs into a `publicVariable` so we can check whether a player
+can access the zeus interface (TODO: public variables for authN is probably a bad idea!).
+
+Also does a few fancy things like checking if the Zeus player has the correct modspack
+loaded etc.
+=========================================================================================
+*/
+
 call para_s_fnc_curator_populate;
 ["update_curators", para_s_fnc_curator_populate, [], 300] call para_g_fnc_scheduler_add_job;
 
-// update objects curators can edit, every 10 seconds
+/*
+=========================================================================================
+init: `para_s_fnc_curator_update_objects`
+=========================================================================================
+Creates a job which update the objects available for interaction in the zeus interface.
+
+Basically stops curators having to right click > edit mission objects > all objects
+whenever the mission has created something new.
+=========================================================================================
+*/
+
 [10] call para_s_fnc_curator_update_objects;
+
+/*
+=========================================================================================
+job: `dopamine_hit`
+=========================================================================================
+Sets up the paradigm dynamic groups system, which allows palyers to create and join
+custom in-game groups.
+=========================================================================================
+*/
 
 call para_s_fnc_init_dopamine;
 ["dopamine_hit", para_s_fnc_init_dopemine, [], 300] call para_g_fnc_scheduler_add_job;
 
+/*
+=========================================================================================
+job: `sysmsg_admin` & `sysmsg_generic`
+=========================================================================================
+Sets up two 'sysmsg' jobs which send random messages to players over system chat at
+different intervals.
+
+    - 'sysmsg_admin' -- critical stuff like server rules.
+    - 'sysmsg_generic' -- advertising and brief explaninations to players of how to do X
+
+=========================================================================================
+*/
+
 ["sysmsg_admin", vn_mf_fnc_sysmsg_print_admin, [], 3000] call para_g_fnc_scheduler_add_job;
 ["sysmsg_generic", vn_mf_fnc_sysmsg_print_others, [], 6666] call para_g_fnc_scheduler_add_job;
+
+/*
+=========================================================================================
+conf: A BUNCH OF STUFF
+=========================================================================================
+The main server side configuration starts happening here and goes on for a bit.
+
+I'm not going to document all of this just now.
+
+----
+TODO: Someone needs to go through and work out if all of these are actually necessary.
+
+TODO: These should ideally be moved up to the top of the file. First get global
+configuration, then apply that configuration during service inits.
+=========================================================================================
+*/
 
 private _gamemode_config = (missionConfigFile >> "gamemode");
 
@@ -123,8 +230,17 @@ para_g_enemiesPerPlayer = ((["ai_scaling", 100] call BIS_fnc_getParamValue) / 10
 //Global variable, so it needs syncing across the network.
 publicVariable "para_g_enemiesPerPlayer";
 
+/*
+=========================================================================================
+init: `vn_mf_fnc_marker_init`
+=========================================================================================
+Read map markers from the map and populate appropriate arrays for use in later server
+system initialisation. Creates a bunch of public server-side arrays for areas like:
+`no_sites`, `zone`, `wreck_recovery`, `supply_officer_initial`, `blocked_area`, etc.
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising markers";
-//Read map markers and populate appropriate arrays
 call vn_mf_fnc_marker_init;
 
 // restore enlisted player counter
@@ -161,18 +277,53 @@ setterraingrid (getNumber(_gamemode_config >> "performance" >> "setterraingrid")
 (getArray(_gamemode_config >> "performance" >> "enableenvironment")) params ["_ambientlife","_ambientsound"];
 enableenvironment [[false,true] select _ambientlife,[false,true] select _ambientsound];
 
-//Set up respawn points.
+/*
+=========================================================================================
+init: `vn_mf_fnc_respawn_points_init`
+=========================================================================================
+Set up respawn points for players
+=========================================================================================
+*/
+
 [] call vn_mf_fnc_respawn_points_init;
 
-// start scheduler
+/*
+=========================================================================================
+init: `para_g_fnc_scheduler_subsystem_init`
+=========================================================================================
+Starts the paradigm scheduler. The scheduler will spawn a specific 'job' function every
+N seconds.
+
+**A BUNCH OF THINGS WILL NOT WORK IF THIS ISN'T STARTED.**
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Starting scheduler";
 [] call para_g_fnc_scheduler_subsystem_init;
 
-// start the event dispatcher, so anything relying on events can fire.
+/*
+=========================================================================================
+init: `para_g_fnc_event_subsystem_init`
+=========================================================================================
+Start the event dispatcher, so anything relying on events can fire.
+
+This is essentially a way to get custom Event Handlers without having to mod the base
+game. Pretty useful actually. We should do more with this as events are way cheaper for
+server performance than scheduled/periodic jobs.
+=========================================================================================
+*/
+
 call para_g_fnc_event_subsystem_init;
 
+/*
+=========================================================================================
+init: `para_s_fnc_cleanup_subsystem_init`
+=========================================================================================
+Deletes bodies, objects and gear after a certain amount of time.
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Cleanup Routine";
-// start cleanup subsystem
 [
     createHashmapFromArray [
         ["minPlayerDistance", ["cleanup_min_player_distance", 400] call BIS_fnc_getParamValue],
@@ -184,9 +335,27 @@ diag_log "VN MikeForce: Initialising Cleanup Routine";
     ]
 ] call para_s_fnc_cleanup_subsystem_init;
 
-// creates and initialize groups and duty officers
+/*
+=========================================================================================
+init: `vn_mf_fnc_group_init`
+=========================================================================================
+Creates and initialize groups and duty officers. Group init here mostly refers to setting
+up various variables. Duty officers obviously for switching roles and teams. Similar to
+the supply officers (see way down below) the duty officers are civialian AI with damage
+turned off and movement diabled.
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising groups and duty officers";
 call vn_mf_fnc_group_init;
+
+/*
+=========================================================================================
+run: `vn_mf_secondaryTasksBySide`
+=========================================================================================
+TODO: Dead code? These variables aren't use anywhere.
+=========================================================================================
+*/
 
 {
     private _taskConfig = _x;
@@ -196,16 +365,72 @@ call vn_mf_fnc_group_init;
     } forEach (getArray (_taskConfig >> 'taskGroups'));
 } forEach (vn_mf_secondaryTaskConfigs);
 
-// start generic scheduler functions
+/*
+=========================================================================================
+job: `save_profiledb`
+=========================================================================================
+Write the contents of `profileNamespace` to the $profile.vars file, i.e. flush data from
+memory to disk for persistance between server restarts.
+
+Disk write ops are the slowest of all data storage ops. Please avoid setting the job
+schedule time to a low number! Lower periodic job runs means writing to disk more often.
+
+Seeting lower job times *probably* has performance impacts. I'm not 100% sure as I don't
+know the internals of Arma3 and whether they set a 'lock' on the data in memory while
+writing. Locks -- https://en.wikipedia.org/wiki/Lock_(computer_science)
+
+This might not be required as the `saveProfileNamespace` command is called automatically
+'when the game is closed'. But i don't know whether 'when the game is closed' includes
+server restarts, which basically are a termination of the running Arma3 process.
+https://community.bistudio.com/wiki/saveProfileNamespace
+=========================================================================================
+*/
+
+diag_log "VN MikeForce: Initialising 'save_profiledb' job.";
+["save_profiledb", {["SAVE"] call para_s_fnc_profile_db}, [], 60] call para_g_fnc_scheduler_add_job;
+
+/*
+=========================================================================================
+run & job: `save_time_elapsed`
+=========================================================================================
+Initialise public variables and start the job to track how much game time has elapsed.
+
+The public variable `para_g_totalgametime` is only used by
+
+    1. `vn_mf_fnc_display_location_time` -- display on player's screen where they are
+    near and how long the mission has run for.
+
+    2. `para_s_fnc_profile_db` -- run TTL expiry on speciofic keys on the
+    profileNamespace KV store. Although there is no Mike Force or Paradigm
+    system/function which uses profile_db TTL expiry. So this is mostly redundent.
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Starting game time monitor";
-// broadcast total time elapsed - initial
 missionNamespace setVariable ["para_g_totalgametime",["GET", "game_time", 0] call para_s_fnc_profile_db select 1,true];
 diag_log format ["VN MikeForce: Total Game Time - %1", para_g_totalgametime];
 ["save_time_elapsed", {call vn_mf_fnc_save_time_elapsed}, [], 5] call para_g_fnc_scheduler_add_job;
 
-// spawn buildables and init vars
+/*
+=========================================================================================
+init: `para_s_fnc_building_system_init`
+=========================================================================================
+1. Initialises a bunch of variables and systems for building.
+2. Recreates buildings that existed before restart (loaded from the profile DB).
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising building system";
 call para_s_fnc_building_system_init;
+
+/*
+=========================================================================================
+run: `vn_mf_fnc_create_supply_officer`
+=========================================================================================
+Creates the actual supply officer objects which players can use to get build/medical/ammo
+supplies etc.
+=========================================================================================
+*/
 
 diag_log "VN MikeForce: Creating supply officers";
 // spawn supply officers
@@ -213,19 +438,52 @@ diag_log "VN MikeForce: Creating supply officers";
     [_x] call vn_mf_fnc_create_supply_officer;
 } forEach vn_mf_markers_supply_officer_initial;
 
+/*
+=========================================================================================
+job: `building_state_tracker`
+=========================================================================================
+Tracks the current state of buildings, this includes running the 'tick' that reduces the
+current supply of the building/base. On top of that, when buildings reach 0% supply they
+become 'deconstructed'. Also handles building deletion (I *think*).
+
+Also WRITES current buildings in the mission to the profile DB for persistence through
+restarts.
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Starting building state tracker";
-// building state tracking
 ["building_state_tracker", {call para_s_fnc_building_state_tracker}, [], 60] call para_g_fnc_scheduler_add_job;
 
-diag_log "VN MikeForce: Starting player list tracker";
-// do slow allplayers list updates
-["loadbal_fps_aggregator", {call para_s_fnc_loadbal_fps_aggregator}, [], 15] call para_g_fnc_scheduler_add_job;
+/*
+=========================================================================================
+run: 'chopped trees'
+=========================================================================================
+Like `para_s_fnc_building_system_init`, but this is for any trees that were cut down
+before a server restarts.
+
+Important when players have built a FOB in an heavy forest area and they want to use it
+again after a server restart!
+=========================================================================================
+*/
 
 // Clear Trees
 ["GET", "chopped_trees", ""] call para_s_fnc_profile_db params ["","_chopped_trees"];
 if !(_chopped_trees isEqualType "") then {
     {[_x] call para_s_fnc_fell_tree_initial;} forEach (_chopped_trees # 0);
 };
+
+/*
+=========================================================================================
+vars: `vc units`
+=========================================================================================
+TODO: Some of these are used in dead code (currently) --
+
+    - `units_vc_officer` --> `fn_task_sec_kill_officer.sqf`
+    - `units_vc_marksman` -- `fn_task_sec_clear_minefield.sqf`
+
+We may want to reintroduce these tasks ^ at a later date somehow?
+=========================================================================================
+*/
 
 //Example unit types. Should be made more dynamic as the gamemode progresses.
 unit_civilian = "vn_c_men_20";
@@ -238,6 +496,14 @@ units_vc_grenadier = ["vn_o_men_vc_07", "vn_o_men_nva_dc_07"];
 units_vc_at = ["vn_o_men_vc_14", "vn_o_men_vc_local_28"];
 units_vc_mg = ["vn_o_men_vc_11", "vn_o_men_vc_local_11"];
 
+/*
+=========================================================================================
+vars: `sog units`
+=========================================================================================
+TODO: Dead code. Completely Unused.
+=========================================================================================
+*/
+
 units_sog_teamleader = ["vn_b_men_sog_01", "vn_b_men_sog_13"];
 units_sog_rto = ["vn_b_men_sog_02", "vn_b_men_sog_14"];
 units_sog_medic = ["vn_b_men_sog_03", "vn_b_men_sog_15"];
@@ -245,12 +511,46 @@ units_sog_scout = ["vn_b_men_sog_09", "vn_b_men_sog_19"];
 units_sog_grenadier = ["vn_b_men_sog_07", "vn_b_men_sog_11"];
 units_sog_machinegunner = ["vn_b_men_sog_06", "vn_b_men_sog_16", "vn_b_men_sog_18"];
 
+/*
+=========================================================================================
+vars: `mines`
+=========================================================================================
+TODO: Only used by dead code (currently) -- `fn_task_sec_clear_minefield.sqf`
+
+We may want to re-implement this ^ later as some sort of support task.
+=========================================================================================
+*/
+
 vehicles_nva_helis = ["vn_o_air_mi2_01_01"];
 vehicles_nva_planes = [];
 vehicles_vc_mortars = ["vn_o_vc_static_mortar_type63"];
 
+/*
+=========================================================================================
+vars: `crates`
+=========================================================================================
+TODO: Only used by dead code (currently)
+
+    - `fn_task_sec_destroy_supplies.sqf`
+    - `fn_task_sec_destroy_emplacement.sqf`
+    - `fn_task_sec_destroy_mortar.sqf`
+
+We may want to re-implement these ^ later as some sort of support task.
+=========================================================================================
+*/
+
 pavn_ammo_crate = "Land_vn_pavn_weapons_stack2";
 aa_emplacement_build_crate = "Land_vn_pavn_weapons_stack3";
+
+/*
+=========================================================================================
+vars: `mines`
+=========================================================================================
+TODO: Only used by dead code (currently) -- `fn_task_sec_clear_minefield.sqf`
+
+We may want to re-implement this ^ later as some sort of support task.
+=========================================================================================
+*/
 
 jungleTraps = [
     "vn_mine_punji_01",
@@ -280,40 +580,159 @@ friendlyATMines = [
     "vn_mine_m15"
 ];
 
+/*
+=========================================================================================
+init: `vn_mf_fnc_stats_init`
+=========================================================================================
+Initialises
+
+    - `player_health_stats` -- tracks things like hunger, thirst and any ailments in a
+    paradigm scheduler job
+
+    - `taskCompleted` event handler -- tracking how many tasks a player has completed of
+    a specific type (used for player medals etc).
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising stats";
 [] call vn_mf_fnc_stats_init;
 
-//Set date here - it's as good a place as any. Day is just before a full moon, for good night ops.
+/*
+=========================================================================================
+init: `para_s_fnc_day_night_subsystem_init`
+=========================================================================================
+Set up the day/night cycle.
+
+Set date here - it's as good a place as any. Day is just before a full moon, for good
+night ops.
+=========================================================================================
+*/
+
 [vn_mf_dawnLength, vn_mf_dayLength, vn_mf_duskLength, vn_mf_nightLength] call para_s_fnc_day_night_subsystem_init;
 
+/*
+=========================================================================================
+init: `para_s_fnc_loadbal_subsystem_init`
+=========================================================================================
+Aggregates headless client FPSes into weighted arrays for use in the load AI balancer.
+
+Essentially makes the game put new Paradigm AI groups on the Headless Client with the
+highest average FPS (lowest current load).
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Loadbalancer";
-//Initialise the AI loadbalancer.
 [] call para_s_fnc_loadbal_subsystem_init;
 
+/*
+=========================================================================================
+init: `para_s_fnc_ai_obj_subsystem_init`
+=========================================================================================
+Start the Paradigm AI objective system. Depends on the load balancer subsystem.
+
+Manages the various AI objectives for assigned units like: attack a position, defend a
+position, set up ambush at position, patrol around a position(s) and pursue specific
+player targets (tracker teams).
+=========================================================================================
+*/
 
 diag_log "VN MikeForce: Initialising AI Objectives";
-// start ai subsystem. Depends on the load balancer subsystem.
 [
     ["hardAiLimit", ["hard_ai_limit", 100] call BIS_fnc_getParamValue]
 ] call para_s_fnc_ai_obj_subsystem_init;
 
+/*
+=========================================================================================
+init: `para_s_fnc_harass_subsystem_init`
+=========================================================================================
+Start harassment subsystem. Depends on the AI subsystem.
+
+'Harassment' AI are the 'tracker teams' which dynamically spawn to chase down players and
+make the mission feel a bit more alive veruss the standard -- 'go here, get in fight, go
+there, get in another fight' gameplay loop.
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Harass";
-// Start harassment subsystem. Depends on the AI subsystem.
 [] call para_s_fnc_harass_subsystem_init;
 
+/*
+=========================================================================================
+init: `vn_mf_fnc_veh_asset_subsystem_init`
+=========================================================================================
+Start vehicle asset management subsystem. Sets up some public server-side variables and
+stats the `vehicle_asset_manager` paradigm job for processing spawner behaviour.
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Vehicle Manager";
-// start vehicle asset management subsystem
 [] call vn_mf_fnc_veh_asset_subsystem_init;
 
+/*
+=========================================================================================
+init: `vn_mf_fnc_veh_create_detection_subsystem_init`
+=========================================================================================
+Start vehicle creation detection subsystem. TL;DR: Fires the `vehicleCreated` paradigm
+event.
+
+TODO: Not sure what this is used for? Do we actually need this? Seems to be Dead Code?
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Vehicle Creation Detection";
-// start vehicle creation detection subsystem
 [] call vn_mf_fnc_veh_create_detection_subsystem_init;
 
+/*
+=========================================================================================
+init: `para_g_fnc_ai_behaviour_subsystem_init`
+=========================================================================================
+TL;DR -- this is the heart of how Mike Force AI units 'do stuff'.
+
+Start the AI behaviour subsystem. AI behaviour determines various group level settings
+for AI based on what is currently happening in the field.
+
+The objectives sets the base behaviour as 'orders'. So a 'patrol' objective will assign
+the objective's AI groups the 'patrol' behaviour, making the AI groups walk from one
+point to another, to another, etc.
+
+During the course of running through the behaviour loop, AI groups can break out into
+other behaviours, like moving from 'patrol' to 'attack' when they realise players are
+nearby. The AI groups will run towards and start attacking the players, ignoring the
+previous 'patrol' orders.
+
+Other things this system does:
+
+    - sets the groups speed, stance, awareness, etc. etc.
+
+    - Pass messages between different AI groups about whether they're in combat or not
+    (not-in-combat-yet AI groups can head off to investigate)
+
+    - An extension of the above -- if the AI are in a mortar, they'll start sending
+    rounds to the approximate position where the players were reported.
+
+    - 'hold' logic for 'defend' AI objectives -- once the AI groups get bored of standing
+    around at their objective to defned they will start patrolling around the location in
+    a circle.
+
+    - Tracks whether there are nearby statics that an AI unit could get into, and makes
+    them get into the static weapons.
+
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising AI Behaviour";
-// start the behaviour subsystem
 [] call para_g_fnc_ai_behaviour_subsystem_init;
 
-//Set up slingloaded item locality on helicopters.
+/*
+=========================================================================================
+run: `para_g_fnc_localize_slingloaded_objects` event handler
+=========================================================================================
+Sets up slingloaded item locality on helicopters.
+
+I have no idea about sling loading. I'm a Spike Team main baby.
+=========================================================================================
+*/
+
 ["vehicleCreated", [
     {
         params ["_args", "_vehicle"];
@@ -323,31 +742,136 @@ diag_log "VN MikeForce: Initialising AI Behaviour";
     []
 ]] call para_g_fnc_event_add_handler;
 
+/*
+=========================================================================================
+init: `vn_mf_fnc_zones_init`
+=========================================================================================
+Initialise the zones in the world.
+
+1. Sets up the public server variables for tracking the state of zones.
+
+2. Sets the map markers for zones to appropriate color / brush (and adds the paradigm
+map thing, sorry I can't remember the name of it right now).
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Zones";
-// Initialise the zones
 [] call vn_mf_fnc_zones_init;
 
+/*
+=========================================================================================
+init: `vn_mf_fnc_sites_object_zfixer_init`
+=========================================================================================
+Stop objects created by the sites system from falling under terrain.
+
+There are a variety of cases whereby objects spawned in, often with the sites system,
+will fall through the world and be inaccessible to players.
+
+This is a bit of a problem when the zone requires these objects be to be destroyed by
+players to move to a new primary task. Basically... it creates a soft locked zone.
+
+This is **especially** problematic when an Arty site spawns in on a rice paddy etc.
+Even if the terrain objects are cleared away, apparently the terrain is actually lowered
+by -0.1m or something, meaning mortars just drop through the world, falling forever and
+never actually being destroyed.
+
+So this system basically trackers all objects spawned in by the 'sites' system and checks
+whether their ATL position's z-coordinate is less than 0.1. If it is, raise the object up
+to a z-coord of 0.1.
+
+It runs every 3 minutes to make sure we avoid the case where things are popping up in
+front of players constantly.
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Sites Object Z-Fixer";
-// stop mortars etc. falling under terrain
 [] call vn_mf_fnc_sites_object_zfixer_init;
 
+/*
+=========================================================================================
+init: `vn_mf_fnc_sites_init`
+=========================================================================================
+Initialise sites - depends on `vn_mf_fnc_zones_init` and the paradigm AI objective
+system. Probably a good idea to have the `sites_zfixer` system set up, but it's not a
+hard requirement.
+
+Starts the site system. Does not actually SPAWN the sites. Just starts the system which
+will allow us to create sites with their compositions and then track their status over
+time.
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Sites";
-// Initialise sites - must be done after zones.
 [] call vn_mf_fnc_sites_init;
 
+/*
+=========================================================================================
+init: `vn_mf_fnc_director_init`
+=========================================================================================
+Initialise the gameplay director - depends on `vn_mf_fnc_zones_init`
+
+This is the heart of the main gameplay logic controlling what happens in zones and which
+*tasks* are created when for each zone.
+
+i.e. it triggers the `prepare_zone`, `capture_zone` and `defend_counterattack` tasks for
+a zone in a specific way according to the state of the current zone.
+
+Also triggers the next zone when a zone is completed (or picks the first zone if nothing
+has been completed e.g. post server restart).
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Gameplay Director";
-// Initialise the gameplay director
 [] call vn_mf_fnc_director_init;
+
+/*
+=========================================================================================
+init: `vn_mf_fnc_arsenal_safe_zones_init`
+=========================================================================================
+Arsenal safe zones stop players from shooting each other at the arsenals.
+
+Bullets get deleted within a 50m (?) radius of the relevant arsenals and a notification
+sent to the player shooting to stop being a troll.
+=========================================================================================
+*/
 
 diag_log "VN MikeForce: Initialising Safe Zones";
 [] call vn_mf_fnc_arsenal_safe_zones_init;
 
+/*
+=========================================================================================
+job: `veh_asset_respawner_job`
+=========================================================================================
+Initialise the vehicle respawner job. Handles vehicles being respawned on a vehicle spawn
+point.
+
+Depends on the `veh_asset_manager` job (no vehicles will spawn if it was not running).
+=========================================================================================
+*/
+
 diag_log "VN MikeForce: Initialising Respawn Scheduler";
-// Initialise respawn job
 ["veh_asset_respawner_job", {call vn_mf_fnc_veh_asset_respawn_job}, [], 1] call para_g_fnc_scheduler_add_job;
+
+/*
+=========================================================================================
+init: `vn_mf_fnc_init_performance_logging`
+=========================================================================================
+Initialises server side performance logging jobs for tracking server load, AI counts, AI
+objectives etc.
+=========================================================================================
+*/
 
 diag_log "VN MikeForce: Initialising Performance Logging";
 [] call vn_mf_fnc_init_performance_logging;
+
+/*
+=========================================================================================
+init: `para_c_fnc_dynamicGroups`
+=========================================================================================
+Sets up the paradigm dynamic groups system, which allows palyers to create and join
+custom in-game groups.
+=========================================================================================
+*/
 
 diag_log "VN MikeForce: Initialising Dynamic Groups";
 ["Initialize"] call para_c_fnc_dynamicGroups;


### PR DESCRIPTION
Minor maintenance update

- Add a bunch of documentation comments to `para_server_init.sqf` to explain each specific thing in the script
- Reduce how often `saveProfileNamespace` is called to avoid frequent disk writes (had to create a separate scheduler job)
- Remove duplicated AI headless client load balancer job
- Disable the zones manager job -- now redundant
- switch `sysmsg`s  to be a `remoteExecCall` with `-2` id instead of a `forEach allPlayers`
- reduce amount of sysmessages for helper messages -- some are out of date, not important, and also a bit concerned the large array was causing job slowdowns.