### PR TITLE
Attachments: Sync chemlight drop on removal

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -236,6 +236,7 @@ class CfgFunctions
 			class attachments_global_delete_objects {};
 			class attachments_client_battery_monitor_init {};
 			class attachments_client_battery_monitor_job {};
+			class attachments_server_spawn_dropped_chemlight {};
 		};
 
 		class system_attachments_lightsources {

--- a/mission/functions/systems/actions/fn_action_remove_chemlight.sqf
+++ b/mission/functions/systems/actions/fn_action_remove_chemlight.sqf
@@ -4,12 +4,10 @@
     Public: No
 
     Description:
-        Allows a player to remove their chemlight manually.
-        Auto-hides if no chemlight is attached.
-        Cleans up after itself.
+        Allows a player to manually remove their attached chemlight.
+        Drops a physical chemlight, synced globally via server.
+        Cleans up all light sources and data. Removes its own addAction.
 
-    Parameter(s): none
-    Returns: nothing
     Example(s): call vn_mf_fnc_action_remove_chemlight;
 */
 
@@ -23,12 +21,19 @@ vn_mf_chemlight_remove_action = player addAction
 [
     "<t color='#FF9900'>Remove Attached Chemlight</t>",
     {
+        private _chemlightClass = player getVariable ["vn_mf_attached_chemlight_class", "Chemlight_green"];
+
+        // Create dropped chemlight on server
+        [player, _chemlightClass] remoteExecCall ["vn_mf_fnc_attachments_server_spawn_dropped_chemlight", 2];
+
+        // Clean up player light sources + tracking
         [player] call vn_mf_fnc_attachments_global_delete_objects;
         [player] call vn_mf_fnc_attachments_global_reset_jip_id;
         player setVariable ["vn_mf_bn_attch_battery_starttime", -1];
-        ["LightsourceAttachRemoved",[]] call para_c_fnc_show_notification;
+        player setVariable ["vn_mf_attached_chemlight_class", nil];
 
-        // Remove the action
+        ["LightsourceAttachRemoved", []] call para_c_fnc_show_notification;
+
         if (!isNil "vn_mf_chemlight_remove_action") then {
             player removeAction vn_mf_chemlight_remove_action;
             vn_mf_chemlight_remove_action = nil;

--- a/mission/functions/systems/attachments/fn_attachments_client_attach_chemlight.sqf
+++ b/mission/functions/systems/attachments/fn_attachments_client_attach_chemlight.sqf
@@ -34,6 +34,7 @@ if !(_interactedItem isEqualTo []) then {
 
 player removeItem _interactedItem;
 player setVariable ["vn_mf_bn_attch_battery_starttime", serverTime];
+player setVariable ["vn_mf_attached_chemlight_class", _interactedItem];
 
 [player, _interactedItem] remoteExec ["vn_mf_fnc_attachments_server_attach_chemlight", 2];
 

--- a/mission/functions/systems/attachments/fn_attachments_server_spawn_dropped_chemlight.sqf
+++ b/mission/functions/systems/attachments/fn_attachments_server_spawn_dropped_chemlight.sqf
@@ -1,0 +1,20 @@
+/*
+    File: fn_attachments_server_spawn_dropped_chemlight.sqf
+    Author: Legend
+    Description:
+        Spawns a dropped chemlight at the player’s feet, synced globally.
+    Params:
+        0: OBJECT - Player dropping the chemlight
+        1: STRING - Classname of chemlight to spawn
+*/
+
+params ["_unit", "_className"];
+
+if (!isServer) exitWith {};
+
+private _pos = _unit modelToWorld [0, 0.3, -1.1];
+private _dropped = _className createVehicle _pos;
+
+private _dir = [[1,0,0], [0,1,0], [0,0,1]] select floor random 3;
+private _tilt = [random 1 - 0.5, random 1 - 0.5, random 1 - 0.5];
+_dropped setVectorDirAndUp [_dir, _tilt];


### PR DESCRIPTION
- Players now drop a visible chemlight on the ground when removing an attached one
- Chemlight rotates randomly to simulate natural drop
- Uses server-side createVehicle for full multiplayer and JIP sync
- All light sources and player variables are cleaned up