### PR TITLE
TaskRoster: Multiple fixups.

### DIFF
--- a/mission/config/subconfigs/tasks/support/greenhornets/tasks.hpp
+++ b/mission/config/subconfigs/tasks/support/greenhornets/tasks.hpp
@@ -7,7 +7,22 @@ class support_gh_cas : support_task
 	tasktype = "attack";
 	taskimage = "vn\missions_f_vietnam\data\img\mikeforce\s\vn_ui_mf_task_gh3.jpg";
 	taskgroups[] = {"GreenHornets", "Muskets", "SatansAngels"};
-	requestgroups[] = {"MACV", "ACAV", "MikeForce", "SpikeTeam", "MilitaryPolice", "3rdMEU", "SASR", "QuarterHorse", "Frogmen", "Montagnard", "7thCav", "TigerForce", "633rdCSG"};
+	requestgroups[] = {
+		"MACV",
+		"ACAV",
+		"ARVN",
+		"MikeForce",
+		"SpikeTeam",
+		"MilitaryPolice",
+		"3rdMEU",
+		"SASR",
+		"QuarterHorse",
+		"Frogmen",
+		"Montagnard",
+		"7thCAV",
+		"TigerForce",
+		"633rdCSG"
+	};
 	rankpoints = 10;
 	taskprogress = 0;
 

--- a/mission/config/subconfigs/tasks/support/spiketeam/tasks.hpp
+++ b/mission/config/subconfigs/tasks/support/spiketeam/tasks.hpp
@@ -57,7 +57,21 @@ class support_st_searchAndDestroy : support_task
 	taskdesc = "%1 has requested you destroy the gun emplacements at this position.";
 	tasktype = "box";
 	taskgroups[] = {"SpikeTeam", "SASR", "Frogmen", "TigerForce"};
-	requestgroups[] = {"MACV", "ACAV", "MikeForce", "MilitaryPolice", "3rdMEU",  "QuarterHorse", "Frogmen",  "7thCav", "633rdCSG", "GreenHornets", "Muskets", "SatansAngels"};
+	requestgroups[] = {
+		"MACV",
+		"ARVN",
+		"ACAV",
+		"MikeForce",
+		"MilitaryPolice",
+		"3rdMEU",
+		"QuarterHorse",
+		"Frogmen",
+		"7thCAV",
+		"633rdCSG",
+		"GreenHornets",
+		"Muskets",
+		"SatansAngels"
+	};
 	rankpoints = 10;
 	taskprogress = 0;
 

--- a/mission/config/subconfigs/tasks/support/tasks.hpp
+++ b/mission/config/subconfigs/tasks/support/tasks.hpp
@@ -13,13 +13,14 @@ class support_resupply : support_task
 	};
 	requestgroups[] = {
 		"MACV",
+		"ARVN",
 		"MikeForce",
 		"3rdMEU",
 		"633rdCSG",
 		"MilitaryPolice",
 		"ACAV",
 		"QuarterHorse",
-		"7thCav",
+		"7thCAV",
 		"SpikeTeam",
 		"SASR",
 		"TigerForce",
@@ -118,13 +119,14 @@ class support_transport : support_task
 	taskgroups[] = {"GreenHornets"};
 	requestgroups[] = {
 		"MACV",
+		"ARVN",
 		"MikeForce",
 		"3rdMEU",
 		"633rdCSG",
 		"MilitaryPolice",
 		"ACAV",
 		"QuarterHorse",
-		"7thCav",
+		"7thCAV",
 		"SpikeTeam",
 		"SASR",
 		"TigerForce",

--- a/mission/config/ui/taskroster/main/ui.hpp
+++ b/mission/config/ui/taskroster/main/ui.hpp
@@ -16,7 +16,7 @@ class vn_tr_disp_taskRoster_main_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 		{
 			idc = -1;
 			x = UIW(1.75);
-			y = UIH(2.5);
+			y = UIH(2.25);
 			w = UIW(8);
 			h = UIH(4.5);
 
@@ -27,26 +27,29 @@ class vn_tr_disp_taskRoster_main_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 		{
 			idc = -1;
 			x = UIW(9.75);
-			y = UIH(2.5);
+			y = UIH(2.25);
 			w = UIW(8);
 			h = UIH(4.5);
 
 			text = "custom\billboards\BN_Welcome_20240621.paa";
 		};
 
+		#define HEIGHT_NEW_ROW_BY_NUMB(N)\
+			y = UIH((7.25 + (N * 2.25)));
+
 		class lhs_server_rules: vn_mf_RscStructuredText
 		{
 			idc = -1;
 			style = "0x10";
 			x = UIW(2);
-			y = UIH(8);
+			HEIGHT_NEW_ROW_BY_NUMB(0)
 			w = UIW(16);
-			h = UIH(2);
+			h = UIH(2.25);
 
 			colorText[] = {0,0,0,1};
 			colorBackground[] = {0,0,0,0};
 			size = TXT_M;
-			text = "<t font='tt2020base_vn_bold'>Server Rules</t>: <a href='https://discord.com/channels/494435095168548866/884580184223797308'>Click here</a> to see current in-game server rules on Discord.";
+			text = "<t font='tt2020base_vn_bold'>Server Rules</t>: <a href='https://discord.com/channels/494435095168548866/884580184223797308'>Click here</a> to see game server rules on Discord.";
 			class Attributes
 			{
 				align = "left";
@@ -60,28 +63,33 @@ class vn_tr_disp_taskRoster_main_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 
 		class lhs_ban_policy_text: lhs_server_rules
 		{
-			y = UIH(10);
+			HEIGHT_NEW_ROW_BY_NUMB(1)
 			text = "<t font='tt2020base_vn_bold'>Ban Policy</t>: <a href='https://discord.com/channels/494435095168548866/972772268478459914'>Click here</a> to see Ban Policy in Discord.";
 		};
 		class lhs_playerreports_text: lhs_server_rules
 		{
-			y = UIH(12);
-			text = "<t font='tt2020base_vn_bold'>Player Reports</t>: <a href='https://discord.com/channels/494435095168548866/1079496263713702018'>Click here</a> to report a team killer / troll / griefer in Discord.";
+			HEIGHT_NEW_ROW_BY_NUMB(2)
+			text = "<t font='tt2020base_vn_bold'>Player Reports</t>: <a href='https://discord.com/channels/494435095168548866/1079496263713702018'>Click here</a> to report bad behaviour in Discord.";
 		};
 		class lhs_bugreports_text: lhs_server_rules
 		{
-			y = UIH(14);
+			HEIGHT_NEW_ROW_BY_NUMB(3)
 			text = "<t font='tt2020base_vn_bold'>Bug Reports</t>: <a href='https://discord.com/channels/494435095168548866/1079495163958792212'>Click here</a> to report game bugs in Discord.";
 		};
 		class lhs_applywlu_text: lhs_server_rules
 		{
-			y = UIH(16);
+			HEIGHT_NEW_ROW_BY_NUMB(4)
 			text = "<t font='tt2020base_vn_bold'>Unit Applications</t>: <a href='https://discord.com/channels/494435095168548866/1245947819790041138'>Click here</a> to apply to whitelisted units in Discord.";
 		};
 		class lhs_training_text: lhs_server_rules
 		{
-			y = UIH(18);
-			text = "<t font='tt2020base_vn_bold'>Training</t>: <a href='https://discord.com/channels/494435095168548866/1246522786063712316'>Click here</a> if you would like to take part in some optional training with one of our instructors.";
+			HEIGHT_NEW_ROW_BY_NUMB(5)
+			text = "<t font='tt2020base_vn_bold'>Training</t>: <a href='https://discord.com/channels/494435095168548866/1246522786063712316'>Click here</a> to join some optional training sessions.";
+		};
+		class lhs_patreon_text: lhs_server_rules
+		{
+			HEIGHT_NEW_ROW_BY_NUMB(6)
+			text = "<t font='tt2020base_vn_bold'>Patreon</t>: <a href='https://discord.com/channels/494435095168548866/783785538167373875'>Click here</a> to support the server on Patreon.";
 		};
 	};
 };
@@ -160,7 +168,7 @@ class vn_tr_disp_taskRoster_Main
 			colorBackground[] = {0,0,0,0};
 			size = TXT_M;
 			
-			text = "Mike Force is a co-operative PvE gamemode by <t font='tt2020base_vn_bold'><a href='https://www.savage-game.com'>Savage Game Design</a></t>. This is a modified version of Mike Force brought to you by <t font='tt2020base_vn_bold'><a href='https://discord.gg/bro-nation'>Bro-Nation</a></t>.<br/><br/>This menu can be accessed at any time by pressing the H key.<br/><br/>We recommend new players read our 'Server Guide' by clicking on the button below!<br/><br/>Please join the <t font='tt2020base_vn_bold'><a href='https://discord.gg/bro-nation'>Bro-Nation Discord</a></t> for additional help, or click on the links on the opposite page.";
+			text = "Mike Force is a co-operative PvE gamemode by <t font='tt2020base_vn_bold'><a href='https://www.savage-game.com'>Savage Game Design</a></t>. This is a modified version of Mike Force brought to you by <t font='tt2020base_vn_bold'><a href='https://discord.gg/bro-nation'>Bro-Nation</a></t>.<br/><br/>This menu can be toggled to open/close at any time by pressing the H key.<br/><br/>We recommend new players read our 'Server Guide' by clicking on the button below!<br/><br/>Please join the <t font='tt2020base_vn_bold'><a href='https://discord.gg/bro-nation'>Bro-Nation Discord</a></t> for additional help, or click on the links on the opposite page.";
 			class Attributes
 			{
 				align = "left";

--- a/mission/config/ui/taskroster/newPlayerGuide/ui.hpp
+++ b/mission/config/ui/taskroster/newPlayerGuide/ui.hpp
@@ -26,13 +26,21 @@ class vn_tr_disp_showNewPlayerGuide_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 			tooltip = "";
 		};
 
+
+		#define RHS_IMAGE_Y_FROM_NUMB(N) \
+			UIH((4 + (6 * N)))
+
+		#define RHS_CAPTION_Y_FROM_NUMB(N) \
+			UIH((4 - 0.75 + (6 * N)))
+
+
 		// ARSENAL //////////////////////////////////////////////////////////////////////
 
 		class rhs_img_arsenal: vn_mf_RscPicture
 		{
 			idc = -1;
 			x = UIW(13);
-			y = UIH(4.25);
+			y = RHS_IMAGE_Y_FROM_NUMB(0);
 			w = UIW(5);
 			h = UIH(5);
 			text = "custom\taskroster\help\img_newplayer_arsenal.paa";
@@ -43,9 +51,9 @@ class vn_tr_disp_showNewPlayerGuide_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 		{
 			idc = -1;
 			x = UIW(2);
-			y = UIH(4.25);
+			y = RHS_IMAGE_Y_FROM_NUMB(0);
 			w = UIW(11.25);
-			h = UIH(5);
+			h = UIH(6);
 
 			colorText[] = {0.1,0.1,0.1,0.9};
 			colorBackground[] = {0,0,0,0.0};
@@ -55,7 +63,7 @@ class vn_tr_disp_showNewPlayerGuide_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 			class Attributes
 			{
 				align = "left";
-				valign = "middle";
+				valign = "top";
 				color = "#000000";
 				colorLink = "#D09B43";
 				font = USEDFONT;
@@ -67,10 +75,11 @@ class vn_tr_disp_showNewPlayerGuide_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 		class rhs_img_arsenal_caption: vn_mf_RscText
 		{
 			idc = -1;
-			x = UIW(14);
-			y = UIH(3.5);
+			x = UIW(12.75);
+			y = RHS_CAPTION_Y_FROM_NUMB(0);
 			w = UIW(5);
 			h = UIH(1);
+			font = USEDFONT_B;
 			sizeEx = TXT_S;
 			colorText[] = {0, 0, 0, 1};
 			text = "Arsenal";
@@ -78,56 +87,44 @@ class vn_tr_disp_showNewPlayerGuide_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 
 		// TELEPORTER ///////////////////////////////////////////////////////////////////
 
-		class rhs_img_teleporter: vn_mf_RscPicture
+		class rhs_img_teleporter: rhs_img_arsenal
 		{
-			idc = -1;
-			x = UIW(13);
-			y = UIH(10);
-			w = UIW(5);
-			h = UIH(5);
-
+			y = RHS_IMAGE_Y_FROM_NUMB(1);
 			text = "custom\taskroster\help\img_newplayer_map.paa";
 			tooltip = "A Teleporter Map Board.";
 		};
 
 		class rhs_img_teleporter_caption: rhs_img_arsenal_caption
 		{
-			x = UIW(13.5);
-			y = UIH(9.2);
+			y = RHS_CAPTION_Y_FROM_NUMB(1);
 			text = "Teleporter";
 		};
         
         class rhs_helptext_teleporter: rhs_helptext_arsenal
         {
-            y = UIH(11.25);
+			y = RHS_IMAGE_Y_FROM_NUMB(1);
             text = "This is a Map Board, use these to quickly teleport to numerous locations on base. Use the 6 key to interact with it.";
         };
 
      	// HELO PADS ////////////////////////////////////////////////////////////////////
 
-		class rhs_img_helopads: vn_mf_RscPicture
+		class rhs_img_helopads: rhs_img_arsenal
 		{
-			idc = -1;
-			x = UIW(13);
-			y = UIH(15.75);
-			w = UIW(5);
-			h = UIH(5);
-
+			y = RHS_IMAGE_Y_FROM_NUMB(2);
 			text = "custom\taskroster\help\img_newplayer_pads.paa";
 			tooltip = "Pick up location.";
 		};
 
 		class rhs_img_helopads_caption: rhs_img_arsenal_caption
 		{
-			x = UIW(13.5);
-			y = UIH(15);
+			y = RHS_CAPTION_Y_FROM_NUMB(2);
 			text = "Helo Pickup";
 		};
 	    
 	    class rhs_helptext_helopads: rhs_helptext_arsenal
         {
-            y = UIH(16.5);
-            text = "These are the helo pick-up pads, near Green Hornets. Switch to the Air Channel with the period key and hail a Green Hornet pilot to get yourself into the fight!";
+			y = RHS_IMAGE_Y_FROM_NUMB(2);
+            text = "These are the helo pick-up pads, near Green Hornets. Switch to the Air Channel with the period key and ask a Green Hornet pilot to get you into the fight!";
         };
 	};
 };
@@ -181,15 +178,23 @@ class vn_tr_disp_showNewPlayerGuide
 			sizeEx = TXT_L;
 		};
 
+		#define LHS_IMAGE_Y_FROM_NUMB(N) \
+			UIY_CU((8.25 - (6 * N)))
+
+		#define LHS_CAPTION_Y_FROM_NUMB(N) \
+			UIY_CU((8.25 + 0.75 - (6 * N)))
+
      	// ZONES ////////////////////////////////////////////////////////////////////////
 
 		class rhs_img_zones: vn_mf_RscPicture
 		{
 			idc = -1;
-			x = UIW(-1);
-			y = UIH(4.75);
+
+			x = UIX_CL(17.5);
+			y = LHS_IMAGE_Y_FROM_NUMB(0);
 			w = UIW(5);
 			h = UIH(5);
+
 			text = "custom\taskroster\help\img_newplayer_zone.paa";
 			tooltip = "Zones to be taken.";
 		};
@@ -197,10 +202,11 @@ class vn_tr_disp_showNewPlayerGuide
 		class rhs_img_zones_caption: vn_mf_RscText
 		{
 			idc = -1;
-			x = UIW(-0.75);
-			y = UIH(4);
-			w = UIW(5);
-			h = UIH(1);
+
+			x = UIX_CL(17.75);
+			y = LHS_CAPTION_Y_FROM_NUMB(0);
+
+			font = USEDFONT_B;
 			sizeEx = TXT_S;
 			colorText[] = {0, 0, 0, 1};
 			text = "Combat Zones";
@@ -209,20 +215,21 @@ class vn_tr_disp_showNewPlayerGuide
 		class rhs_helptext_zones: vn_mf_RscStructuredText
 		{
 			idc = -1;
-			x = UIW(4);
-			y = UIH(4.75);
+
+			x = UIX_CL(12.5);
+			y = LHS_IMAGE_Y_FROM_NUMB(0);
 			w = UIW(11.5);
 			h = UIH(5);
 
 			colorText[] = {0.1,0.1,0.1,0.9};
 			colorBackground[] = {0,0,0,0.0};
-			text = "These are the areas on the map to take. Do not enter blue zones. Yellow circled zones are the active ao. When all sites are destroyed inside the zone the defence phase starts. Green zones are completed.";
+			text = "Zones are where the action happens. Active zones are marked by task markers. Green zones are completed. Do not enter blue zones. Destroy all sites in active red zones. Defend yellow zones from counterattack. ";
 			size = UIH(0.69);
 			tooltip = "";
 			class Attributes
 			{
 				align = "left";
-				valign = "middle";
+				valign = "top";
 				color = "#000000";
 				colorLink = "#D09B43";
 				font = USEDFONT;
@@ -233,13 +240,9 @@ class vn_tr_disp_showNewPlayerGuide
 
      	// MAP LEGEND ///////////////////////////////////////////////////////////////////
 
-		class rhs_img_legend: vn_mf_RscPicture
+		class rhs_img_legend: rhs_img_zones
 		{
-			idc = -1;
-			x = UIW(-1);
-			y = UIH(10.5);
-			w = UIW(5);
-			h = UIH(5);
+			y = LHS_IMAGE_Y_FROM_NUMB(1);
 
 			text = "custom\taskroster\help\img_newplayer_legend.paa";
 			tooltip = "Map Legend.";
@@ -247,28 +250,22 @@ class vn_tr_disp_showNewPlayerGuide
 
 		class rhs_img_legend_caption: rhs_img_zones_caption
 		{
-			x = UIW(-0.60);
-			y = UIH(9.7);
+			y = LHS_CAPTION_Y_FROM_NUMB(1);
 			w = UIW(5);
-			h = UIH(1);
 			text = "Map Legend";
 		};
 
         class rhs_helptext_zones_legend: rhs_helptext_zones
         {
-            y = UIH(11);
+			y = LHS_IMAGE_Y_FROM_NUMB(1);
             text = "This is a map legend and can usually be found somewhere on the map. Use this to help navigate yourself around the base and the rest of the map.";
         };
 
 		// CAS IS WHITELISTED PLEASE STOP ASKING ////////////////////////////////////////
 
-		class rhs_img_cas: vn_mf_RscPicture
+		class rhs_img_cas: rhs_img_zones
 		{
-			idc = -1;
-			x = UIW(-1);
-			y = UIH(16.25);
-			w = UIW(5);
-			h = UIH(5);
+			y = LHS_IMAGE_Y_FROM_NUMB(2);
 
 			text = "custom\taskroster\help\img_newplayer_cas.paa";
 			tooltip = "CAS is whitelisted.";
@@ -276,16 +273,13 @@ class vn_tr_disp_showNewPlayerGuide
 
 		class rhs_img_cas_caption: rhs_img_zones_caption
 		{
-			x = UIW(-0.75);
-			y = UIH(15.5);
-			w = UIW(5);
-			h = UIH(1);
+			y = LHS_CAPTION_Y_FROM_NUMB(2);
 			text = "CAS and Arty";
 		};
      
         class rhs_helptext_cas: rhs_helptext_zones
         {
-            y = UIH(16.50);
+			y = LHS_IMAGE_Y_FROM_NUMB(2);
             text = "CAS and heavy artilley are whitelisted, this is to prevent misuse and abuse of these powerful assets to improve all players experience. Enquire in Discord for how to join.";
         };
 		

--- a/mission/config/ui/taskroster/playerInfo/ui.hpp
+++ b/mission/config/ui/taskroster/playerInfo/ui.hpp
@@ -121,7 +121,7 @@ class vn_tr_disp_showPlayerInfo_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 
 			colorText[] = {0.1,0.1,0.1,0.9};
 			colorBackground[] = {0,0,0,0.0};
-			text = "Walk up to a duty officer and press the 6 key while looking at them. This will bring up a wheel menu where you can click on the role(s) you want. Duty officers can be located by the white dot markers on the map around the main base.";
+			text = "Find a duty officer. Duty officers are shown on map by white dots (press 'M' key). Press the 6 key while looking directly at a Duty Officer. The 'roles' menu will show. Click on the role you want.";
 			size = UIH(0.69);
 			tooltip = "";
 			class Attributes
@@ -233,8 +233,8 @@ class vn_tr_disp_showPlayerInfo
 		class infostats_title: vn_mf_RscText
 		{
 			idc = -1;
-			x = UIW(0);
-			y = UIH(2);
+			x = UIX_CL(17.5);
+			y = UIY_CU(10.5);
 			w = UIW(15);
 			h = UIH(2);
 
@@ -250,8 +250,8 @@ class vn_tr_disp_showPlayerInfo
 		class infostats_txt_playername: vn_mf_RscStructuredText
 		{
 			idc = VN_TR_PLAYERINFO_NAME_IDC;
-			x = UIW(0);
-			y = UIH(4);
+			x = UIX_CL(17.5);
+			y = UIY_CU(8.5);
 			w = UIW(15);
 			h = UIH(0.8);
 
@@ -276,35 +276,35 @@ class vn_tr_disp_showPlayerInfo
 		class infostats_txt_serialnumber: infostats_txt_playername
 		{
 			idc = VN_TR_PLAYERINFO_SNUM_IDC;
-			y = UIH(5);
+			y = UIY_CU(7.5);
 			text = "serialnumber";
 			tooltip = "Serial Number";
 		};
 		class infostats_txt_playeruid: infostats_txt_playername
 		{
 			idc = VN_TR_PLAYERINFO_UID_IDC;
-			y = UIH(6);
+			y = UIY_CU(6.5);
 			text = "playeruid";
 			tooltip = "Player UID";
 		};
 		class infostats_txt_playerrank: infostats_txt_playername
 		{
 			idc = VN_TR_PLAYERINFO_RANK_IDC;
-			y = UIH(7);
+			y = UIY_CU(5.5);
 			text = "playerrank";
 			tooltip = "Player Rank";
 		};
 		class infostats_txt_rankpoints: infostats_txt_playername
 		{
 			idc = VN_TR_PLAYERINFO_POINTS_IDC;
-			y = UIH(8);
+			y = UIY_CU(4.5);
 			text = "-1";
 			tooltip = "Rank Points";
 		};
 		class infostats_txt_rankprogress: infostats_txt_playername
 		{
 			idc = VN_TR_PLAYERINFO_PROGR_IDC;
-			y = UIH(9);
+			y = UIY_CU(3.5);
 			text = "-1";
 			tooltip = "Rank Progress";
 		};
@@ -312,8 +312,8 @@ class vn_tr_disp_showPlayerInfo
 		class infostats_subtitle_medals: vn_mf_RscText
 		{
 			idc = -1;
-			x = UIW(0);
-			y = UIH(11);
+			x = UIX_CL(17.5);
+			y = UIY_CU(2);
 			w = UIW(15);
 			h = UIH(2);
 
@@ -326,9 +326,36 @@ class vn_tr_disp_showPlayerInfo
 			sizeEx = TXT_L;
 		};
 
+		class infostats_helptext_medals: vn_mf_RscStructuredText
+		{
+			idc = -1;
+			x = UIX_CL(17.5);
+			y = UIY_CU(0.5);
+			w = UIW(17);
+			h = UIH(2);
+
+			colorText[] = {0.1,0.1,0.1,0.9};
+			colorBackground[] = {0,0,0,0.0};
+			text = "Medals are earned by completing certain actions in game.";
+			size = UIH(0.69);
+			tooltip = "";
+			class Attributes
+			{
+				align = "left";
+				valign = "middle";
+				color = "#000000";
+				colorLink = "#D09B43";
+				font = USEDFONT;
+				size = 1;
+				shadow = 0;
+			};
+		};
+
+		// this is displaying elements backwards on the X axis.
+		// but it works for now, so it's staying that way.
 		#define RIBBON_POS(X, Y) \
-			x = UIW((((2 + 0.25) * X))); \
-			y = UIH((13 + (((2/3.3333) + 0.25) * Y))); \
+			x = UIX_CL(-3.5 + (((2 + 0.25) * X)) ); \
+			y = UIY_CU(1.5-(((2/3.3333) + 0.25) * Y)); \
 			w = UIW(2); \
 			h = UIH((2/3.3333));
 
@@ -490,8 +517,8 @@ class vn_tr_disp_showPlayerInfo
 		{
 			idc = VN_TR_PLAYERINFO_MEDAL_RIBBON_IDC;
 
-			x = UIW(0.75);
-			y = UIH(18);
+			x = UIX_CL(14.25);
+			y = UIY_CU(-6);
 			w = UIW(1.2);
 			h = UIH(2.5);
 
@@ -506,15 +533,15 @@ class vn_tr_disp_showPlayerInfo
 		{
 			idc = VN_TR_PLAYERINFO_REWARD_TEXT_IDC;
 
-			x = UIW(2.5);
-			y = UIH(18.5);
-			w = UIW(12.5);
+			x = UIX_CL(13);
+			y = UIY_CU(-6);
+			w = UIW(9);
 			h = UIH(3);
 
 			colorText[] = {0.1,0.1,0.1,0.9};
 			colorBackground[] = {0,0,0,0.0};
 			text = "reward";
-			size = TXT_M;
+			size = TXT_L;
 			tooltip = "";
 			class Attributes
 			{

--- a/mission/config/ui/taskroster/requestSupport/ui.hpp
+++ b/mission/config/ui/taskroster/requestSupport/ui.hpp
@@ -74,8 +74,8 @@ class vn_tr_disp_requestSupportMap_RHS : vn_mf_RscControlsGroupNoScrollbarHV
 		{
 			idc = VN_TR_SUPREQ_ACCEPT_IDC;
 
-			x = UIX_CL(4.5);
-			y = UIY_CU(-8.5);
+			x = UIW(12);
+			y = UIH(21);
 			w = UIW(6);
 			h = UIH(1.5);
 
@@ -90,8 +90,8 @@ class vn_tr_disp_requestSupportMap_RHS : vn_mf_RscControlsGroupNoScrollbarHV
 		{
 			idc = VN_TR_SUPREQ_ABORT_IDC;
 
-			x = UIX_CL(14.5);
-			y = UIY_CU(-8.5);
+			x = UIW(2);
+			y = UIH(21);
 			w = UIW(6);
 			h = UIH(1.5);
 

--- a/mission/config/ui/taskroster/tasksInfo/ui.hpp
+++ b/mission/config/ui/taskroster/tasksInfo/ui.hpp
@@ -28,8 +28,10 @@ class vn_tr_missionInfoPolaroid_base : vn_mf_RscControlsGroupNoScrollbarHV
 		class vn_tr_missionInfo_miniMap: vn_mf_RscMapControl
 		{
 			idc = VN_TR_ACTIVETASKS_RHS_MAP_IDC;
-			x = UIW(18);
-			y = UIH(17.65);
+			// x = UIW(18);
+			// y = UIH(17.65);
+			x = UIX_CR(1.5);
+			y = UIY_CU(-5.25)
 			w = UIW(9.9);
 			h = UIH(6.9);
 

--- a/mission/config/ui/taskroster/teamInfo/ui.hpp
+++ b/mission/config/ui/taskroster/teamInfo/ui.hpp
@@ -99,8 +99,8 @@ class vn_tr_disp_showTeamInfo_rhs : vn_mf_RscControlsGroupNoScrollbarHV
 		{
 			idc = VN_TR_SHOWTEAMINFO_RHS_CHANGETEAM_BUTTON_IDC;
 
-			x = UIX_CL(4.5);
-			y = UIY_CU(-8.5);
+			x = UIW(11.5);
+			y = UIH(21);
 			w = UIW(6);
 			h = UIH(1.5);
 

--- a/mission/para_player_init_client.sqf
+++ b/mission/para_player_init_client.sqf
@@ -292,6 +292,13 @@ cutText ["", "BLACK IN", 4];
 				"<t align='left'>4. Click 'OK'.</t><br/>"
 			] joinString ""
 		);
+
+		// hints do not disappear when other UI elements are open.
+		// their default 30 second timer gets paused.
+		[] spawn {
+			sleep 10;
+			hintSilent "";
+		};
 	};
 };
 


### PR DESCRIPTION
- Switch to the correct UI Co-ordinate systems for certain page elements (fixes weird element placement on different monitor scales like 4:3).
  - Active Tasks: The preview map
  - Select Team: 'CHANGE TEAM' button
  - Create Tasks: 'CLEAR MAP' and 'CONFIRM' buttons
  - Stats & Info: Entire left page
- Fix the 'Training'/ text on the welcome page being cut-off at lower resolutions.
- Add Patreon discord channel link to main welcome page.
- Add `ARVN` to the units that can call in support tasks.
- Fix `7thCav` not being able to use support tasks (should have been `7thCAV`).
- Make the medal pop-up dispaly look a bit prettier (is it prettier? I dunno).
- Make it clear the H key can be used to close the task roster in the welcome page.
- Make the hint about not showing the task roster on server join automatically disappear after 10 seconds (if UI elements are open then Arma will not time out hints and they stay open).
- Make RHS welcome page elements have more space between them vertically.
- Change various bits of text to make them clearer, shorter and clear up typos.
- Tweak some of the New Player Guide so maintainence is easier in future (row Y position macros and inheritence).