### PR TITLE
Taskroster: fixup team role limit extra counting of players.

### DIFF
--- a/mission/functions/core/ui/taskroster/teamInfo/fn_tr_teamInfo_show.sqf
+++ b/mission/functions/core/ui/taskroster/teamInfo/fn_tr_teamInfo_show.sqf
@@ -49,7 +49,9 @@ private _traitsTeam = _traitConfigs
 		private _traitIcon = getText (_traitConfig >> "icon");
 		private _traitText = (getText (_traitConfig >> "text") call para_c_fnc_localize);
 		private _traitPlayerCount = count (
-			allPlayers select {_x getUnitTrait _traitName}
+			allPlayers
+				select {(_x getVariable ["vn_mf_db_player_group", "FAILED"]) isEqualTo _groupID}
+				select {_x getUnitTrait _traitName}
 		);
 		private _traitPlayerCountLimit = getNumber (_groupConfig >> "rolelimits" >> _traitName);
 


### PR DESCRIPTION
Taskroster UI was counting ALL PLAYERS who have a specific trait, not players IN THE TEAM who have a specific trait.