### PR TITLE
Spectator: Press Corp can enter into spectator mode with free look, 3PP and 1PP views

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -199,6 +199,7 @@ class CfgFunctions
 			class action_curator_force_reset_idle_vehicle {};
 			class action_curator_lock_spawner {};
 			class action_curator_unlock_spawner {};
+			class action_press_toggle_spectator {};
 		};
 
 		class system_actives {

--- a/mission/functions/systems/actions/fn_action_init.sqf
+++ b/mission/functions/systems/actions/fn_action_init.sqf
@@ -34,8 +34,16 @@ if (isNil "vn_mf_actions_initialized" || vn_mf_actions_player != player) then //
 	call vn_mf_fnc_action_lower_flag;
 	call vn_mf_fnc_action_reraise_flag;
 	"vn_holdActionAdd_layer" cutText ["","PLAIN"];
-	call vn_mf_fnc_action_curator_force_recover_wrecked_vehicle;
-	call vn_mf_fnc_action_curator_force_reset_idle_vehicle;
-	call vn_mf_fnc_action_curator_lock_spawner;
-	call vn_mf_fnc_action_curator_unlock_spawner;
+	// curator / admin / moderator only
+	if (missionNamespace getVariable ['curatorUIDs', []] findIf { _x == getPlayerUID player} > -1) then {
+		call vn_mf_fnc_action_curator_force_recover_wrecked_vehicle;
+		call vn_mf_fnc_action_curator_force_reset_idle_vehicle;
+		call vn_mf_fnc_action_curator_lock_spawner;
+		call vn_mf_fnc_action_curator_unlock_spawner;
+	};
+	// press corp only
+	if (player getVariable ['vn_mf_db_player_group', 'FAILED'] isEqualTo "PressCorp") then {
+		diag_log format ["ajksfhasffssasaffffffffff"];
+		call vn_mf_fnc_action_press_toggle_spectator;
+	};
 };

--- a/mission/functions/systems/actions/fn_action_init.sqf
+++ b/mission/functions/systems/actions/fn_action_init.sqf
@@ -35,15 +35,10 @@ if (isNil "vn_mf_actions_initialized" || vn_mf_actions_player != player) then //
 	call vn_mf_fnc_action_reraise_flag;
 	"vn_holdActionAdd_layer" cutText ["","PLAIN"];
 	// curator / admin / moderator only
-	if (missionNamespace getVariable ['curatorUIDs', []] findIf { _x == getPlayerUID player} > -1) then {
-		call vn_mf_fnc_action_curator_force_recover_wrecked_vehicle;
-		call vn_mf_fnc_action_curator_force_reset_idle_vehicle;
-		call vn_mf_fnc_action_curator_lock_spawner;
-		call vn_mf_fnc_action_curator_unlock_spawner;
-	};
+	call vn_mf_fnc_action_curator_force_recover_wrecked_vehicle;
+	call vn_mf_fnc_action_curator_force_reset_idle_vehicle;
+	call vn_mf_fnc_action_curator_lock_spawner;
+	call vn_mf_fnc_action_curator_unlock_spawner;
 	// press corp only
-	if (player getVariable ['vn_mf_db_player_group', 'FAILED'] isEqualTo "PressCorp") then {
-		diag_log format ["ajksfhasffssasaffffffffff"];
-		call vn_mf_fnc_action_press_toggle_spectator;
-	};
+	call vn_mf_fnc_action_press_toggle_spectator;
 };

--- a/mission/functions/systems/actions/fn_action_press_toggle_spectator.sqf
+++ b/mission/functions/systems/actions/fn_action_press_toggle_spectator.sqf
@@ -1,0 +1,90 @@
+/*
+	File: fn_action_press_toggle_spectator.sqf
+	Author: 'DJ' Dijksterhuis
+	Public: No
+	
+	Description:
+		Press Corp members can enter (and exit!) spectator mode.
+	
+	Parameter(s): none
+	
+	Returns:
+	
+	Example(s):
+		call vn_mf_fnc_action_press_toggle_spectator;
+*/
+
+// TODO: Do we grant moderators access to this instead of zeus?
+
+player addAction
+[
+	format [
+		"<t color='#0663A1' size='0.85' font='tt2020base_vn_bold'>%1</t>",
+		"[PRESS] Spectate"
+	],  // title
+	{
+		params ["_target", "_caller", "_actionId", "_arguments"];
+
+		// disable HUD to remove paradigm UI elements
+		// if `hud_enabled` is not set assume the hud is enabled
+		// (player probably hasn't used the keybind yet)
+		if (player getVariable ["hud_enabled", true]) then {
+			[] call vn_mf_fnc_ui_hud_toggle;
+		};
+
+		// hide the player and disable simulation
+		player enableSimulationGlobal false;
+		player hideObjectGlobal true;
+
+		// start the spectator mode
+		player setVariable ["vn_mf_press_close_spectator", false];
+		["Initialize", [player, [west]]] call BIS_fnc_EGSpectator;
+
+		// set up a spawn running a loop every 0.5 seconds checking whether
+		// the player wants to close the spectator interface.
+		// if so, renable simulation, renable the HUD, close spectator mode
+		// and remove the above event handler
+		[player] spawn {
+			params ["_player"];
+
+			// create an event handler that checks for the ZERO key being pressed
+			// when pressed, set a variable on the player indicating we need to close the UI
+
+			private _eh = (findDisplay 60492) displayAddEventHandler ["KeyDown", {
+				params ["_displayOrControl", "_key", "_shift", "_ctrl", "_alt"];
+				// ESCAPE key is key 1
+				if (_key isEqualTo 1) exitWith {
+					// this is using `player` on purpose!
+					// the `_player` variable does not exist in the event handler's scope!
+					player setVariable ["vn_mf_press_close_spectator", true];
+					true;
+				};
+			}];
+
+			// wait until the player has pressed the key to exit spectator mode
+			while {!(_player getVariable ["vn_mf_press_close_spectator", false])} do {
+				sleep 0.5;
+			};
+
+			// reset everything
+			_player enableSimulationGlobal true;
+			_player hideObjectGlobal false;
+			[] call vn_mf_fnc_ui_hud_toggle;
+
+			// remove the display's event handler then exit out of spectator mode
+			(findDisplay 60492) displayRemoveEventHandler ["KeyDown", _eh];
+			["Terminate"] call BIS_fnc_EGSpectator;
+
+		};
+	},  // script
+	nil,  // arguments
+	1,  // priority
+	true,  // showWindow
+	true,  // hideOnUse
+	"",  // shortcut
+	"player getVariable ['vn_mf_db_player_group', 'MikeForce'] isEqualTo 'PressCorp'",  // condition
+	1,  // radius
+	false,  // unconscious
+	"",  // selection
+	""  // memoryPoint
+];

--- a/mission/functions/systems/actions/fn_action_press_toggle_spectator.sqf
+++ b/mission/functions/systems/actions/fn_action_press_toggle_spectator.sqf
@@ -16,11 +16,16 @@
 
 // TODO: Do we grant moderators access to this instead of zeus?
 
+private _conditionToShow = [
+	"((player getVariable ['vn_mf_db_player_group', 'MikeForce']) isEqualTo 'PressCorp')",
+	"((player distance2D (getMarkerPos 'mf_respawn_presscorp')) < 25)"
+] joinString "&&";
+
 player addAction
 [
 	format [
 		"<t color='#0663A1' size='0.85' font='tt2020base_vn_bold'>%1</t>",
-		"[PRESS] Spectate"
+		"[PRESSCORP] Spectate"
 	],  // title
 	{
 		params ["_target", "_caller", "_actionId", "_arguments"];
@@ -78,11 +83,11 @@ player addAction
 		};
 	},  // script
 	nil,  // arguments
-	1,  // priority
+	-10,  // priority
 	true,  // showWindow
 	true,  // hideOnUse
 	"",  // shortcut
-	"player getVariable ['vn_mf_db_player_group', 'MikeForce'] isEqualTo 'PressCorp'",  // condition
+	_conditionToShow,
 	1,  // radius
 	false,  // unconscious
 	"",  // selection


### PR DESCRIPTION
Adds an action to press members so that they can enter into spectator mode whenever they want.

When entering spectator mode the press player character is hidden and simulation disabled (no-one can whack them with a shovel and take them away, for example).

Blufor player indicators are available in spectator mode, but not opfor.

Can use free look or enter into 3PP to follow a player, or enter in 1PP for a specific player.

## Screenshots

![20240907091415_1](https://github.com/user-attachments/assets/4a0d945c-2a10-489a-97d4-32753213d46f)
![20240907091419_1](https://github.com/user-attachments/assets/6156137a-7696-43f5-8ffb-1d88691f76ce)
![20240907091516_1](https://github.com/user-attachments/assets/4fb5e786-bac9-4f28-98d3-2a3e510aa230)
![20240907091520_1](https://github.com/user-attachments/assets/93080c08-0eca-4b0e-b126-292ee3625c42)
![20240907091521_1](https://github.com/user-attachments/assets/0cebc0a0-0aed-4bb0-9fae-d294732e3594)


