### PR TITLE
Attachments: Add manual chemlight removal interaction

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -202,6 +202,8 @@ class CfgFunctions
 			class action_curator_lock_spawner {};
 			class action_curator_unlock_spawner {};
 			class action_press_toggle_spectator {};
+			class action_remove_chemlight {};
+
 		};
 
 		class system_actives {

--- a/mission/config/notifications.hpp
+++ b/mission/config/notifications.hpp
@@ -497,6 +497,12 @@ class CfgNotifications
 		iconPicture = "\A3\ui_f\data\Map\Markers\Military\warning_ca.paa";
 	};
 
+	class LightsourceAttachRemoved : ErrLightsourceAttachChemlightNotPermitted {
+    title = "Light Source Attachment";
+    description = "You removed the attached chemlight.";
+    iconPicture = "\A3\ui_f\data\Map\Markers\Military\warning_ca.paa";
+	};
+
 	class IntelError: Error {
 		title = "Intel Not Collected";
 		description = "Keep looking at the intel object until it disappears!";

--- a/mission/functions/systems/actions/fn_action_remove_chemlight.sqf
+++ b/mission/functions/systems/actions/fn_action_remove_chemlight.sqf
@@ -1,0 +1,44 @@
+/*
+    File: fn_action_remove_chemlight.sqf
+    Author: Legend
+    Public: No
+
+    Description:
+        Allows a player to remove their chemlight manually.
+        Auto-hides if no chemlight is attached.
+        Cleans up after itself.
+
+    Parameter(s): none
+    Returns: nothing
+    Example(s): call vn_mf_fnc_action_remove_chemlight;
+*/
+
+if (!isNil "vn_mf_chemlight_remove_action") then {
+    player removeAction vn_mf_chemlight_remove_action;
+};
+
+private _conditionToShow = "count (attachedObjects player select { toLower typeOf _x find 'chemlight' > -1 }) > 0";
+
+vn_mf_chemlight_remove_action = player addAction
+[
+    "<t color='#FF9900'>Remove Attached Chemlight</t>",
+    {
+        [player] call vn_mf_fnc_attachments_global_delete_objects;
+        [player] call vn_mf_fnc_attachments_global_reset_jip_id;
+        player setVariable ["vn_mf_bn_attch_battery_starttime", -1];
+        ["LightsourceAttachRemoved",[]] call para_c_fnc_show_notification;
+
+        // Remove the action
+        if (!isNil "vn_mf_chemlight_remove_action") then {
+            player removeAction vn_mf_chemlight_remove_action;
+            vn_mf_chemlight_remove_action = nil;
+        };
+    },
+    nil,
+    0.1,
+    true,
+    true,
+    "",
+    _conditionToShow,
+    2
+];

--- a/mission/functions/systems/attachments/fn_attachments_client_attach_chemlight.sqf
+++ b/mission/functions/systems/attachments/fn_attachments_client_attach_chemlight.sqf
@@ -36,3 +36,6 @@ player removeItem _interactedItem;
 player setVariable ["vn_mf_bn_attch_battery_starttime", serverTime];
 
 [player, _interactedItem] remoteExec ["vn_mf_fnc_attachments_server_attach_chemlight", 2];
+
+call vn_mf_fnc_action_remove_chemlight;
+

--- a/mission/functions/systems/attachments/fn_attachments_client_battery_monitor_job.sqf
+++ b/mission/functions/systems/attachments/fn_attachments_client_battery_monitor_job.sqf
@@ -27,6 +27,11 @@ if((_startTime > 0) && {serverTime > (_startTime + _ttl)}) exitWith {
     [player] call vn_mf_fnc_attachments_global_delete_objects;
     ["LightsourceAttachOutOfEnergy",[]] call para_c_fnc_show_notification;
     player setVariable ["vn_mf_bn_attch_battery_starttime", -1];
+
+        if (!isNil "vn_mf_chemlight_remove_action") then {
+        player removeAction vn_mf_chemlight_remove_action;
+        vn_mf_chemlight_remove_action = nil;
+    };
 };
 
 // one tick a minute before the player is going to lose the light source.


### PR DESCRIPTION
Adds support for players to manually remove attached chemlights via a contextual action.
- Only appears when a chemlight is active and player is eligible
- Handles full cleanup: JIP, light sources, and battery timers
- New notification distinguishes between natural expiry vs manual removal
- Priority tuned to appear at the bottom of interaction list
- Tested across attach/detach loops, battery expiry, and spawn conditions

This rounds out the original light source system created by DJ
with a player-facing interaction and tactical flexibility.