### PR TITLE
Radar - Fix

### DIFF
--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_radar.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_radar.sqf
@@ -81,19 +81,11 @@ params ["_pos"];
 	//Teardown condition
 	{
 		params ["_siteStore"];
-		//Teardown when all guns destroyed
-		(_siteStore getVariable "objectsToDestroy" findIf {alive _x} == -1)
+		[_siteStore] call vn_mf_fnc_sites_utils_std_check_teardown;
 	},
 	//Teardown code
 	{
 		params ["_siteStore"];
-
-		{
-			deleteMarker _x;
-		} forEach (_siteStore getVariable "markers");
-
-		{
-			[_x] call para_s_fnc_ai_obj_finish_objective;
-		} forEach (_siteStore getVariable ["aiObjectives", []]);
+		[_siteStore] call vn_mf_fnc_sites_utils_std_teardown;
 	}
 ] call vn_mf_fnc_sites_create_site;


### PR DESCRIPTION
Partial marker was not being removed due to the old teardown script being used. Have updated to the newer system, both partial and main marker now removed on destruction.