### PR TITLE
TEAMS - ARVN - ASSETS - LOAD COEF

### DIFF
--- a/mission/config/subconfigs/teams.hpp
+++ b/mission/config/subconfigs/teams.hpp
@@ -709,7 +709,7 @@ class ARVN
     {
         camouflageCoef = 0.8;
         audibleCoef = 0.6;
-        loadCoef = 1;
+        loadCoef = 0.5;
         engineer = true;
         explosiveSpecialist = true;
         medic = false;

--- a/mission/config/subconfigs/vehicle_respawn_info.hpp
+++ b/mission/config/subconfigs/vehicle_respawn_info.hpp
@@ -792,6 +792,8 @@ class spawn_point_types {
 					"vn_i_armor_m125_01",
 					"vn_i_armor_m132_01",
 					"vn_i_armor_m113_acav_06",
+					"vn_i_armor_m113_acav_05",
+					"vn_i_armor_m113_acav_04",
 				};
 			};
 		};


### PR DESCRIPTION
Added two vehicles to existing ARVN spawn.
M113A1 ACAV (M134)
M113A1 ACAV (Mk18)
![20250405105423_1](https://github.com/user-attachments/assets/681bceac-ff99-49a8-9ad9-e28ae0af5523)
![20250405105017_1](https://github.com/user-attachments/assets/a8863163-8026-4ab4-94b7-c856e2bad72e)

Adjusted load coefficiency to match that of spike team.

