### PR TITLE
TaskRoster: Fixup: Delete local map marker on page unload.

### DIFF
--- a/mission/config/ui/taskroster/requestSupport/ui.hpp
+++ b/mission/config/ui/taskroster/requestSupport/ui.hpp
@@ -111,7 +111,7 @@ class vn_tr_disp_showRequestSupport
 	name = "vn_tr_disp_showRequestSupport";
 	//If already opened -> Recalling it -> Reloading the Dialog (e.g. like updating the view, without "closing" it)
 	onLoad = "[""onLoad"",_this,""vn_tr_disp_showRequestSupport"",''] call 	(uinamespace getvariable 'BIS_fnc_initDisplay'); call vn_mf_fnc_tr_supportTask_show;";
-	onUnload = "[""onUnload"",_this,""vn_tr_disp_showRequestSupport"",''] call 	(uinamespace getvariable 'BIS_fnc_initDisplay');";
+	onUnload = "[""onUnload"",_this,""vn_tr_disp_showRequestSupport"",''] call 	(uinamespace getvariable 'BIS_fnc_initDisplay'); call vn_mf_fnc_tr_supportTask_map_hide;";
 	idd = -1;
 	movingEnable = 1;
 	enableSimulation = 1;


### PR DESCRIPTION
Put down a task map marker

![image](https://github.com/user-attachments/assets/7b14718f-ca0d-4fc6-ad46-babc81d9f2df)

Stays on map if closing the task roster without clearing the map

![image](https://github.com/user-attachments/assets/027f33bb-723a-4d02-be49-d5d97678e6f7)
