### PR TITLE
buildables.hpp changes (FIXED)

### DIFF
--- a/maps/cam_lao_nam/mission.sqm
+++ b/maps/cam_lao_nam/mission.sqm
@@ -1,14 +1,14 @@
 version=54;
 class EditorData
 {
-	moveGridStep=1;
+	moveGridStep=32;
 	angleGridStep=0.08726646;
 	scaleGridStep=1;
 	autoGroupingDist=10;
-	toggles=618;
+	toggles=586;
 	class ItemIDProvider
 	{
-		nextID=19520;
+		nextID=19561;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=30834;
+		nextID=31754;
 	};
 	class Camera
 	{
-		pos[]={15770.802,100.9061,6942.1802};
-		dir[]={0.029909531,-0.48128694,0.87606615};
-		up[]={0.016422903,0.87653917,0.48104581};
-		aside[]={0.99942738,-4.1569729e-07,-0.034121688};
+		pos[]={15654.677,145.77792,6935.9702};
+		dir[]={0.47289431,-0.67885166,0.56182379};
+		up[]={0.43717352,0.73424464,0.51938647};
+		aside[]={0.76509792,-2.2591848e-08,-0.64399517};
 	};
 };
 binarizationWanted=0;
@@ -39,8 +39,8 @@ addons[]=
 	"A3_Modules_F",
 	"A3_Structures_F_Mil_Flags",
 	"A3_Props_F_Enoch_Civilian_Camping",
-	"A3_Structures_F_Mil_Helipads",
 	"air_f_vietnam_02_c",
+	"A3_Structures_F_Mil_Helipads",
 	"A3_Misc_F_Helpers",
 	"A3_Structures_F_Civ_InfoBoards",
 	"A3_Structures_F_Walls",
@@ -525,7 +525,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=595;
+		items=592;
 		class Item0
 		{
 			dataType="Marker";
@@ -1140,7 +1140,7 @@ class Mission
 			};
 			id=264;
 			type="vn_module_whitelistedarsenal";
-			atlOffset=1933983.2;
+			atlOffset=1933983.3;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -1804,7 +1804,7 @@ class Mission
 					name="Pleiku";
 					class Entities
 					{
-						items=196;
+						items=202;
 						class Item0
 						{
 							dataType="Marker";
@@ -1853,12 +1853,12 @@ class Mission
 						class Item4
 						{
 							dataType="Marker";
-							position[]={15648.487,14.960205,7148.7354};
+							position[]={15648.487,14.96,7148.7349};
 							name="wreck_recovery";
 							text="@STR_vn_mf_wreck_recovery";
 							type="b_maint";
 							id=778;
-							atlOffset=-0.019794464;
+							atlOffset=-0.019999504;
 						};
 						class Item5
 						{
@@ -3500,102 +3500,6 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={15721.337,14.98,7080.4541};
-								angles[]={0,3.1898646,0};
-							};
-							side="Empty";
-							flags=4;
-							class Attributes
-							{
-							};
-							id=7369;
-							type="Land_HelipadCivil_F";
-						};
-						class Item68
-						{
-							dataType="Object";
-							class PositionInfo
-							{
-								position[]={15757.116,14.98,7079.6182};
-								angles[]={0,3.1898646,0};
-							};
-							side="Empty";
-							flags=4;
-							class Attributes
-							{
-							};
-							id=7370;
-							type="Land_HelipadCivil_F";
-						};
-						class Item69
-						{
-							dataType="Object";
-							class PositionInfo
-							{
-								position[]={15811.014,14.98,7077.7725};
-								angles[]={0,3.1528554,0};
-							};
-							side="Empty";
-							flags=4;
-							class Attributes
-							{
-							};
-							id=7371;
-							type="Land_HelipadCivil_F";
-						};
-						class Item70
-						{
-							dataType="Object";
-							class PositionInfo
-							{
-								position[]={15851.905,14.98,7076.5698};
-								angles[]={0,3.1711545,0};
-							};
-							side="Empty";
-							flags=4;
-							class Attributes
-							{
-							};
-							id=7372;
-							type="Land_HelipadCivil_F";
-						};
-						class Item71
-						{
-							dataType="Object";
-							class PositionInfo
-							{
-								position[]={15755.048,14.98,7027.7993};
-								angles[]={0,3.1898646,0};
-							};
-							side="Empty";
-							flags=4;
-							class Attributes
-							{
-							};
-							id=7373;
-							type="Land_HelipadCivil_F";
-						};
-						class Item72
-						{
-							dataType="Object";
-							class PositionInfo
-							{
-								position[]={15718.234,14.98,7028.8105};
-								angles[]={0,3.1898646,0};
-							};
-							side="Empty";
-							flags=4;
-							class Attributes
-							{
-							};
-							id=7374;
-							type="Land_HelipadCivil_F";
-						};
-						class Item73
-						{
-							dataType="Object";
-							class PositionInfo
-							{
 								position[]={15739.73,18.752029,7096.3081};
 								angles[]={0,5.5999517,0};
 							};
@@ -3624,7 +3528,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item74
+						class Item68
 						{
 							dataType="Object";
 							class PositionInfo
@@ -3657,7 +3561,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item75
+						class Item69
 						{
 							dataType="Object";
 							class PositionInfo
@@ -3691,7 +3595,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item76
+						class Item70
 						{
 							dataType="Object";
 							class PositionInfo
@@ -3725,7 +3629,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item77
+						class Item71
 						{
 							dataType="Marker";
 							position[]={16211.258,21.257999,7240.5356};
@@ -3738,7 +3642,7 @@ class Mission
 							id=7394;
 							atlOffset=6.2779999;
 						};
-						class Item78
+						class Item72
 						{
 							dataType="Marker";
 							position[]={16213.642,14.98,7239.1895};
@@ -3750,7 +3654,7 @@ class Mission
 							b=1091.5706;
 							id=442;
 						};
-						class Item79
+						class Item73
 						{
 							dataType="Object";
 							class PositionInfo
@@ -3767,7 +3671,7 @@ class Mission
 							id=7568;
 							type="Land_vn_object_trashcan_01";
 						};
-						class Item80
+						class Item74
 						{
 							dataType="Object";
 							class PositionInfo
@@ -3784,39 +3688,7 @@ class Mission
 							id=7570;
 							type="Land_vn_object_trashcan_01";
 						};
-						class Item81
-						{
-							dataType="Object";
-							class PositionInfo
-							{
-								position[]={15809.295,14.98,7037.5684};
-								angles[]={0,3.1528554,0};
-							};
-							side="Empty";
-							flags=4;
-							class Attributes
-							{
-							};
-							id=7694;
-							type="Land_HelipadCivil_F";
-						};
-						class Item82
-						{
-							dataType="Object";
-							class PositionInfo
-							{
-								position[]={15851.562,14.98,7035.6777};
-								angles[]={0,3.1711545,0};
-							};
-							side="Empty";
-							flags=4;
-							class Attributes
-							{
-							};
-							id=7695;
-							type="Land_HelipadCivil_F";
-						};
-						class Item83
+						class Item75
 						{
 							dataType="Object";
 							class PositionInfo
@@ -3849,7 +3721,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item84
+						class Item76
 						{
 							dataType="Marker";
 							position[]={16446.758,14.344,7120.6748};
@@ -3861,7 +3733,7 @@ class Mission
 							id=8168;
 							atlOffset=-0.63599968;
 						};
-						class Item85
+						class Item77
 						{
 							dataType="Marker";
 							position[]={16454.631,14.98,7069.311};
@@ -3872,7 +3744,7 @@ class Mission
 							alpha=0.75414002;
 							id=8169;
 						};
-						class Item86
+						class Item78
 						{
 							dataType="Marker";
 							position[]={16574.957,14.98,7070.0942};
@@ -3883,7 +3755,7 @@ class Mission
 							alpha=0.75414002;
 							id=8170;
 						};
-						class Item87
+						class Item79
 						{
 							dataType="Marker";
 							position[]={16691.373,14.98,7067.4771};
@@ -3894,51 +3766,7 @@ class Mission
 							alpha=0.75414002;
 							id=8171;
 						};
-						class Item88
-						{
-							dataType="Marker";
-							position[]={15810.539,14.98,7077.8931};
-							name="marker_92";
-							text="P1";
-							type="mil_pickup";
-							colorName="ColorWEST";
-							alpha=0.74909103;
-							id=8172;
-						};
-						class Item89
-						{
-							dataType="Marker";
-							position[]={15852.17,14.98,7076.5659};
-							name="marker_93";
-							text="P2";
-							type="mil_pickup";
-							colorName="ColorWEST";
-							alpha=0.74909103;
-							id=8173;
-						};
-						class Item90
-						{
-							dataType="Marker";
-							position[]={15809.063,14.98,7037.5918};
-							name="marker_94";
-							text="P3";
-							type="mil_pickup";
-							colorName="ColorWEST";
-							alpha=0.74909103;
-							id=8174;
-						};
-						class Item91
-						{
-							dataType="Marker";
-							position[]={15851.578,14.98,7036.1152};
-							name="marker_95";
-							text="P4";
-							type="mil_pickup";
-							colorName="ColorWEST";
-							alpha=0.74909103;
-							id=8175;
-						};
-						class Item92
+						class Item80
 						{
 							dataType="Marker";
 							position[]={16575.543,14.97998,7037.5249};
@@ -3950,7 +3778,7 @@ class Mission
 							id=8400;
 							atlOffset=-1.9073486e-05;
 						};
-						class Item93
+						class Item81
 						{
 							dataType="Marker";
 							position[]={17184.65,14.97998,7022.7148};
@@ -3962,12 +3790,12 @@ class Mission
 							id=8401;
 							atlOffset=-1.9073486e-05;
 						};
-						class Item94
+						class Item82
 						{
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={15680.306,18.752029,7005.7812};
+								position[]={15680.306,18.752029,7005.7813};
 								angles[]={0,5.5999517,0};
 							};
 							side="Empty";
@@ -3995,7 +3823,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item95
+						class Item83
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4028,7 +3856,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item96
+						class Item84
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4061,7 +3889,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item97
+						class Item85
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4094,7 +3922,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item98
+						class Item86
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4127,7 +3955,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item99
+						class Item87
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4160,7 +3988,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item100
+						class Item88
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4193,7 +4021,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item101
+						class Item89
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4226,7 +4054,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item102
+						class Item90
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4259,7 +4087,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item103
+						class Item91
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4293,12 +4121,12 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item104
+						class Item92
 						{
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={16145.03,18.752029,7057.9062};
+								position[]={16145.03,18.752029,7057.9063};
 								angles[]={0,2.4333858,0};
 							};
 							side="Empty";
@@ -4326,7 +4154,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item105
+						class Item93
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4376,7 +4204,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item106
+						class Item94
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -4389,7 +4217,7 @@ class Mission
 							id=14096;
 							type="HeadlessClient_F";
 						};
-						class Item107
+						class Item95
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -4402,7 +4230,7 @@ class Mission
 							id=14097;
 							type="HeadlessClient_F";
 						};
-						class Item108
+						class Item96
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4449,7 +4277,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item109
+						class Item97
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4483,7 +4311,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item110
+						class Item98
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4518,7 +4346,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item111
+						class Item99
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4534,7 +4362,7 @@ class Mission
 							type="Sign_Arrow_Direction_Green_F";
 							atlOffset=0.97060966;
 						};
-						class Item112
+						class Item100
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -4547,7 +4375,7 @@ class Mission
 							type="Logic";
 							atlOffset=0.0030384064;
 						};
-						class Item113
+						class Item101
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4582,7 +4410,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item114
+						class Item102
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4598,7 +4426,7 @@ class Mission
 							type="Sign_Arrow_Direction_Green_F";
 							atlOffset=0.97000027;
 						};
-						class Item115
+						class Item103
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -4610,7 +4438,7 @@ class Mission
 							id=16553;
 							type="Logic";
 						};
-						class Item116
+						class Item104
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4645,7 +4473,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item117
+						class Item105
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4661,7 +4489,7 @@ class Mission
 							type="Sign_Arrow_Direction_Green_F";
 							atlOffset=0.97000027;
 						};
-						class Item118
+						class Item106
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -4673,7 +4501,7 @@ class Mission
 							id=16556;
 							type="Logic";
 						};
-						class Item119
+						class Item107
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4708,7 +4536,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item120
+						class Item108
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4724,7 +4552,7 @@ class Mission
 							type="Sign_Arrow_Direction_Green_F";
 							atlOffset=1.000001;
 						};
-						class Item121
+						class Item109
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -4736,7 +4564,7 @@ class Mission
 							id=16448;
 							type="Logic";
 						};
-						class Item122
+						class Item110
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4771,7 +4599,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item123
+						class Item111
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -4783,7 +4611,7 @@ class Mission
 							id=16668;
 							type="Logic";
 						};
-						class Item124
+						class Item112
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4799,7 +4627,7 @@ class Mission
 							type="Sign_Arrow_Direction_Green_F";
 							atlOffset=0.95761967;
 						};
-						class Item125
+						class Item113
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4834,7 +4662,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item126
+						class Item114
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -4846,7 +4674,7 @@ class Mission
 							id=16673;
 							type="Logic";
 						};
-						class Item127
+						class Item115
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4862,7 +4690,7 @@ class Mission
 							type="Sign_Arrow_Direction_Green_F";
 							atlOffset=0.96089077;
 						};
-						class Item128
+						class Item116
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4895,7 +4723,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item129
+						class Item117
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4943,7 +4771,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item130
+						class Item118
 						{
 							dataType="Object";
 							class PositionInfo
@@ -4992,7 +4820,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item131
+						class Item119
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5041,7 +4869,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item132
+						class Item120
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5075,7 +4903,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item133
+						class Item121
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5109,7 +4937,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item134
+						class Item122
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5143,7 +4971,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item135
+						class Item123
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5178,7 +5006,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item136
+						class Item124
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5212,7 +5040,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item137
+						class Item125
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5286,7 +5114,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item138
+						class Item126
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5321,7 +5149,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item139
+						class Item127
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5356,7 +5184,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item140
+						class Item128
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5391,7 +5219,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item141
+						class Item129
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5425,7 +5253,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item142
+						class Item130
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5459,7 +5287,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item143
+						class Item131
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5493,7 +5321,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item144
+						class Item132
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5526,7 +5354,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item145
+						class Item133
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5559,7 +5387,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item146
+						class Item134
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5592,7 +5420,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item147
+						class Item135
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5625,7 +5453,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item148
+						class Item136
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5659,7 +5487,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item149
+						class Item137
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5693,7 +5521,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item150
+						class Item138
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5727,7 +5555,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item151
+						class Item139
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5761,7 +5589,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item152
+						class Item140
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5775,7 +5603,7 @@ class Mission
 							id=17969;
 							type="Land_HelipadEmpty_F";
 						};
-						class Item153
+						class Item141
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5808,7 +5636,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item154
+						class Item142
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5841,7 +5669,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item155
+						class Item143
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5874,7 +5702,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item156
+						class Item144
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5909,7 +5737,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item157
+						class Item145
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5944,7 +5772,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item158
+						class Item146
 						{
 							dataType="Object";
 							class PositionInfo
@@ -5979,7 +5807,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item159
+						class Item147
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6014,7 +5842,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item160
+						class Item148
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6049,7 +5877,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item161
+						class Item149
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6084,7 +5912,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item162
+						class Item150
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6119,7 +5947,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item163
+						class Item151
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6152,7 +5980,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item164
+						class Item152
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6185,7 +6013,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item165
+						class Item153
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6218,7 +6046,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item166
+						class Item154
 						{
 							dataType="Marker";
 							position[]={16073.3,14.98,6810.5132};
@@ -6228,7 +6056,7 @@ class Mission
 							colorName="ColorWEST";
 							id=18207;
 						};
-						class Item167
+						class Item155
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6260,7 +6088,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item168
+						class Item156
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6292,7 +6120,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item169
+						class Item157
 						{
 							dataType="Marker";
 							position[]={16680.199,30.393,6104.7749};
@@ -6305,7 +6133,7 @@ class Mission
 							id=14148;
 							atlOffset=5.7015305;
 						};
-						class Item170
+						class Item158
 						{
 							dataType="Marker";
 							position[]={15694.477,14.98,6894.6348};
@@ -6315,7 +6143,7 @@ class Mission
 							colorName="ColorWEST";
 							id=18267;
 						};
-						class Item171
+						class Item159
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6348,7 +6176,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item172
+						class Item160
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6381,7 +6209,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item173
+						class Item161
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6415,7 +6243,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item174
+						class Item162
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -6459,7 +6287,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item175
+						class Item163
 						{
 							dataType="Marker";
 							position[]={15984.026,12.380859,8013.8267};
@@ -6469,7 +6297,7 @@ class Mission
 							id=18343;
 							atlOffset=6.0456924;
 						};
-						class Item176
+						class Item164
 						{
 							dataType="Marker";
 							position[]={16411.01,14.98,6522.771};
@@ -6478,7 +6306,7 @@ class Mission
 							type="b_support";
 							id=18345;
 						};
-						class Item177
+						class Item165
 						{
 							dataType="Marker";
 							position[]={15951.927,12.298294,7973.96};
@@ -6488,7 +6316,7 @@ class Mission
 							id=18352;
 							atlOffset=0.00760746;
 						};
-						class Item178
+						class Item166
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -6532,7 +6360,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item179
+						class Item167
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -6577,7 +6405,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item180
+						class Item168
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -6622,7 +6450,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item181
+						class Item169
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -6667,7 +6495,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item182
+						class Item170
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -6711,7 +6539,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item183
+						class Item171
 						{
 							dataType="Marker";
 							position[]={16554.518,14.97998,6468.7661};
@@ -6725,7 +6553,7 @@ class Mission
 							id=18728;
 							atlOffset=-1.9073486e-05;
 						};
-						class Item184
+						class Item172
 						{
 							dataType="Marker";
 							position[]={16540.873,16.118671,6468.0825};
@@ -6735,7 +6563,7 @@ class Mission
 							id=18729;
 							atlOffset=1.1058083;
 						};
-						class Item185
+						class Item173
 						{
 							dataType="Marker";
 							position[]={16567.094,14.98,6468.8428};
@@ -6744,7 +6572,7 @@ class Mission
 							type="b_maint";
 							id=18732;
 						};
-						class Item186
+						class Item174
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -6788,7 +6616,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item187
+						class Item175
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6837,7 +6665,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item188
+						class Item176
 						{
 							dataType="Object";
 							class PositionInfo
@@ -6870,7 +6698,7 @@ class Mission
 								nAttributes=1;
 							};
 						};
-						class Item189
+						class Item177
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -6915,7 +6743,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item190
+						class Item178
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -6960,7 +6788,7 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item191
+						class Item179
 						{
 							dataType="Logic";
 							class PositionInfo
@@ -7005,57 +6833,390 @@ class Mission
 								nAttributes=2;
 							};
 						};
-						class Item192
+						class Item180
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={15717.414,14.98,7077.772};
+								angles[]={0,3.1528502,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=19522;
+							type="Land_HelipadCivil_F";
+						};
+						class Item181
 						{
 							dataType="Marker";
-							position[]={15721.401,14.98,7080.3198};
-							name="marker_97";
+							position[]={15717.414,14.98,7077.772};
+							name="marker_105";
 							text="SP1";
 							type="mil_pickup";
 							colorName="ColorWEST";
 							alpha=0.74909103;
-							id=19497;
+							id=19526;
 						};
-						class Item193
+						class Item182
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={15756.836,14.98,7077.772};
+								angles[]={0,3.1528502,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=19534;
+							type="Land_HelipadCivil_F";
+						};
+						class Item183
 						{
 							dataType="Marker";
-							position[]={15757.182,14.98,7079.3872};
-							name="marker_98";
+							position[]={15756.836,14.98,7077.772};
+							name="marker_109";
 							text="SP2";
 							type="mil_pickup";
 							colorName="ColorWEST";
 							alpha=0.74909103;
-							id=19498;
+							id=19535;
 						};
-						class Item194
+						class Item184
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={15717.414,14.98,7037.3506};
+								angles[]={0,3.1528502,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=19536;
+							type="Land_HelipadCivil_F";
+						};
+						class Item185
 						{
 							dataType="Marker";
-							position[]={15718.08,14.98,7028.8242};
-							name="marker_102";
+							position[]={15717.414,14.98,7037.3511};
+							name="marker_106";
 							text="SP3";
 							type="mil_pickup";
 							colorName="ColorWEST";
 							alpha=0.74909103;
-							id=19499;
+							id=19537;
 						};
-						class Item195
+						class Item186
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={15756.836,14.98,7037.3506};
+								angles[]={0,3.1528502,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=19538;
+							type="Land_HelipadCivil_F";
+						};
+						class Item187
 						{
 							dataType="Marker";
-							position[]={15755.093,14.98,7027.6479};
-							name="marker_104";
+							position[]={15756.836,14.98,7037.3511};
+							name="marker_110";
 							text="SP4";
 							type="mil_pickup";
 							colorName="ColorWEST";
 							alpha=0.74909103;
-							id=19500;
+							id=19539;
+						};
+						class Item188
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={15805.435,14.98,7077.8359};
+								angles[]={0,3.1528502,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=19540;
+							type="Land_HelipadCivil_F";
+						};
+						class Item189
+						{
+							dataType="Marker";
+							position[]={15805.435,14.98,7077.8359};
+							name="marker_107";
+							text="P1";
+							type="mil_pickup";
+							colorName="ColorWEST";
+							alpha=0.74909103;
+							id=19541;
+						};
+						class Item190
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={15844.856,14.98,7077.8359};
+								angles[]={0,3.1528502,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=19542;
+							type="Land_HelipadCivil_F";
+						};
+						class Item191
+						{
+							dataType="Marker";
+							position[]={15844.856,14.98,7077.8359};
+							name="marker_111";
+							text="P2";
+							type="mil_pickup";
+							colorName="ColorWEST";
+							alpha=0.74909103;
+							id=19543;
+						};
+						class Item192
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={15805.435,14.98,7037.4146};
+								angles[]={0,3.1528502,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=19544;
+							type="Land_HelipadCivil_F";
+						};
+						class Item193
+						{
+							dataType="Marker";
+							position[]={15805.435,14.98,7037.415};
+							name="marker_108";
+							text="P3";
+							type="mil_pickup";
+							colorName="ColorWEST";
+							alpha=0.74909103;
+							id=19545;
+						};
+						class Item194
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={15844.856,14.98,7037.415};
+								angles[]={0,3.1528502,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+								disableSimulation=1;
+							};
+							id=19546;
+							type="Land_HelipadCivil_F";
+							class CustomAttributes
+							{
+								class Attribute0
+								{
+									property="allowDamage";
+									expression="_this allowdamage _value;";
+									class Value
+									{
+										class data
+										{
+											singleType="BOOL";
+											value=0;
+										};
+									};
+								};
+								nAttributes=1;
+							};
+						};
+						class Item195
+						{
+							dataType="Marker";
+							position[]={15844.856,14.98,7037.415};
+							name="marker_113";
+							text="P4";
+							type="mil_pickup";
+							colorName="ColorWEST";
+							alpha=0.74909103;
+							id=19547;
+						};
+						class Item196
+						{
+							dataType="Marker";
+							position[]={20054.307,1.9432786,9795.5508};
+							name="marker_114";
+							text="P1";
+							type="mil_pickup";
+							colorName="ColorWEST";
+							alpha=0.74909103;
+							id=19549;
+							atlOffset=0.10103917;
+						};
+						class Item197
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={20054.307,1.9423695,9795.5508};
+								angles[]={0,0.38681731,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+								disableSimulation=1;
+							};
+							id=19553;
+							type="Land_vn_b_helipad_01";
+							atlOffset=0.10013008;
+							class CustomAttributes
+							{
+								class Attribute0
+								{
+									property="allowDamage";
+									expression="_this allowdamage _value;";
+									class Value
+									{
+										class data
+										{
+											singleType="BOOL";
+											value=0;
+										};
+									};
+								};
+								nAttributes=1;
+							};
+						};
+						class Item198
+						{
+							dataType="Marker";
+							position[]={20085.098,2.023,9782.4541};
+							name="marker_115";
+							text="P2";
+							type="mil_pickup";
+							colorName="ColorWEST";
+							alpha=0.74909103;
+							id=19554;
+							atlOffset=0.22017598;
+						};
+						class Item199
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={20085.098,2.0226905,9782.4541};
+								angles[]={0,0.38863248,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+								disableSimulation=1;
+							};
+							id=19555;
+							type="Land_vn_b_helipad_01";
+							atlOffset=0.21986651;
+							class CustomAttributes
+							{
+								class Attribute0
+								{
+									property="allowDamage";
+									expression="_this allowdamage _value;";
+									class Value
+									{
+										class data
+										{
+											singleType="BOOL";
+											value=0;
+										};
+									};
+								};
+								nAttributes=1;
+							};
+						};
+						class Item200
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={19964.377,5.2984705,9725.0186};
+								angles[]={0,0.02768092,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+								disableSimulation=1;
+							};
+							id=19559;
+							type="Land_vn_b_helipad_01";
+							atlOffset=0.13100004;
+							class CustomAttributes
+							{
+								class Attribute0
+								{
+									property="allowDamage";
+									expression="_this allowdamage _value;";
+									class Value
+									{
+										class data
+										{
+											singleType="BOOL";
+											value=0;
+										};
+									};
+								};
+								nAttributes=1;
+							};
+						};
+						class Item201
+						{
+							dataType="Marker";
+							position[]={19964.467,5.3460002,9725.126};
+							name="wreck_recovery_5";
+							markerType="ELLIPSE";
+							type="ellipse";
+							colorName="ColorBlack";
+							fillName="Horizontal";
+							a=10;
+							b=10;
+							id=19560;
+							atlOffset=0.0075421333;
 						};
 					};
 					id=18329;
-					atlOffset=0.21304321;
+					atlOffset=-5.5397072;
 				};
 			};
 			id=686;
-			atlOffset=-37.892113;
+			atlOffset=89.706337;
 		};
 		class Item74
 		{
@@ -7074,13 +7235,13 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={20746.055,381152.12,3915.53};
+				position[]={20746.055,381152.13,3915.53};
 				angles[]={0,4.541172,0};
 			};
 			name="vn_mf_masterarm";
 			id=823;
 			type="vn_module_masterarm";
-			atlOffset=381242.12;
+			atlOffset=381242.13;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -8698,51 +8859,6 @@ class Mission
 		};
 		class Item160
 		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={20065.127,3.4611053,9784.75};
-				angles[]={0,5.0856609,0};
-			};
-			areaSize[]={10,0,50};
-			areaIsRectangle=1;
-			flags=1;
-			id=9000;
-			type="ModuleHideTerrainObjects_F";
-			atlOffset=1.0584955;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="#filter";
-					expression="_this setVariable [""#filter"",_value]";
-					class Value
-					{
-						class data
-						{
-							singleType="SCALAR";
-							value=4;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="#hideLocally";
-					expression="_this setVariable [""#hideLocally"",_value]";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=2;
-			};
-		};
-		class Item161
-		{
 			dataType="Object";
 			class PositionInfo
 			{
@@ -8758,43 +8874,7 @@ class Mission
 			type="vn_fireplace_burning_f";
 			atlOffset=0.023401022;
 		};
-		class Item162
-		{
-			dataType="Marker";
-			position[]={20047.619,1.3007812,9786.5703};
-			name="marker_96";
-			text="P1";
-			type="mil_pickup";
-			colorName="ColorBlue";
-			alpha=0.74909103;
-			id=9091;
-			atlOffset=-1.9447412;
-		};
-		class Item163
-		{
-			dataType="Marker";
-			position[]={20067.029,1.4619141,9779.8848};
-			name="marker_101";
-			text="P2";
-			type="mil_pickup";
-			colorName="ColorBlue";
-			alpha=0.74909103;
-			id=9092;
-			atlOffset=-1.4168873;
-		};
-		class Item164
-		{
-			dataType="Marker";
-			position[]={20083.482,1.1785889,9773.7529};
-			name="marker_103";
-			text="P3";
-			type="mil_pickup";
-			colorName="ColorBlue";
-			alpha=0.74909103;
-			id=9093;
-			atlOffset=-1.3049145;
-		};
-		class Item165
+		class Item161
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8837,7 +8917,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item166
+		class Item162
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8880,7 +8960,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item167
+		class Item163
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8923,7 +9003,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item168
+		class Item164
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8965,7 +9045,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item169
+		class Item165
 		{
 			dataType="Marker";
 			position[]={2844.668,0,8586.6553};
@@ -8977,7 +9057,7 @@ class Mission
 			id=13958;
 			atlOffset=7.3896022;
 		};
-		class Item170
+		class Item166
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9175,7 +9255,7 @@ class Mission
 				nAttributes=14;
 			};
 		};
-		class Item171
+		class Item167
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9186,7 +9266,7 @@ class Mission
 			type="vn_module_logistics";
 			atlOffset=89.477356;
 		};
-		class Item172
+		class Item168
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9214,7 +9294,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item173
+		class Item169
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9243,7 +9323,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item174
+		class Item170
 		{
 			dataType="Marker";
 			position[]={17423.734,30.685818,5639.2544};
@@ -9253,7 +9333,7 @@ class Mission
 			id=14103;
 			atlOffset=0.76521111;
 		};
-		class Item175
+		class Item171
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9298,7 +9378,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item176
+		class Item172
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9444,7 +9524,7 @@ class Mission
 				nAttributes=10;
 			};
 		};
-		class Item177
+		class Item173
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9460,7 +9540,7 @@ class Mission
 			type="Land_vn_helipadrescue_f";
 			atlOffset=0.48744583;
 		};
-		class Item178
+		class Item174
 		{
 			dataType="Group";
 			side="East";
@@ -9556,7 +9636,7 @@ class Mission
 			};
 			id=15535;
 		};
-		class Item179
+		class Item175
 		{
 			dataType="Group";
 			side="East";
@@ -9652,7 +9732,7 @@ class Mission
 			};
 			id=15538;
 		};
-		class Item180
+		class Item176
 		{
 			dataType="Group";
 			side="East";
@@ -9748,7 +9828,7 @@ class Mission
 			};
 			id=15541;
 		};
-		class Item181
+		class Item177
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9764,7 +9844,7 @@ class Mission
 			id=15588;
 			type="vn_sign_town_d_09_01";
 		};
-		class Item182
+		class Item178
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9780,7 +9860,7 @@ class Mission
 			id=15589;
 			type="vn_sign_town_d_10";
 		};
-		class Item183
+		class Item179
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9797,7 +9877,7 @@ class Mission
 			type="vn_sign_town_d_03";
 			atlOffset=7.6293945e-06;
 		};
-		class Item184
+		class Item180
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9814,7 +9894,7 @@ class Mission
 			type="vn_sign_town_d_01";
 			atlOffset=7.6293945e-06;
 		};
-		class Item185
+		class Item181
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9830,7 +9910,7 @@ class Mission
 			type="Land_Sunshade_01_F";
 			atlOffset=4.7683716e-06;
 		};
-		class Item186
+		class Item182
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9846,7 +9926,7 @@ class Mission
 			type="Land_Sun_chair_F";
 			atlOffset=5.5799241;
 		};
-		class Item187
+		class Item183
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9863,7 +9943,7 @@ class Mission
 			type="Land_vn_helipadrescue_f";
 			atlOffset=-0.0086288452;
 		};
-		class Item188
+		class Item184
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9879,7 +9959,7 @@ class Mission
 			id=16364;
 			type="Land_vn_helipadrescue_f";
 		};
-		class Item189
+		class Item185
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9895,7 +9975,7 @@ class Mission
 			id=16367;
 			type="Land_vn_helipadrescue_f";
 		};
-		class Item190
+		class Item186
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9912,7 +9992,7 @@ class Mission
 			type="Land_vn_helipadrescue_f";
 			atlOffset=-0.015256882;
 		};
-		class Item191
+		class Item187
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9929,7 +10009,7 @@ class Mission
 			type="Land_vn_helipadrescue_f";
 			atlOffset=-1.9073486e-06;
 		};
-		class Item192
+		class Item188
 		{
 			dataType="Object";
 			class PositionInfo
@@ -9946,7 +10026,7 @@ class Mission
 			type="Land_vn_helipadrescue_f";
 			atlOffset=0.11613464;
 		};
-		class Item193
+		class Item189
 		{
 			dataType="Marker";
 			position[]={15130.835,65.040001,4662.7598};
@@ -9955,7 +10035,7 @@ class Mission
 			type="b_maint";
 			id=16907;
 		};
-		class Item194
+		class Item190
 		{
 			dataType="Marker";
 			position[]={20014.043,4.9299998,6563.7344};
@@ -9964,7 +10044,7 @@ class Mission
 			type="b_maint";
 			id=16908;
 		};
-		class Item195
+		class Item191
 		{
 			dataType="Marker";
 			position[]={18682.721,21.41,8429.293};
@@ -9973,7 +10053,7 @@ class Mission
 			type="b_maint";
 			id=16909;
 		};
-		class Item196
+		class Item192
 		{
 			dataType="Marker";
 			position[]={14772.033,244.05,9556.3232};
@@ -9982,7 +10062,7 @@ class Mission
 			type="b_maint";
 			id=16910;
 		};
-		class Item197
+		class Item193
 		{
 			dataType="Marker";
 			position[]={16046.766,26.379999,3698.7891};
@@ -9991,7 +10071,7 @@ class Mission
 			type="b_maint";
 			id=16911;
 		};
-		class Item198
+		class Item194
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10007,7 +10087,7 @@ class Mission
 			id=17149;
 			type="Land_vn_helipadrescue_f";
 		};
-		class Item199
+		class Item195
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10024,7 +10104,7 @@ class Mission
 			type="Land_vn_helipadrescue_f";
 			atlOffset=-1.9073486e-06;
 		};
-		class Item200
+		class Item196
 		{
 			dataType="Marker";
 			position[]={14683.076,99.589996,6905.7041};
@@ -10033,7 +10113,7 @@ class Mission
 			type="b_maint";
 			id=17968;
 		};
-		class Item201
+		class Item197
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10047,7 +10127,7 @@ class Mission
 			id=18196;
 			type="Land_HelipadEmpty_F";
 		};
-		class Item202
+		class Item198
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10062,7 +10142,7 @@ class Mission
 			type="Land_HelipadEmpty_F";
 			atlOffset=0.0071964264;
 		};
-		class Item203
+		class Item199
 		{
 			dataType="Object";
 			class PositionInfo
@@ -10077,7 +10157,7 @@ class Mission
 			type="Land_HelipadEmpty_F";
 			atlOffset=0.0071163177;
 		};
-		class Item204
+		class Item200
 		{
 			dataType="Group";
 			side="East";
@@ -12438,7 +12518,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item205
+		class Item201
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -12483,7 +12563,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item206
+		class Item202
 		{
 			dataType="Layer";
 			name="RADAR_3_60m";
@@ -12603,7 +12683,7 @@ class Mission
 			id=11104;
 			atlOffset=103.16;
 		};
-		class Item207
+		class Item203
 		{
 			dataType="Layer";
 			name="RADAR_3_60m";
@@ -12723,7 +12803,7 @@ class Mission
 			id=9952;
 			atlOffset=103.16;
 		};
-		class Item208
+		class Item204
 		{
 			dataType="Layer";
 			name="FACTORY_2_40m";
@@ -12781,7 +12861,7 @@ class Mission
 			id=12391;
 			atlOffset=103.16;
 		};
-		class Item209
+		class Item205
 		{
 			dataType="Layer";
 			name="ARTYx_3_15m";
@@ -12821,7 +12901,7 @@ class Mission
 			id=10304;
 			atlOffset=103.16;
 		};
-		class Item210
+		class Item206
 		{
 			dataType="Layer";
 			name="Camp_08_20m";
@@ -12850,7 +12930,7 @@ class Mission
 			id=13436;
 			atlOffset=103.16;
 		};
-		class Item211
+		class Item207
 		{
 			dataType="Layer";
 			name="Camp_5_25m";
@@ -12879,7 +12959,7 @@ class Mission
 			id=13057;
 			atlOffset=103.16;
 		};
-		class Item212
+		class Item208
 		{
 			dataType="Layer";
 			name="FACTORY_1_55m";
@@ -12908,7 +12988,7 @@ class Mission
 			id=12328;
 			atlOffset=103.16;
 		};
-		class Item213
+		class Item209
 		{
 			dataType="Layer";
 			name="HQ_1_35m";
@@ -12937,7 +13017,7 @@ class Mission
 			id=12116;
 			atlOffset=103.16;
 		};
-		class Item214
+		class Item210
 		{
 			dataType="Layer";
 			name="HQ_2_32m";
@@ -12966,7 +13046,7 @@ class Mission
 			id=11843;
 			atlOffset=103.16;
 		};
-		class Item215
+		class Item211
 		{
 			dataType="Layer";
 			name="Camp_11_25m";
@@ -12995,7 +13075,7 @@ class Mission
 			id=10276;
 			atlOffset=103.16;
 		};
-		class Item216
+		class Item212
 		{
 			dataType="Layer";
 			name="HQ_2_32m";
@@ -13024,7 +13104,7 @@ class Mission
 			id=10245;
 			atlOffset=103.16;
 		};
-		class Item217
+		class Item213
 		{
 			dataType="Layer";
 			name="Mortar range";
@@ -13053,7 +13133,7 @@ class Mission
 			id=9297;
 			atlOffset=103.16;
 		};
-		class Item218
+		class Item214
 		{
 			dataType="Layer";
 			name="Mortar range";
@@ -13082,7 +13162,7 @@ class Mission
 			id=9202;
 			atlOffset=103.16;
 		};
-		class Item219
+		class Item215
 		{
 			dataType="Layer";
 			name="Camp_7_15m";
@@ -13100,7 +13180,7 @@ class Mission
 			id=13374;
 			atlOffset=103.16;
 		};
-		class Item220
+		class Item216
 		{
 			dataType="Layer";
 			name="Camp_6_35m";
@@ -13118,7 +13198,7 @@ class Mission
 			id=13307;
 			atlOffset=103.16;
 		};
-		class Item221
+		class Item217
 		{
 			dataType="Layer";
 			name="FACTORY_3_55";
@@ -13136,7 +13216,7 @@ class Mission
 			id=12656;
 			atlOffset=103.16;
 		};
-		class Item222
+		class Item218
 		{
 			dataType="Layer";
 			name="HQ_3_30m";
@@ -13154,7 +13234,7 @@ class Mission
 			id=11715;
 			atlOffset=103.16;
 		};
-		class Item223
+		class Item219
 		{
 			dataType="Layer";
 			name="HQ_4_30m";
@@ -13172,7 +13252,7 @@ class Mission
 			id=11426;
 			atlOffset=103.16;
 		};
-		class Item224
+		class Item220
 		{
 			dataType="Layer";
 			name="HQ_4_30m";
@@ -13190,35 +13270,35 @@ class Mission
 			id=10117;
 			atlOffset=103.16;
 		};
-		class Item225
+		class Item221
 		{
 			dataType="Layer";
 			name="Hidden Outpost";
 			id=13777;
 			atlOffset=103.16;
 		};
-		class Item226
+		class Item222
 		{
 			dataType="Layer";
 			name="Explosive Field";
 			id=11286;
 			atlOffset=103.16;
 		};
-		class Item227
+		class Item223
 		{
 			dataType="Layer";
 			name="Explosive Field";
 			id=8905;
 			atlOffset=103.16;
 		};
-		class Item228
+		class Item224
 		{
 			dataType="Layer";
 			name="Vehicles";
 			id=704;
 			atlOffset=103.16;
 		};
-		class Item229
+		class Item225
 		{
 			dataType="Layer";
 			name="PleikuAirbase";
@@ -15364,18 +15444,17 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={15784.354,19.537302,7381.1465};
+								position[]={15784.354,17.918474,7381.1465};
 								angles[]={0,3.1308355,0};
 							};
 							side="Empty";
-							flags=1;
+							flags=5;
 							class Attributes
 							{
 								disableSimulation=1;
 							};
 							id=18189;
 							type="vn_sign_direction_f";
-							atlOffset=1.6188269;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -15509,7 +15588,7 @@ class Mission
 						};
 					};
 					id=18319;
-					atlOffset=-5.8704729;
+					atlOffset=-5.8767958;
 				};
 				class Item3
 				{
@@ -17895,8 +17974,8 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={15947.92,0.058087893,8079.4985};
-								angles[]={0,0.017546283,0};
+								position[]={20085.348,0.2527948,9837.2754};
+								angles[]={0,0.36661315,0};
 							};
 							side="Empty";
 							class Attributes
@@ -17904,15 +17983,15 @@ class Mission
 							};
 							id=18701;
 							type="Sign_Arrow_Direction_Green_F";
-							atlOffset=4.94982;
+							atlOffset=7.067728;
 						};
 						class Item59
 						{
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={15943.662,1.9939771,8084.2202};
-								angles[]={0,1.4947395,0};
+								position[]={20087.494,2.188683,9833.8369};
+								angles[]={0,5.1599312,0};
 							};
 							side="Empty";
 							flags=1;
@@ -17922,7 +18001,7 @@ class Mission
 							};
 							id=18702;
 							type="vn_signad_sponsors_f";
-							atlOffset=4.756216;
+							atlOffset=7.4509106;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -17946,13 +18025,13 @@ class Mission
 							dataType="Logic";
 							class PositionInfo
 							{
-								position[]={15948.738,1.8415227,8082.6431};
-								angles[]={0,5.7248545,0};
+								position[]={20087.438,2.0362287,9838.6104};
+								angles[]={0,3.1068606,0};
 							};
 							init="['unlocked_boats_small', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=18703;
 							type="Logic";
-							atlOffset=6.6020002;
+							atlOffset=9.2227879;
 						};
 						class Item61
 						{
@@ -18058,8 +18137,8 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={15935.081,0.058088847,8148.8828};
-								angles[]={0,6.2635369,0};
+								position[]={20108.213,0.058088847,9826.6719};
+								angles[]={0,0.41668385,0};
 							};
 							side="Empty";
 							class Attributes
@@ -18067,15 +18146,15 @@ class Mission
 							};
 							id=18718;
 							type="Sign_Arrow_Direction_Green_F";
-							atlOffset=4.8348117;
+							atlOffset=6.4099932;
 						};
 						class Item66
 						{
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={15938.656,1.9939761,8147.2007};
-								angles[]={0,4.6683679,0};
+								position[]={20110.969,1.8318439,9824};
+								angles[]={0,5.104701,0};
 							};
 							side="Empty";
 							flags=1;
@@ -18085,7 +18164,7 @@ class Mission
 							};
 							id=18719;
 							type="vn_signad_sponsors_f";
-							atlOffset=5.3784084;
+							atlOffset=6.8820114;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -18109,13 +18188,13 @@ class Mission
 							dataType="Logic";
 							class PositionInfo
 							{
-								position[]={15935.633,1.8411574,8150.9092};
-								angles[]={0,5.7248545,0};
+								position[]={20110.051,1.7300329,9828.3496};
+								angles[]={0,6.0739202,0};
 							};
 							init="['udt_boats_small', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
 							id=18720;
 							type="Logic";
-							atlOffset=6.835;
+							atlOffset=8.5510921;
 						};
 						class Item68
 						{
@@ -18165,7 +18244,7 @@ class Mission
 						};
 					};
 					id=18321;
-					atlOffset=0.32702494;
+					atlOffset=7.7646246;
 				};
 				class Item5
 				{
@@ -21755,7 +21834,7 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={15894.251,15.114315,6819.2812};
+								position[]={15894.251,15.114315,6819.2813};
 								angles[]={0,1.5842136,0};
 							};
 							side="Empty";
@@ -25380,7 +25459,7 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={16412.062,15.121468,6570.2891};
+								position[]={16412.063,15.121468,6570.2891};
 							};
 							side="Empty";
 							flags=5;
@@ -26136,7 +26215,7 @@ class Mission
 							dataType="Logic";
 							class PositionInfo
 							{
-								position[]={16450.807,15.971004,6573.2812};
+								position[]={16450.807,15.971004,6573.2813};
 								angles[]={0,5.7482767,0};
 							};
 							init="['acav_grnd_firesupport_heavy', 0] call vn_mf_fnc_veh_asset_3DEN_spawn_point";
@@ -26891,7 +26970,7 @@ class Mission
 									};
 									id=18423;
 									type="Land_HelipadEmpty_F";
-									atlOffset=0.011260986;
+									atlOffset=0.013122559;
 								};
 								class Item2
 								{
@@ -34074,9 +34153,9 @@ class Mission
 				};
 			};
 			id=18339;
-			atlOffset=-2.2610168;
+			atlOffset=-2.3052502;
 		};
-		class Item230
+		class Item226
 		{
 			dataType="Layer";
 			name="DacAssets";
@@ -36429,7 +36508,7 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={277.63199,132.92397,18671.312};
+								position[]={277.63199,132.92397,18671.313};
 								angles[]={0,4.7548356,0};
 							};
 							side="Empty";
@@ -39017,7 +39096,7 @@ class Mission
 			id=18340;
 			atlOffset=-52.612106;
 		};
-		class Item231
+		class Item227
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39091,7 +39170,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item232
+		class Item228
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39125,7 +39204,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item233
+		class Item229
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39172,7 +39251,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item234
+		class Item230
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39219,7 +39298,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item235
+		class Item231
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39266,7 +39345,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item236
+		class Item232
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39313,7 +39392,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item237
+		class Item233
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39360,7 +39439,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item238
+		class Item234
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39407,7 +39486,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item239
+		class Item235
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39454,7 +39533,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item240
+		class Item236
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39500,7 +39579,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item241
+		class Item237
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39547,7 +39626,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item242
+		class Item238
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39594,7 +39673,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item243
+		class Item239
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39641,7 +39720,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item244
+		class Item240
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39688,7 +39767,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item245
+		class Item241
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39736,7 +39815,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item246
+		class Item242
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39784,7 +39863,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item247
+		class Item243
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39832,7 +39911,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item248
+		class Item244
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39880,7 +39959,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item249
+		class Item245
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39928,7 +40007,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item250
+		class Item246
 		{
 			dataType="Object";
 			class PositionInfo
@@ -39976,7 +40055,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item251
+		class Item247
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40024,7 +40103,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item252
+		class Item248
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40072,7 +40151,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item253
+		class Item249
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40120,7 +40199,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item254
+		class Item250
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40167,7 +40246,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item255
+		class Item251
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40214,7 +40293,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item256
+		class Item252
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40261,7 +40340,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item257
+		class Item253
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40308,7 +40387,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item258
+		class Item254
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40355,7 +40434,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item259
+		class Item255
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40402,7 +40481,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item260
+		class Item256
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40449,7 +40528,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item261
+		class Item257
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40495,7 +40574,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item262
+		class Item258
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40541,7 +40620,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item263
+		class Item259
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40587,7 +40666,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item264
+		class Item260
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40633,7 +40712,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item265
+		class Item261
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40680,7 +40759,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item266
+		class Item262
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40726,7 +40805,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item267
+		class Item263
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40772,7 +40851,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item268
+		class Item264
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40818,7 +40897,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item269
+		class Item265
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40864,7 +40943,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item270
+		class Item266
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40910,7 +40989,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item271
+		class Item267
 		{
 			dataType="Object";
 			class PositionInfo
@@ -40956,7 +41035,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item272
+		class Item268
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41002,7 +41081,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item273
+		class Item269
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41048,7 +41127,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item274
+		class Item270
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41094,7 +41173,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item275
+		class Item271
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41141,7 +41220,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item276
+		class Item272
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41188,7 +41267,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item277
+		class Item273
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41235,7 +41314,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item278
+		class Item274
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41282,7 +41361,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item279
+		class Item275
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41329,7 +41408,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item280
+		class Item276
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41376,7 +41455,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item281
+		class Item277
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41423,7 +41502,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item282
+		class Item278
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41470,7 +41549,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item283
+		class Item279
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41516,7 +41595,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item284
+		class Item280
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41563,7 +41642,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item285
+		class Item281
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41610,7 +41689,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item286
+		class Item282
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41657,7 +41736,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item287
+		class Item283
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41693,7 +41772,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item288
+		class Item284
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41728,7 +41807,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item289
+		class Item285
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41763,7 +41842,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item290
+		class Item286
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41798,7 +41877,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item291
+		class Item287
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41834,7 +41913,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item292
+		class Item288
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41869,7 +41948,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item293
+		class Item289
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41904,7 +41983,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item294
+		class Item290
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41939,7 +42018,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item295
+		class Item291
 		{
 			dataType="Object";
 			class PositionInfo
@@ -41974,7 +42053,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item296
+		class Item292
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42008,7 +42087,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item297
+		class Item293
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42043,7 +42122,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item298
+		class Item294
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42078,7 +42157,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item299
+		class Item295
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42113,7 +42192,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item300
+		class Item296
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42149,7 +42228,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item301
+		class Item297
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42184,7 +42263,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item302
+		class Item298
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42219,7 +42298,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item303
+		class Item299
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42253,7 +42332,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item304
+		class Item300
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42288,7 +42367,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item305
+		class Item301
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42324,7 +42403,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item306
+		class Item302
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42359,7 +42438,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item307
+		class Item303
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42393,7 +42472,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item308
+		class Item304
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42427,7 +42506,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item309
+		class Item305
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42461,7 +42540,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item310
+		class Item306
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42496,7 +42575,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item311
+		class Item307
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42530,7 +42609,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item312
+		class Item308
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42566,7 +42645,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item313
+		class Item309
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42601,7 +42680,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item314
+		class Item310
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42635,7 +42714,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item315
+		class Item311
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42669,7 +42748,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item316
+		class Item312
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42705,7 +42784,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item317
+		class Item313
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42741,7 +42820,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item318
+		class Item314
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42776,7 +42855,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item319
+		class Item315
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42823,7 +42902,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item320
+		class Item316
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42870,7 +42949,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item321
+		class Item317
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42916,7 +42995,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item322
+		class Item318
 		{
 			dataType="Object";
 			class PositionInfo
@@ -42962,7 +43041,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item323
+		class Item319
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43008,7 +43087,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item324
+		class Item320
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43054,7 +43133,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item325
+		class Item321
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43088,7 +43167,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item326
+		class Item322
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43134,7 +43213,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item327
+		class Item323
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43180,7 +43259,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item328
+		class Item324
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43226,7 +43305,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item329
+		class Item325
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43273,7 +43352,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item330
+		class Item326
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43319,7 +43398,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item331
+		class Item327
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43365,7 +43444,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item332
+		class Item328
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43411,7 +43490,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item333
+		class Item329
 		{
 			dataType="Marker";
 			position[]={13806.902,432.72104,8341.4941};
@@ -43420,7 +43499,7 @@ class Mission
 			type="b_maint";
 			id=18697;
 		};
-		class Item334
+		class Item330
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43455,7 +43534,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item335
+		class Item331
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43490,7 +43569,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item336
+		class Item332
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43537,7 +43616,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item337
+		class Item333
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43571,7 +43650,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item338
+		class Item334
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43605,7 +43684,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item339
+		class Item335
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43639,7 +43718,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item340
+		class Item336
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -43650,7 +43729,7 @@ class Mission
 			type="vn_module_photo_camera_enable_screenshots";
 			atlOffset=88.815002;
 		};
-		class Item341
+		class Item337
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43666,7 +43745,7 @@ class Mission
 			type="vn_b_boonie_02_02";
 			atlOffset=0.85053158;
 		};
-		class Item342
+		class Item338
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43682,7 +43761,7 @@ class Mission
 			type="vn_flag_101stab";
 			atlOffset=-0.015350342;
 		};
-		class Item343
+		class Item339
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43697,7 +43776,7 @@ class Mission
 			id=18777;
 			type="vn_flag_101stab";
 		};
-		class Item344
+		class Item340
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43713,7 +43792,7 @@ class Mission
 			id=18778;
 			type="vn_steeldrum_bbq_02";
 		};
-		class Item345
+		class Item341
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43730,7 +43809,7 @@ class Mission
 			type="vn_fireplace_burning_f";
 			atlOffset=0.027119637;
 		};
-		class Item346
+		class Item342
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43777,7 +43856,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item347
+		class Item343
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43811,7 +43890,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item348
+		class Item344
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43845,7 +43924,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item349
+		class Item345
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43879,7 +43958,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item350
+		class Item346
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43913,7 +43992,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item351
+		class Item347
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43948,7 +44027,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item352
+		class Item348
 		{
 			dataType="Object";
 			class PositionInfo
@@ -43983,7 +44062,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item353
+		class Item349
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44019,7 +44098,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item354
+		class Item350
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44055,7 +44134,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item355
+		class Item351
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44090,7 +44169,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item356
+		class Item352
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44125,7 +44204,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item357
+		class Item353
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44161,7 +44240,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item358
+		class Item354
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44197,7 +44276,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item359
+		class Item355
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44212,7 +44291,7 @@ class Mission
 			id=18806;
 			type="Land_Bucket_F";
 		};
-		class Item360
+		class Item356
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44247,7 +44326,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item361
+		class Item357
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44282,7 +44361,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item362
+		class Item358
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44317,7 +44396,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item363
+		class Item359
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44352,7 +44431,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item364
+		class Item360
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44387,7 +44466,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item365
+		class Item361
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44422,7 +44501,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item366
+		class Item362
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44457,7 +44536,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item367
+		class Item363
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44492,7 +44571,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item368
+		class Item364
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44527,7 +44606,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item369
+		class Item365
 		{
 			dataType="Object";
 			class PositionInfo
@@ -44561,7 +44640,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item370
+		class Item366
 		{
 			dataType="Group";
 			side="West";
@@ -44621,7 +44700,7 @@ class Mission
 			};
 			id=18953;
 		};
-		class Item371
+		class Item367
 		{
 			dataType="Group";
 			side="West";
@@ -44681,7 +44760,7 @@ class Mission
 			};
 			id=18955;
 		};
-		class Item372
+		class Item368
 		{
 			dataType="Group";
 			side="West";
@@ -44741,7 +44820,7 @@ class Mission
 			};
 			id=18957;
 		};
-		class Item373
+		class Item369
 		{
 			dataType="Group";
 			side="West";
@@ -44801,7 +44880,7 @@ class Mission
 			};
 			id=18959;
 		};
-		class Item374
+		class Item370
 		{
 			dataType="Group";
 			side="West";
@@ -44861,7 +44940,7 @@ class Mission
 			};
 			id=18961;
 		};
-		class Item375
+		class Item371
 		{
 			dataType="Group";
 			side="West";
@@ -44873,7 +44952,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={15679.083,18.357374,7386.5312};
+						position[]={15679.083,18.357374,7386.5313};
 						angles[]={0,3.644387,0};
 					};
 					side="West";
@@ -44923,7 +45002,7 @@ class Mission
 			id=18963;
 			atlOffset=-1.9073486e-06;
 		};
-		class Item376
+		class Item372
 		{
 			dataType="Group";
 			side="West";
@@ -44985,7 +45064,7 @@ class Mission
 			id=18965;
 			atlOffset=0.00051689148;
 		};
-		class Item377
+		class Item373
 		{
 			dataType="Group";
 			side="West";
@@ -45045,7 +45124,7 @@ class Mission
 			};
 			id=18967;
 		};
-		class Item378
+		class Item374
 		{
 			dataType="Group";
 			side="West";
@@ -45105,7 +45184,7 @@ class Mission
 			};
 			id=18969;
 		};
-		class Item379
+		class Item375
 		{
 			dataType="Group";
 			side="West";
@@ -45167,7 +45246,7 @@ class Mission
 			id=18971;
 			atlOffset=1.9073486e-06;
 		};
-		class Item380
+		class Item376
 		{
 			dataType="Group";
 			side="West";
@@ -45227,7 +45306,7 @@ class Mission
 			};
 			id=18973;
 		};
-		class Item381
+		class Item377
 		{
 			dataType="Group";
 			side="West";
@@ -45287,7 +45366,7 @@ class Mission
 			};
 			id=18975;
 		};
-		class Item382
+		class Item378
 		{
 			dataType="Group";
 			side="West";
@@ -45347,7 +45426,7 @@ class Mission
 			};
 			id=18977;
 		};
-		class Item383
+		class Item379
 		{
 			dataType="Group";
 			side="West";
@@ -45409,7 +45488,7 @@ class Mission
 			id=18979;
 			atlOffset=0.0093040466;
 		};
-		class Item384
+		class Item380
 		{
 			dataType="Group";
 			side="West";
@@ -45469,7 +45548,7 @@ class Mission
 			};
 			id=18981;
 		};
-		class Item385
+		class Item381
 		{
 			dataType="Group";
 			side="West";
@@ -45529,7 +45608,7 @@ class Mission
 			};
 			id=18983;
 		};
-		class Item386
+		class Item382
 		{
 			dataType="Group";
 			side="West";
@@ -45589,7 +45668,7 @@ class Mission
 			};
 			id=18985;
 		};
-		class Item387
+		class Item383
 		{
 			dataType="Group";
 			side="West";
@@ -45649,7 +45728,7 @@ class Mission
 			};
 			id=18987;
 		};
-		class Item388
+		class Item384
 		{
 			dataType="Group";
 			side="West";
@@ -45711,7 +45790,7 @@ class Mission
 			id=18989;
 			atlOffset=1.9073486e-06;
 		};
-		class Item389
+		class Item385
 		{
 			dataType="Group";
 			side="West";
@@ -45773,7 +45852,7 @@ class Mission
 			id=18991;
 			atlOffset=1.9073486e-06;
 		};
-		class Item390
+		class Item386
 		{
 			dataType="Group";
 			side="West";
@@ -45833,7 +45912,7 @@ class Mission
 			};
 			id=18993;
 		};
-		class Item391
+		class Item387
 		{
 			dataType="Group";
 			side="West";
@@ -45893,7 +45972,7 @@ class Mission
 			};
 			id=18995;
 		};
-		class Item392
+		class Item388
 		{
 			dataType="Group";
 			side="West";
@@ -45955,7 +46034,7 @@ class Mission
 			id=18997;
 			atlOffset=0.12563324;
 		};
-		class Item393
+		class Item389
 		{
 			dataType="Group";
 			side="West";
@@ -46017,7 +46096,7 @@ class Mission
 			id=18999;
 			atlOffset=0.051130295;
 		};
-		class Item394
+		class Item390
 		{
 			dataType="Group";
 			side="West";
@@ -46079,7 +46158,7 @@ class Mission
 			id=19001;
 			atlOffset=0.11222267;
 		};
-		class Item395
+		class Item391
 		{
 			dataType="Group";
 			side="West";
@@ -46141,7 +46220,7 @@ class Mission
 			id=19003;
 			atlOffset=0.084127426;
 		};
-		class Item396
+		class Item392
 		{
 			dataType="Group";
 			side="West";
@@ -46203,7 +46282,7 @@ class Mission
 			id=19005;
 			atlOffset=0.13380432;
 		};
-		class Item397
+		class Item393
 		{
 			dataType="Group";
 			side="West";
@@ -46265,7 +46344,7 @@ class Mission
 			id=19007;
 			atlOffset=0.085460663;
 		};
-		class Item398
+		class Item394
 		{
 			dataType="Group";
 			side="West";
@@ -46325,7 +46404,7 @@ class Mission
 			};
 			id=19009;
 		};
-		class Item399
+		class Item395
 		{
 			dataType="Group";
 			side="West";
@@ -46387,7 +46466,7 @@ class Mission
 			id=19011;
 			atlOffset=4.0054321e-05;
 		};
-		class Item400
+		class Item396
 		{
 			dataType="Group";
 			side="West";
@@ -46449,7 +46528,7 @@ class Mission
 			id=19013;
 			atlOffset=0.1174202;
 		};
-		class Item401
+		class Item397
 		{
 			dataType="Group";
 			side="West";
@@ -46511,7 +46590,7 @@ class Mission
 			id=19015;
 			atlOffset=0.12084579;
 		};
-		class Item402
+		class Item398
 		{
 			dataType="Group";
 			side="West";
@@ -46573,7 +46652,7 @@ class Mission
 			id=19017;
 			atlOffset=0.082567215;
 		};
-		class Item403
+		class Item399
 		{
 			dataType="Group";
 			side="West";
@@ -46635,7 +46714,7 @@ class Mission
 			id=19019;
 			atlOffset=0.14259148;
 		};
-		class Item404
+		class Item400
 		{
 			dataType="Group";
 			side="West";
@@ -46697,7 +46776,7 @@ class Mission
 			id=19021;
 			atlOffset=0.13325882;
 		};
-		class Item405
+		class Item401
 		{
 			dataType="Group";
 			side="West";
@@ -46759,7 +46838,7 @@ class Mission
 			id=19023;
 			atlOffset=0.12231255;
 		};
-		class Item406
+		class Item402
 		{
 			dataType="Group";
 			side="West";
@@ -46821,7 +46900,7 @@ class Mission
 			id=19025;
 			atlOffset=0.0066986084;
 		};
-		class Item407
+		class Item403
 		{
 			dataType="Group";
 			side="West";
@@ -46883,7 +46962,7 @@ class Mission
 			id=19027;
 			atlOffset=0.033052444;
 		};
-		class Item408
+		class Item404
 		{
 			dataType="Group";
 			side="West";
@@ -46945,7 +47024,7 @@ class Mission
 			id=19029;
 			atlOffset=0.020145416;
 		};
-		class Item409
+		class Item405
 		{
 			dataType="Group";
 			side="West";
@@ -47007,7 +47086,7 @@ class Mission
 			id=19031;
 			atlOffset=0.018545151;
 		};
-		class Item410
+		class Item406
 		{
 			dataType="Group";
 			side="West";
@@ -47067,7 +47146,7 @@ class Mission
 			};
 			id=19033;
 		};
-		class Item411
+		class Item407
 		{
 			dataType="Group";
 			side="West";
@@ -47127,7 +47206,7 @@ class Mission
 			};
 			id=19035;
 		};
-		class Item412
+		class Item408
 		{
 			dataType="Group";
 			side="West";
@@ -47187,7 +47266,7 @@ class Mission
 			};
 			id=19037;
 		};
-		class Item413
+		class Item409
 		{
 			dataType="Group";
 			side="West";
@@ -47247,7 +47326,7 @@ class Mission
 			};
 			id=19039;
 		};
-		class Item414
+		class Item410
 		{
 			dataType="Group";
 			side="West";
@@ -47307,7 +47386,7 @@ class Mission
 			};
 			id=19041;
 		};
-		class Item415
+		class Item411
 		{
 			dataType="Group";
 			side="West";
@@ -47367,7 +47446,7 @@ class Mission
 			};
 			id=19043;
 		};
-		class Item416
+		class Item412
 		{
 			dataType="Group";
 			side="West";
@@ -47429,7 +47508,7 @@ class Mission
 			id=19045;
 			atlOffset=0.00049209595;
 		};
-		class Item417
+		class Item413
 		{
 			dataType="Group";
 			side="West";
@@ -47489,7 +47568,7 @@ class Mission
 			};
 			id=19047;
 		};
-		class Item418
+		class Item414
 		{
 			dataType="Group";
 			side="West";
@@ -47549,7 +47628,7 @@ class Mission
 			};
 			id=19049;
 		};
-		class Item419
+		class Item415
 		{
 			dataType="Group";
 			side="West";
@@ -47609,7 +47688,7 @@ class Mission
 			};
 			id=19051;
 		};
-		class Item420
+		class Item416
 		{
 			dataType="Group";
 			side="West";
@@ -47669,7 +47748,7 @@ class Mission
 			};
 			id=19053;
 		};
-		class Item421
+		class Item417
 		{
 			dataType="Group";
 			side="West";
@@ -47729,7 +47808,7 @@ class Mission
 			};
 			id=19055;
 		};
-		class Item422
+		class Item418
 		{
 			dataType="Group";
 			side="West";
@@ -47789,7 +47868,7 @@ class Mission
 			};
 			id=19057;
 		};
-		class Item423
+		class Item419
 		{
 			dataType="Group";
 			side="West";
@@ -47851,7 +47930,7 @@ class Mission
 			id=19059;
 			atlOffset=0.0092773438;
 		};
-		class Item424
+		class Item420
 		{
 			dataType="Group";
 			side="West";
@@ -47911,7 +47990,7 @@ class Mission
 			};
 			id=19061;
 		};
-		class Item425
+		class Item421
 		{
 			dataType="Group";
 			side="West";
@@ -47973,7 +48052,7 @@ class Mission
 			id=19063;
 			atlOffset=-1.9073486e-06;
 		};
-		class Item426
+		class Item422
 		{
 			dataType="Group";
 			side="West";
@@ -48033,7 +48112,7 @@ class Mission
 			};
 			id=19065;
 		};
-		class Item427
+		class Item423
 		{
 			dataType="Group";
 			side="West";
@@ -48093,7 +48172,7 @@ class Mission
 			};
 			id=19067;
 		};
-		class Item428
+		class Item424
 		{
 			dataType="Group";
 			side="West";
@@ -48153,7 +48232,7 @@ class Mission
 			};
 			id=19069;
 		};
-		class Item429
+		class Item425
 		{
 			dataType="Group";
 			side="West";
@@ -48213,7 +48292,7 @@ class Mission
 			};
 			id=19071;
 		};
-		class Item430
+		class Item426
 		{
 			dataType="Group";
 			side="West";
@@ -48273,7 +48352,7 @@ class Mission
 			};
 			id=19073;
 		};
-		class Item431
+		class Item427
 		{
 			dataType="Group";
 			side="West";
@@ -48333,7 +48412,7 @@ class Mission
 			};
 			id=19075;
 		};
-		class Item432
+		class Item428
 		{
 			dataType="Group";
 			side="West";
@@ -48395,7 +48474,7 @@ class Mission
 			id=19077;
 			atlOffset=0.12560844;
 		};
-		class Item433
+		class Item429
 		{
 			dataType="Group";
 			side="West";
@@ -48457,7 +48536,7 @@ class Mission
 			id=19079;
 			atlOffset=0.05109024;
 		};
-		class Item434
+		class Item430
 		{
 			dataType="Group";
 			side="West";
@@ -48519,7 +48598,7 @@ class Mission
 			id=19081;
 			atlOffset=0.11219597;
 		};
-		class Item435
+		class Item431
 		{
 			dataType="Group";
 			side="West";
@@ -48581,7 +48660,7 @@ class Mission
 			id=19083;
 			atlOffset=0.084098816;
 		};
-		class Item436
+		class Item432
 		{
 			dataType="Group";
 			side="West";
@@ -48643,7 +48722,7 @@ class Mission
 			id=19085;
 			atlOffset=0.13377571;
 		};
-		class Item437
+		class Item433
 		{
 			dataType="Group";
 			side="West";
@@ -48705,7 +48784,7 @@ class Mission
 			id=19087;
 			atlOffset=0.085432053;
 		};
-		class Item438
+		class Item434
 		{
 			dataType="Group";
 			side="West";
@@ -48765,7 +48844,7 @@ class Mission
 			};
 			id=19089;
 		};
-		class Item439
+		class Item435
 		{
 			dataType="Group";
 			side="West";
@@ -48827,7 +48906,7 @@ class Mission
 			id=19091;
 			atlOffset=1.1444092e-05;
 		};
-		class Item440
+		class Item436
 		{
 			dataType="Group";
 			side="West";
@@ -48889,7 +48968,7 @@ class Mission
 			id=19093;
 			atlOffset=0.11739159;
 		};
-		class Item441
+		class Item437
 		{
 			dataType="Group";
 			side="West";
@@ -48951,7 +49030,7 @@ class Mission
 			id=19095;
 			atlOffset=0.12081718;
 		};
-		class Item442
+		class Item438
 		{
 			dataType="Group";
 			side="West";
@@ -49013,7 +49092,7 @@ class Mission
 			id=19097;
 			atlOffset=0.082540512;
 		};
-		class Item443
+		class Item439
 		{
 			dataType="Group";
 			side="West";
@@ -49075,7 +49154,7 @@ class Mission
 			id=19099;
 			atlOffset=0.14256477;
 		};
-		class Item444
+		class Item440
 		{
 			dataType="Group";
 			side="West";
@@ -49137,7 +49216,7 @@ class Mission
 			id=19101;
 			atlOffset=0.13323021;
 		};
-		class Item445
+		class Item441
 		{
 			dataType="Group";
 			side="West";
@@ -49199,7 +49278,7 @@ class Mission
 			id=19103;
 			atlOffset=0.12228394;
 		};
-		class Item446
+		class Item442
 		{
 			dataType="Group";
 			side="West";
@@ -49261,7 +49340,7 @@ class Mission
 			id=19105;
 			atlOffset=0.0066719055;
 		};
-		class Item447
+		class Item443
 		{
 			dataType="Group";
 			side="West";
@@ -49323,7 +49402,7 @@ class Mission
 			id=19107;
 			atlOffset=0.033025742;
 		};
-		class Item448
+		class Item444
 		{
 			dataType="Group";
 			side="West";
@@ -49385,7 +49464,7 @@ class Mission
 			id=19109;
 			atlOffset=0.020118713;
 		};
-		class Item449
+		class Item445
 		{
 			dataType="Group";
 			side="West";
@@ -49447,7 +49526,7 @@ class Mission
 			id=19111;
 			atlOffset=0.018518448;
 		};
-		class Item450
+		class Item446
 		{
 			dataType="Group";
 			side="West";
@@ -49507,7 +49586,7 @@ class Mission
 			};
 			id=19113;
 		};
-		class Item451
+		class Item447
 		{
 			dataType="Group";
 			side="West";
@@ -49569,7 +49648,7 @@ class Mission
 			id=19115;
 			atlOffset=0.013397217;
 		};
-		class Item452
+		class Item448
 		{
 			dataType="Group";
 			side="West";
@@ -49629,7 +49708,7 @@ class Mission
 			};
 			id=19117;
 		};
-		class Item453
+		class Item449
 		{
 			dataType="Group";
 			side="West";
@@ -49689,7 +49768,7 @@ class Mission
 			};
 			id=19119;
 		};
-		class Item454
+		class Item450
 		{
 			dataType="Group";
 			side="West";
@@ -49749,7 +49828,7 @@ class Mission
 			};
 			id=19121;
 		};
-		class Item455
+		class Item451
 		{
 			dataType="Group";
 			side="West";
@@ -49811,7 +49890,7 @@ class Mission
 			id=19123;
 			atlOffset=0.021564484;
 		};
-		class Item456
+		class Item452
 		{
 			dataType="Group";
 			side="West";
@@ -49871,7 +49950,7 @@ class Mission
 			};
 			id=19125;
 		};
-		class Item457
+		class Item453
 		{
 			dataType="Group";
 			side="West";
@@ -49933,7 +50012,7 @@ class Mission
 			id=19127;
 			atlOffset=1.9073486e-06;
 		};
-		class Item458
+		class Item454
 		{
 			dataType="Group";
 			side="West";
@@ -49995,7 +50074,7 @@ class Mission
 			id=19129;
 			atlOffset=1.9073486e-06;
 		};
-		class Item459
+		class Item455
 		{
 			dataType="Group";
 			side="West";
@@ -50057,7 +50136,7 @@ class Mission
 			id=19131;
 			atlOffset=0.0051803589;
 		};
-		class Item460
+		class Item456
 		{
 			dataType="Group";
 			side="West";
@@ -50119,7 +50198,7 @@ class Mission
 			id=19133;
 			atlOffset=0.008605957;
 		};
-		class Item461
+		class Item457
 		{
 			dataType="Group";
 			side="West";
@@ -50179,7 +50258,7 @@ class Mission
 			};
 			id=19135;
 		};
-		class Item462
+		class Item458
 		{
 			dataType="Group";
 			side="West";
@@ -50241,7 +50320,7 @@ class Mission
 			id=19137;
 			atlOffset=0.030353546;
 		};
-		class Item463
+		class Item459
 		{
 			dataType="Group";
 			side="West";
@@ -50303,7 +50382,7 @@ class Mission
 			id=19139;
 			atlOffset=0.021018982;
 		};
-		class Item464
+		class Item460
 		{
 			dataType="Group";
 			side="West";
@@ -50365,7 +50444,7 @@ class Mission
 			id=19141;
 			atlOffset=0.010072708;
 		};
-		class Item465
+		class Item461
 		{
 			dataType="Group";
 			side="West";
@@ -50425,7 +50504,7 @@ class Mission
 			};
 			id=19143;
 		};
-		class Item466
+		class Item462
 		{
 			dataType="Group";
 			side="West";
@@ -50485,7 +50564,7 @@ class Mission
 			};
 			id=19145;
 		};
-		class Item467
+		class Item463
 		{
 			dataType="Group";
 			side="West";
@@ -50545,7 +50624,7 @@ class Mission
 			};
 			id=19147;
 		};
-		class Item468
+		class Item464
 		{
 			dataType="Group";
 			side="West";
@@ -50605,7 +50684,7 @@ class Mission
 			};
 			id=19149;
 		};
-		class Item469
+		class Item465
 		{
 			dataType="Group";
 			side="West";
@@ -50667,7 +50746,7 @@ class Mission
 			id=19151;
 			atlOffset=0.0051803589;
 		};
-		class Item470
+		class Item466
 		{
 			dataType="Layer";
 			name="Unit Bases";
@@ -50685,7 +50764,7 @@ class Mission
 			id=19153;
 			atlOffset=103.16;
 		};
-		class Item471
+		class Item467
 		{
 			dataType="Layer";
 			name="Unit Bases_1";
@@ -50703,7 +50782,7 @@ class Mission
 			id=19156;
 			atlOffset=103.16;
 		};
-		class Item472
+		class Item468
 		{
 			dataType="Layer";
 			name="Unit Bases_2";
@@ -50721,7 +50800,7 @@ class Mission
 			id=19159;
 			atlOffset=103.16;
 		};
-		class Item473
+		class Item469
 		{
 			dataType="Object";
 			class PositionInfo
@@ -50755,7 +50834,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item474
+		class Item470
 		{
 			dataType="Object";
 			class PositionInfo
@@ -50789,7 +50868,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item475
+		class Item471
 		{
 			dataType="Object";
 			class PositionInfo
@@ -50823,7 +50902,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item476
+		class Item472
 		{
 			dataType="Object";
 			class PositionInfo
@@ -50857,7 +50936,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item477
+		class Item473
 		{
 			dataType="Object";
 			class PositionInfo
@@ -50891,7 +50970,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item478
+		class Item474
 		{
 			dataType="Object";
 			class PositionInfo
@@ -50925,7 +51004,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item479
+		class Item475
 		{
 			dataType="Object";
 			class PositionInfo
@@ -50959,7 +51038,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item480
+		class Item476
 		{
 			dataType="Object";
 			class PositionInfo
@@ -50993,7 +51072,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item481
+		class Item477
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51027,7 +51106,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item482
+		class Item478
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51061,7 +51140,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item483
+		class Item479
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51095,7 +51174,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item484
+		class Item480
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51129,7 +51208,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item485
+		class Item481
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51163,7 +51242,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item486
+		class Item482
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51197,7 +51276,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item487
+		class Item483
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51231,7 +51310,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item488
+		class Item484
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51265,7 +51344,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item489
+		class Item485
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51299,7 +51378,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item490
+		class Item486
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51333,7 +51412,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item491
+		class Item487
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51367,7 +51446,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item492
+		class Item488
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51401,7 +51480,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item493
+		class Item489
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51435,7 +51514,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item494
+		class Item490
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51469,7 +51548,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item495
+		class Item491
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51503,7 +51582,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item496
+		class Item492
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51537,7 +51616,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item497
+		class Item493
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51571,7 +51650,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item498
+		class Item494
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51605,7 +51684,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item499
+		class Item495
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51639,7 +51718,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item500
+		class Item496
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51673,7 +51752,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item501
+		class Item497
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51707,7 +51786,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item502
+		class Item498
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51741,7 +51820,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item503
+		class Item499
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51775,7 +51854,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item504
+		class Item500
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51809,7 +51888,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item505
+		class Item501
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51843,7 +51922,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item506
+		class Item502
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51877,7 +51956,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item507
+		class Item503
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51911,7 +51990,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item508
+		class Item504
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51945,7 +52024,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item509
+		class Item505
 		{
 			dataType="Object";
 			class PositionInfo
@@ -51979,7 +52058,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item510
+		class Item506
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52013,7 +52092,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item511
+		class Item507
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52047,7 +52126,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item512
+		class Item508
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52081,7 +52160,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item513
+		class Item509
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52115,7 +52194,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item514
+		class Item510
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52149,7 +52228,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item515
+		class Item511
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52183,7 +52262,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item516
+		class Item512
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52217,7 +52296,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item517
+		class Item513
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52251,7 +52330,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item518
+		class Item514
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52285,7 +52364,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item519
+		class Item515
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52319,7 +52398,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item520
+		class Item516
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52353,7 +52432,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item521
+		class Item517
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52387,7 +52466,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item522
+		class Item518
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52421,7 +52500,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item523
+		class Item519
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52455,7 +52534,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item524
+		class Item520
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52489,7 +52568,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item525
+		class Item521
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52523,7 +52602,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item526
+		class Item522
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52557,7 +52636,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item527
+		class Item523
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52591,7 +52670,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item528
+		class Item524
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52625,7 +52704,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item529
+		class Item525
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52659,7 +52738,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item530
+		class Item526
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52693,7 +52772,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item531
+		class Item527
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52727,7 +52806,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item532
+		class Item528
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52761,7 +52840,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item533
+		class Item529
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52795,7 +52874,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item534
+		class Item530
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52829,7 +52908,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item535
+		class Item531
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52863,7 +52942,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item536
+		class Item532
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52897,7 +52976,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item537
+		class Item533
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52931,7 +53010,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item538
+		class Item534
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52965,7 +53044,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item539
+		class Item535
 		{
 			dataType="Object";
 			class PositionInfo
@@ -52999,7 +53078,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item540
+		class Item536
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53033,7 +53112,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item541
+		class Item537
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53067,7 +53146,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item542
+		class Item538
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53101,7 +53180,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item543
+		class Item539
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53135,7 +53214,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item544
+		class Item540
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53169,7 +53248,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item545
+		class Item541
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53203,7 +53282,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item546
+		class Item542
 		{
 			dataType="Layer";
 			name="Unit Bases_3";
@@ -53221,7 +53300,7 @@ class Mission
 			id=19256;
 			atlOffset=103.16;
 		};
-		class Item547
+		class Item543
 		{
 			dataType="Layer";
 			name="Unit Bases_4";
@@ -53454,7 +53533,7 @@ class Mission
 							dataType="Object";
 							class PositionInfo
 							{
-								position[]={15831.181,14.98,7056.0591};
+								position[]={15825.481,14.98,7056.123};
 								angles[]={1.5693651,0,6.2570052};
 							};
 							side="Empty";
@@ -53508,7 +53587,7 @@ class Mission
 			id=19268;
 			atlOffset=0.39640617;
 		};
-		class Item548
+		class Item544
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53525,7 +53604,7 @@ class Mission
 			type="UserTexture1m_F";
 			atlOffset=-0.01219368;
 		};
-		class Item549
+		class Item545
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53559,7 +53638,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item550
+		class Item546
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53593,7 +53672,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item551
+		class Item547
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53610,7 +53689,7 @@ class Mission
 			type="Land_vn_guardtower_01_f";
 			atlOffset=0.88782883;
 		};
-		class Item552
+		class Item548
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53644,7 +53723,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item553
+		class Item549
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53678,7 +53757,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item554
+		class Item550
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53695,7 +53774,7 @@ class Mission
 			type="Land_vn_sign_warningmilitaryarea_f";
 			atlOffset=0.14048195;
 		};
-		class Item555
+		class Item551
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53728,7 +53807,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item556
+		class Item552
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53762,7 +53841,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item557
+		class Item553
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53796,7 +53875,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item558
+		class Item554
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53830,7 +53909,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item559
+		class Item555
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53864,7 +53943,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item560
+		class Item556
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53898,7 +53977,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item561
+		class Item557
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53945,7 +54024,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item562
+		class Item558
 		{
 			dataType="Object";
 			class PositionInfo
@@ -53979,7 +54058,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item563
+		class Item559
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54014,7 +54093,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item564
+		class Item560
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54047,7 +54126,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item565
+		class Item561
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54081,7 +54160,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item566
+		class Item562
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54116,7 +54195,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item567
+		class Item563
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54150,14 +54229,14 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item568
+		class Item564
 		{
 			dataType="Layer";
 			name="Layer 29684";
 			id=19359;
 			atlOffset=103.16;
 		};
-		class Item569
+		class Item565
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54190,7 +54269,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item570
+		class Item566
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54224,7 +54303,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item571
+		class Item567
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54259,7 +54338,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item572
+		class Item568
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54293,7 +54372,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item573
+		class Item569
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54327,7 +54406,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item574
+		class Item570
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54361,7 +54440,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item575
+		class Item571
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54395,7 +54474,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item576
+		class Item572
 		{
 			dataType="Object";
 			class PositionInfo
@@ -54429,7 +54508,644 @@ class Mission
 				nAttributes=1;
 			};
 		};
+		class Item573
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={16275.046,21.154259,6327.7261};
+				angles[]={0,0.59040993,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=19451;
+			type="Land_vn_mil_wallbig_4m_f";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item574
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={16271.212,21.351112,6321.6709};
+				angles[]={0,3.7319958,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+			};
+			id=19453;
+			type="Land_vn_mil_wallbig_4m_f";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item575
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15316.024,21.57559,6966.8003};
+				angles[]={0,0.78540027,0};
+			};
+			side="Empty";
+			flags=1;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19464;
+			type="Land_vn_bridgesea_01_f";
+			atlOffset=18.950943;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item576
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15349.952,20.090034,7000.71};
+				angles[]={0,0.78539819,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19467;
+			type="Land_vn_bridgesea_01_ramp_f";
+			atlOffset=0.14842415;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
 		class Item577
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15333.637,2.2855892,6984.0781};
+				angles[]={0,3.9269907,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19468;
+			type="Land_vn_bridgesea_01_pillar_f";
+			atlOffset=-26.602947;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item578
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15214.539,20.084476,6865.3228};
+				angles[]={0,3.926991,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19469;
+			type="Land_vn_bridgesea_01_ramp_f";
+			atlOffset=0.14842606;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item579
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15282.233,21.57559,6933.0098};
+				angles[]={0,3.9269912,0};
+			};
+			side="Empty";
+			flags=1;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19470;
+			type="Land_vn_bridgesea_01_f";
+			atlOffset=26.302986;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item580
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15248.465,21.57559,6899.2412};
+				angles[]={0,3.9269912,0};
+			};
+			side="Empty";
+			flags=1;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19471;
+			type="Land_vn_bridgesea_01_f";
+			atlOffset=15.730919;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item581
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15302.951,2.2855892,6953.458};
+				angles[]={0,3.9269907,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19473;
+			type="Land_vn_bridgesea_01_pillar_f";
+			atlOffset=-16.270748;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item582
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15256.781,2.2855892,6907.2881};
+				angles[]={0,3.9269907,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19474;
+			type="Land_vn_bridgesea_01_pillar_f";
+			atlOffset=-16.664127;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item583
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15231.865,2.2855892,6882.3726};
+				angles[]={0,3.9269907,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19475;
+			type="Land_vn_bridgesea_01_pillar_f";
+			atlOffset=-31.143114;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item584
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15279.952,2.2855892,6930.459};
+				angles[]={0,3.9269907,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				disableSimulation=1;
+			};
+			id=19476;
+			type="Land_vn_bridgesea_01_pillar_f";
+			atlOffset=-10.93735;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item585
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15684.953,15.763977,7055.4712};
+				angles[]={0,1.1782196,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="supply_CleanUp_0";
+				disableSimulation=1;
+			};
+			id=19506;
+			type="Land_GarbageContainer_closed_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item586
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15685.088,15.7185,7058.7549};
+				angles[]={0,2.1381505,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="supply_CleanUp_1";
+				disableSimulation=1;
+			};
+			id=19507;
+			type="Land_GarbageContainer_open_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item587
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={16398.434,15.763977,6536.0781};
+				angles[]={0,3.5344141,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="supply_cleanup_2";
+				disableSimulation=1;
+			};
+			id=19515;
+			type="Land_GarbageContainer_closed_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item588
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={16400.744,15.7185,6536.064};
+				angles[]={0,2.8362823,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="supply_cleanup_3";
+				disableSimulation=1;
+			};
+			id=19516;
+			type="Land_GarbageContainer_open_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item589
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15974.093,12.913208,7965.4927};
+				angles[]={0,1.7890865,0};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="supply_cleanup_4";
+				disableSimulation=1;
+			};
+			id=19519;
+			type="Land_GarbageContainer_closed_F";
+			atlOffset=-0.010558128;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item590
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={20070.012,4.8702393,9771.0488};
+				angles[]={0,5.0856609,0};
+			};
+			areaSize[]={9.9535971,0,38.115589};
+			areaIsRectangle=1;
+			flags=1;
+			id=9000;
+			type="ModuleHideTerrainObjects_F";
+			atlOffset=1.1303039;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="#filter";
+					expression="_this setVariable [""#filter"",_value]";
+					class Value
+					{
+						class data
+						{
+							singleType="SCALAR";
+							value=4;
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="#hideLocally";
+					expression="_this setVariable [""#hideLocally"",_value]";
+					class Value
+					{
+						class data
+						{
+							singleType="BOOL";
+							value=0;
+						};
+					};
+				};
+				nAttributes=2;
+			};
+		};
+		class Item591
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -54469,598 +55185,6 @@ class Mission
 					};
 				};
 				nAttributes=2;
-			};
-		};
-		class Item578
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={16275.046,21.154259,6327.7261};
-				angles[]={0,0.59040993,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=19451;
-			type="Land_vn_mil_wallbig_4m_f";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item579
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={16271.212,21.351112,6321.6709};
-				angles[]={0,3.7319958,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-			};
-			id=19453;
-			type="Land_vn_mil_wallbig_4m_f";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item580
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15316.024,21.57559,6966.8003};
-				angles[]={0,0.78540027,0};
-			};
-			side="Empty";
-			flags=1;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19464;
-			type="Land_vn_bridgesea_01_f";
-			atlOffset=18.950943;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item581
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15349.952,20.090034,7000.71};
-				angles[]={0,0.78539819,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19467;
-			type="Land_vn_bridgesea_01_ramp_f";
-			atlOffset=0.14842415;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item582
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15333.637,2.2855892,6984.0781};
-				angles[]={0,3.9269907,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19468;
-			type="Land_vn_bridgesea_01_pillar_f";
-			atlOffset=-26.602947;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item583
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15214.539,20.084476,6865.3228};
-				angles[]={0,3.926991,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19469;
-			type="Land_vn_bridgesea_01_ramp_f";
-			atlOffset=0.14842606;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item584
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15282.233,21.57559,6933.0098};
-				angles[]={0,3.9269912,0};
-			};
-			side="Empty";
-			flags=1;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19470;
-			type="Land_vn_bridgesea_01_f";
-			atlOffset=26.302986;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item585
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15248.465,21.57559,6899.2412};
-				angles[]={0,3.9269912,0};
-			};
-			side="Empty";
-			flags=1;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19471;
-			type="Land_vn_bridgesea_01_f";
-			atlOffset=15.730919;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item586
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15302.951,2.2855892,6953.458};
-				angles[]={0,3.9269907,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19473;
-			type="Land_vn_bridgesea_01_pillar_f";
-			atlOffset=-16.270748;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item587
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15256.781,2.2855892,6907.2881};
-				angles[]={0,3.9269907,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19474;
-			type="Land_vn_bridgesea_01_pillar_f";
-			atlOffset=-16.664127;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item588
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15231.865,2.2855892,6882.3726};
-				angles[]={0,3.9269907,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19475;
-			type="Land_vn_bridgesea_01_pillar_f";
-			atlOffset=-31.143114;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item589
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15279.952,2.2855892,6930.459};
-				angles[]={0,3.9269907,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				disableSimulation=1;
-			};
-			id=19476;
-			type="Land_vn_bridgesea_01_pillar_f";
-			atlOffset=-10.93735;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item590
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15684.953,15.763977,7055.4712};
-				angles[]={0,1.1782196,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				name="supply_CleanUp_0";
-				disableSimulation=1;
-			};
-			id=19506;
-			type="Land_GarbageContainer_closed_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item591
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15685.088,15.7185,7058.7549};
-				angles[]={0,2.1381505,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				name="supply_CleanUp_1";
-				disableSimulation=1;
-			};
-			id=19507;
-			type="Land_GarbageContainer_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item592
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={16398.434,15.763977,6536.0781};
-				angles[]={0,3.5344141,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				name="supply_cleanup_2";
-				disableSimulation=1;
-			};
-			id=19515;
-			type="Land_GarbageContainer_closed_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item593
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={16400.744,15.7185,6536.064};
-				angles[]={0,2.8362823,0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				name="supply_cleanup_3";
-				disableSimulation=1;
-			};
-			id=19516;
-			type="Land_GarbageContainer_open_F";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item594
-		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={15974.093,12.913208,7965.4927};
-				angles[]={0,1.7890865,-0};
-			};
-			side="Empty";
-			flags=5;
-			class Attributes
-			{
-				name="supply_cleanup_4";
-				disableSimulation=1;
-			};
-			id=19519;
-			type="Land_GarbageContainer_closed_F";
-			atlOffset=-0.010558128;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="allowDamage";
-					expression="_this allowdamage _value;";
-					class Value
-					{
-						class data
-						{
-							singleType="BOOL";
-							value=0;
-						};
-					};
-				};
-				nAttributes=1;
 			};
 		};
 	};
@@ -55136,7 +55260,7 @@ class Mission
 			class Item6
 			{
 				linkID=6;
-				item0=3784;
+				item0=4474;
 				item1=264;
 				class CustomData
 				{
@@ -55146,7 +55270,7 @@ class Mission
 			class Item7
 			{
 				linkID=7;
-				item0=4474;
+				item0=1177;
 				item1=264;
 				class CustomData
 				{
@@ -55156,7 +55280,7 @@ class Mission
 			class Item8
 			{
 				linkID=8;
-				item0=1177;
+				item0=1502;
 				item1=264;
 				class CustomData
 				{
@@ -55166,7 +55290,7 @@ class Mission
 			class Item9
 			{
 				linkID=9;
-				item0=1502;
+				item0=6532;
 				item1=264;
 				class CustomData
 				{
@@ -55176,7 +55300,7 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=6532;
+				item0=6261;
 				item1=264;
 				class CustomData
 				{
@@ -55186,7 +55310,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=6261;
+				item0=6545;
 				item1=264;
 				class CustomData
 				{
@@ -55196,7 +55320,7 @@ class Mission
 			class Item12
 			{
 				linkID=12;
-				item0=6545;
+				item0=1413;
 				item1=264;
 				class CustomData
 				{
@@ -55206,7 +55330,7 @@ class Mission
 			class Item13
 			{
 				linkID=13;
-				item0=1413;
+				item0=7241;
 				item1=264;
 				class CustomData
 				{
@@ -55216,8 +55340,8 @@ class Mission
 			class Item14
 			{
 				linkID=14;
-				item0=7241;
-				item1=264;
+				item0=7664;
+				item1=705;
 				class CustomData
 				{
 					type="Sync";
@@ -55226,7 +55350,7 @@ class Mission
 			class Item15
 			{
 				linkID=15;
-				item0=7664;
+				item0=7677;
 				item1=705;
 				class CustomData
 				{
@@ -55236,7 +55360,7 @@ class Mission
 			class Item16
 			{
 				linkID=16;
-				item0=7677;
+				item0=7672;
 				item1=705;
 				class CustomData
 				{
@@ -55246,8 +55370,8 @@ class Mission
 			class Item17
 			{
 				linkID=17;
-				item0=7672;
-				item1=705;
+				item0=8994;
+				item1=264;
 				class CustomData
 				{
 					type="Sync";
@@ -55256,8 +55380,8 @@ class Mission
 			class Item18
 			{
 				linkID=18;
-				item0=8994;
-				item1=264;
+				item0=7677;
+				item1=7664;
 				class CustomData
 				{
 					type="Sync";
@@ -55266,7 +55390,7 @@ class Mission
 			class Item19
 			{
 				linkID=19;
-				item0=7677;
+				item0=7672;
 				item1=7664;
 				class CustomData
 				{
@@ -55276,8 +55400,8 @@ class Mission
 			class Item20
 			{
 				linkID=20;
-				item0=7672;
-				item1=7664;
+				item0=264;
+				item1=14747;
 				class CustomData
 				{
 					type="Sync";
@@ -55286,8 +55410,8 @@ class Mission
 			class Item21
 			{
 				linkID=21;
-				item0=264;
-				item1=14747;
+				item0=1541;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -55296,7 +55420,7 @@ class Mission
 			class Item22
 			{
 				linkID=22;
-				item0=1541;
+				item0=1538;
 				item1=823;
 				class CustomData
 				{
@@ -55306,7 +55430,7 @@ class Mission
 			class Item23
 			{
 				linkID=23;
-				item0=1538;
+				item0=5822;
 				item1=823;
 				class CustomData
 				{
@@ -55316,7 +55440,7 @@ class Mission
 			class Item24
 			{
 				linkID=24;
-				item0=5822;
+				item0=18179;
 				item1=823;
 				class CustomData
 				{
@@ -55326,7 +55450,7 @@ class Mission
 			class Item25
 			{
 				linkID=25;
-				item0=18179;
+				item0=18178;
 				item1=823;
 				class CustomData
 				{
@@ -55336,7 +55460,7 @@ class Mission
 			class Item26
 			{
 				linkID=26;
-				item0=18178;
+				item0=18180;
 				item1=823;
 				class CustomData
 				{
@@ -55346,7 +55470,7 @@ class Mission
 			class Item27
 			{
 				linkID=27;
-				item0=18180;
+				item0=18181;
 				item1=823;
 				class CustomData
 				{
@@ -55356,7 +55480,7 @@ class Mission
 			class Item28
 			{
 				linkID=28;
-				item0=18181;
+				item0=8336;
 				item1=823;
 				class CustomData
 				{
@@ -55366,7 +55490,7 @@ class Mission
 			class Item29
 			{
 				linkID=29;
-				item0=8336;
+				item0=8335;
 				item1=823;
 				class CustomData
 				{
@@ -55376,7 +55500,7 @@ class Mission
 			class Item30
 			{
 				linkID=30;
-				item0=8335;
+				item0=8348;
 				item1=823;
 				class CustomData
 				{
@@ -55386,7 +55510,7 @@ class Mission
 			class Item31
 			{
 				linkID=31;
-				item0=8348;
+				item0=8347;
 				item1=823;
 				class CustomData
 				{
@@ -55396,8 +55520,8 @@ class Mission
 			class Item32
 			{
 				linkID=32;
-				item0=8347;
-				item1=823;
+				item0=6544;
+				item1=264;
 				class CustomData
 				{
 					type="Sync";
@@ -55406,8 +55530,8 @@ class Mission
 			class Item33
 			{
 				linkID=33;
-				item0=6544;
-				item1=264;
+				item0=264;
+				item1=15198;
 				class CustomData
 				{
 					type="Sync";
@@ -55416,8 +55540,8 @@ class Mission
 			class Item34
 			{
 				linkID=34;
-				item0=264;
-				item1=15198;
+				item0=15264;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -55426,7 +55550,7 @@ class Mission
 			class Item35
 			{
 				linkID=35;
-				item0=15264;
+				item0=15262;
 				item1=823;
 				class CustomData
 				{
@@ -55436,7 +55560,7 @@ class Mission
 			class Item36
 			{
 				linkID=36;
-				item0=15262;
+				item0=15261;
 				item1=823;
 				class CustomData
 				{
@@ -55446,8 +55570,8 @@ class Mission
 			class Item37
 			{
 				linkID=37;
-				item0=15261;
-				item1=823;
+				item0=16447;
+				item1=16448;
 				class CustomData
 				{
 					type="Sync";
@@ -55456,7 +55580,7 @@ class Mission
 			class Item38
 			{
 				linkID=38;
-				item0=16447;
+				item0=16446;
 				item1=16448;
 				class CustomData
 				{
@@ -55466,8 +55590,8 @@ class Mission
 			class Item39
 			{
 				linkID=39;
-				item0=16446;
-				item1=16448;
+				item0=16468;
+				item1=16467;
 				class CustomData
 				{
 					type="Sync";
@@ -55476,7 +55600,7 @@ class Mission
 			class Item40
 			{
 				linkID=40;
-				item0=16468;
+				item0=16466;
 				item1=16467;
 				class CustomData
 				{
@@ -55486,8 +55610,8 @@ class Mission
 			class Item41
 			{
 				linkID=41;
-				item0=16466;
-				item1=16467;
+				item0=16452;
+				item1=16451;
 				class CustomData
 				{
 					type="Sync";
@@ -55496,7 +55620,7 @@ class Mission
 			class Item42
 			{
 				linkID=42;
-				item0=16452;
+				item0=16450;
 				item1=16451;
 				class CustomData
 				{
@@ -55506,8 +55630,8 @@ class Mission
 			class Item43
 			{
 				linkID=43;
-				item0=16450;
-				item1=16451;
+				item0=16464;
+				item1=16463;
 				class CustomData
 				{
 					type="Sync";
@@ -55516,7 +55640,7 @@ class Mission
 			class Item44
 			{
 				linkID=44;
-				item0=16464;
+				item0=16462;
 				item1=16463;
 				class CustomData
 				{
@@ -55526,8 +55650,8 @@ class Mission
 			class Item45
 			{
 				linkID=45;
-				item0=16462;
-				item1=16463;
+				item0=16460;
+				item1=16459;
 				class CustomData
 				{
 					type="Sync";
@@ -55536,7 +55660,7 @@ class Mission
 			class Item46
 			{
 				linkID=46;
-				item0=16460;
+				item0=16458;
 				item1=16459;
 				class CustomData
 				{
@@ -55546,8 +55670,8 @@ class Mission
 			class Item47
 			{
 				linkID=47;
-				item0=16458;
-				item1=16459;
+				item0=16388;
+				item1=16393;
 				class CustomData
 				{
 					type="Sync";
@@ -55556,7 +55680,7 @@ class Mission
 			class Item48
 			{
 				linkID=48;
-				item0=16388;
+				item0=16390;
 				item1=16393;
 				class CustomData
 				{
@@ -55566,8 +55690,8 @@ class Mission
 			class Item49
 			{
 				linkID=49;
-				item0=16390;
-				item1=16393;
+				item0=16396;
+				item1=16394;
 				class CustomData
 				{
 					type="Sync";
@@ -55576,7 +55700,7 @@ class Mission
 			class Item50
 			{
 				linkID=50;
-				item0=16396;
+				item0=16391;
 				item1=16394;
 				class CustomData
 				{
@@ -55586,8 +55710,8 @@ class Mission
 			class Item51
 			{
 				linkID=51;
-				item0=16391;
-				item1=16394;
+				item0=16389;
+				item1=16395;
 				class CustomData
 				{
 					type="Sync";
@@ -55596,7 +55720,7 @@ class Mission
 			class Item52
 			{
 				linkID=52;
-				item0=16389;
+				item0=16392;
 				item1=16395;
 				class CustomData
 				{
@@ -55606,8 +55730,8 @@ class Mission
 			class Item53
 			{
 				linkID=53;
-				item0=16392;
-				item1=16395;
+				item0=16498;
+				item1=16496;
 				class CustomData
 				{
 					type="Sync";
@@ -55616,7 +55740,7 @@ class Mission
 			class Item54
 			{
 				linkID=54;
-				item0=16498;
+				item0=16497;
 				item1=16496;
 				class CustomData
 				{
@@ -55626,8 +55750,8 @@ class Mission
 			class Item55
 			{
 				linkID=55;
-				item0=16497;
-				item1=16496;
+				item0=16501;
+				item1=16499;
 				class CustomData
 				{
 					type="Sync";
@@ -55636,7 +55760,7 @@ class Mission
 			class Item56
 			{
 				linkID=56;
-				item0=16501;
+				item0=16500;
 				item1=16499;
 				class CustomData
 				{
@@ -55646,8 +55770,8 @@ class Mission
 			class Item57
 			{
 				linkID=57;
-				item0=16500;
-				item1=16499;
+				item0=16504;
+				item1=16502;
 				class CustomData
 				{
 					type="Sync";
@@ -55656,7 +55780,7 @@ class Mission
 			class Item58
 			{
 				linkID=58;
-				item0=16504;
+				item0=16503;
 				item1=16502;
 				class CustomData
 				{
@@ -55666,8 +55790,8 @@ class Mission
 			class Item59
 			{
 				linkID=59;
-				item0=16503;
-				item1=16502;
+				item0=16507;
+				item1=16505;
 				class CustomData
 				{
 					type="Sync";
@@ -55676,7 +55800,7 @@ class Mission
 			class Item60
 			{
 				linkID=60;
-				item0=16507;
+				item0=16506;
 				item1=16505;
 				class CustomData
 				{
@@ -55686,8 +55810,8 @@ class Mission
 			class Item61
 			{
 				linkID=61;
-				item0=16506;
-				item1=16505;
+				item0=16471;
+				item1=16470;
 				class CustomData
 				{
 					type="Sync";
@@ -55696,7 +55820,7 @@ class Mission
 			class Item62
 			{
 				linkID=62;
-				item0=16471;
+				item0=16472;
 				item1=16470;
 				class CustomData
 				{
@@ -55706,8 +55830,8 @@ class Mission
 			class Item63
 			{
 				linkID=63;
-				item0=16472;
-				item1=16470;
+				item0=16511;
+				item1=16509;
 				class CustomData
 				{
 					type="Sync";
@@ -55716,7 +55840,7 @@ class Mission
 			class Item64
 			{
 				linkID=64;
-				item0=16511;
+				item0=16510;
 				item1=16509;
 				class CustomData
 				{
@@ -55726,8 +55850,8 @@ class Mission
 			class Item65
 			{
 				linkID=65;
-				item0=16510;
-				item1=16509;
+				item0=16514;
+				item1=16512;
 				class CustomData
 				{
 					type="Sync";
@@ -55736,7 +55860,7 @@ class Mission
 			class Item66
 			{
 				linkID=66;
-				item0=16514;
+				item0=16513;
 				item1=16512;
 				class CustomData
 				{
@@ -55746,8 +55870,8 @@ class Mission
 			class Item67
 			{
 				linkID=67;
-				item0=16513;
-				item1=16512;
+				item0=16517;
+				item1=16515;
 				class CustomData
 				{
 					type="Sync";
@@ -55756,7 +55880,7 @@ class Mission
 			class Item68
 			{
 				linkID=68;
-				item0=16517;
+				item0=16516;
 				item1=16515;
 				class CustomData
 				{
@@ -55766,8 +55890,8 @@ class Mission
 			class Item69
 			{
 				linkID=69;
-				item0=16516;
-				item1=16515;
+				item0=16520;
+				item1=16518;
 				class CustomData
 				{
 					type="Sync";
@@ -55776,7 +55900,7 @@ class Mission
 			class Item70
 			{
 				linkID=70;
-				item0=16520;
+				item0=16519;
 				item1=16518;
 				class CustomData
 				{
@@ -55786,8 +55910,8 @@ class Mission
 			class Item71
 			{
 				linkID=71;
-				item0=16519;
-				item1=16518;
+				item0=16418;
+				item1=16419;
 				class CustomData
 				{
 					type="Sync";
@@ -55796,7 +55920,7 @@ class Mission
 			class Item72
 			{
 				linkID=72;
-				item0=16418;
+				item0=16417;
 				item1=16419;
 				class CustomData
 				{
@@ -55806,8 +55930,8 @@ class Mission
 			class Item73
 			{
 				linkID=73;
-				item0=16417;
-				item1=16419;
+				item0=16421;
+				item1=16433;
 				class CustomData
 				{
 					type="Sync";
@@ -55816,7 +55940,7 @@ class Mission
 			class Item74
 			{
 				linkID=74;
-				item0=16421;
+				item0=16427;
 				item1=16433;
 				class CustomData
 				{
@@ -55826,8 +55950,8 @@ class Mission
 			class Item75
 			{
 				linkID=75;
-				item0=16427;
-				item1=16433;
+				item0=16422;
+				item1=16434;
 				class CustomData
 				{
 					type="Sync";
@@ -55836,7 +55960,7 @@ class Mission
 			class Item76
 			{
 				linkID=76;
-				item0=16422;
+				item0=16428;
 				item1=16434;
 				class CustomData
 				{
@@ -55846,8 +55970,8 @@ class Mission
 			class Item77
 			{
 				linkID=77;
-				item0=16428;
-				item1=16434;
+				item0=16402;
+				item1=16401;
 				class CustomData
 				{
 					type="Sync";
@@ -55856,7 +55980,7 @@ class Mission
 			class Item78
 			{
 				linkID=78;
-				item0=16402;
+				item0=16404;
 				item1=16401;
 				class CustomData
 				{
@@ -55866,8 +55990,8 @@ class Mission
 			class Item79
 			{
 				linkID=79;
-				item0=16404;
-				item1=16401;
+				item0=16403;
+				item1=16406;
 				class CustomData
 				{
 					type="Sync";
@@ -55876,7 +56000,7 @@ class Mission
 			class Item80
 			{
 				linkID=80;
-				item0=16403;
+				item0=16405;
 				item1=16406;
 				class CustomData
 				{
@@ -55886,8 +56010,8 @@ class Mission
 			class Item81
 			{
 				linkID=81;
-				item0=16405;
-				item1=16406;
+				item0=16474;
+				item1=16473;
 				class CustomData
 				{
 					type="Sync";
@@ -55896,7 +56020,7 @@ class Mission
 			class Item82
 			{
 				linkID=82;
-				item0=16474;
+				item0=16475;
 				item1=16473;
 				class CustomData
 				{
@@ -55906,8 +56030,8 @@ class Mission
 			class Item83
 			{
 				linkID=83;
-				item0=16475;
-				item1=16473;
+				item0=16477;
+				item1=16476;
 				class CustomData
 				{
 					type="Sync";
@@ -55916,7 +56040,7 @@ class Mission
 			class Item84
 			{
 				linkID=84;
-				item0=16477;
+				item0=16478;
 				item1=16476;
 				class CustomData
 				{
@@ -55926,8 +56050,8 @@ class Mission
 			class Item85
 			{
 				linkID=85;
-				item0=16478;
-				item1=16476;
+				item0=16480;
+				item1=16479;
 				class CustomData
 				{
 					type="Sync";
@@ -55936,7 +56060,7 @@ class Mission
 			class Item86
 			{
 				linkID=86;
-				item0=16480;
+				item0=16481;
 				item1=16479;
 				class CustomData
 				{
@@ -55946,8 +56070,8 @@ class Mission
 			class Item87
 			{
 				linkID=87;
-				item0=16481;
-				item1=16479;
+				item0=16440;
+				item1=16441;
 				class CustomData
 				{
 					type="Sync";
@@ -55956,7 +56080,7 @@ class Mission
 			class Item88
 			{
 				linkID=88;
-				item0=16440;
+				item0=16439;
 				item1=16441;
 				class CustomData
 				{
@@ -55966,8 +56090,8 @@ class Mission
 			class Item89
 			{
 				linkID=89;
-				item0=16439;
-				item1=16441;
+				item0=16443;
+				item1=16444;
 				class CustomData
 				{
 					type="Sync";
@@ -55976,7 +56100,7 @@ class Mission
 			class Item90
 			{
 				linkID=90;
-				item0=16443;
+				item0=16442;
 				item1=16444;
 				class CustomData
 				{
@@ -55986,8 +56110,8 @@ class Mission
 			class Item91
 			{
 				linkID=91;
-				item0=16442;
-				item1=16444;
+				item0=16397;
+				item1=16399;
 				class CustomData
 				{
 					type="Sync";
@@ -55996,7 +56120,7 @@ class Mission
 			class Item92
 			{
 				linkID=92;
-				item0=16397;
+				item0=16398;
 				item1=16399;
 				class CustomData
 				{
@@ -56006,8 +56130,8 @@ class Mission
 			class Item93
 			{
 				linkID=93;
-				item0=16398;
-				item1=16399;
+				item0=16411;
+				item1=16410;
 				class CustomData
 				{
 					type="Sync";
@@ -56016,7 +56140,7 @@ class Mission
 			class Item94
 			{
 				linkID=94;
-				item0=16411;
+				item0=16412;
 				item1=16410;
 				class CustomData
 				{
@@ -56026,8 +56150,8 @@ class Mission
 			class Item95
 			{
 				linkID=95;
-				item0=16412;
-				item1=16410;
+				item0=16414;
+				item1=16413;
 				class CustomData
 				{
 					type="Sync";
@@ -56036,7 +56160,7 @@ class Mission
 			class Item96
 			{
 				linkID=96;
-				item0=16414;
+				item0=16415;
 				item1=16413;
 				class CustomData
 				{
@@ -56046,8 +56170,8 @@ class Mission
 			class Item97
 			{
 				linkID=97;
-				item0=16415;
-				item1=16413;
+				item0=16530;
+				item1=16529;
 				class CustomData
 				{
 					type="Sync";
@@ -56056,8 +56180,8 @@ class Mission
 			class Item98
 			{
 				linkID=98;
-				item0=16530;
-				item1=16529;
+				item0=16534;
+				item1=16533;
 				class CustomData
 				{
 					type="Sync";
@@ -56066,7 +56190,7 @@ class Mission
 			class Item99
 			{
 				linkID=99;
-				item0=16534;
+				item0=16532;
 				item1=16533;
 				class CustomData
 				{
@@ -56076,8 +56200,8 @@ class Mission
 			class Item100
 			{
 				linkID=100;
-				item0=16532;
-				item1=16533;
+				item0=16541;
+				item1=16540;
 				class CustomData
 				{
 					type="Sync";
@@ -56086,7 +56210,7 @@ class Mission
 			class Item101
 			{
 				linkID=101;
-				item0=16541;
+				item0=16539;
 				item1=16540;
 				class CustomData
 				{
@@ -56096,8 +56220,8 @@ class Mission
 			class Item102
 			{
 				linkID=102;
-				item0=16539;
-				item1=16540;
+				item0=16544;
+				item1=16543;
 				class CustomData
 				{
 					type="Sync";
@@ -56106,7 +56230,7 @@ class Mission
 			class Item103
 			{
 				linkID=103;
-				item0=16544;
+				item0=16542;
 				item1=16543;
 				class CustomData
 				{
@@ -56116,8 +56240,8 @@ class Mission
 			class Item104
 			{
 				linkID=104;
-				item0=16542;
-				item1=16543;
+				item0=16547;
+				item1=16546;
 				class CustomData
 				{
 					type="Sync";
@@ -56126,7 +56250,7 @@ class Mission
 			class Item105
 			{
 				linkID=105;
-				item0=16547;
+				item0=16545;
 				item1=16546;
 				class CustomData
 				{
@@ -56136,8 +56260,8 @@ class Mission
 			class Item106
 			{
 				linkID=106;
-				item0=16545;
-				item1=16546;
+				item0=16550;
+				item1=16549;
 				class CustomData
 				{
 					type="Sync";
@@ -56146,7 +56270,7 @@ class Mission
 			class Item107
 			{
 				linkID=107;
-				item0=16550;
+				item0=16548;
 				item1=16549;
 				class CustomData
 				{
@@ -56156,8 +56280,8 @@ class Mission
 			class Item108
 			{
 				linkID=108;
-				item0=16548;
-				item1=16549;
+				item0=16552;
+				item1=16553;
 				class CustomData
 				{
 					type="Sync";
@@ -56166,7 +56290,7 @@ class Mission
 			class Item109
 			{
 				linkID=109;
-				item0=16552;
+				item0=16551;
 				item1=16553;
 				class CustomData
 				{
@@ -56176,8 +56300,8 @@ class Mission
 			class Item110
 			{
 				linkID=110;
-				item0=16551;
-				item1=16553;
+				item0=16555;
+				item1=16556;
 				class CustomData
 				{
 					type="Sync";
@@ -56186,7 +56310,7 @@ class Mission
 			class Item111
 			{
 				linkID=111;
-				item0=16555;
+				item0=16554;
 				item1=16556;
 				class CustomData
 				{
@@ -56196,8 +56320,8 @@ class Mission
 			class Item112
 			{
 				linkID=112;
-				item0=16554;
-				item1=16556;
+				item0=16562;
+				item1=16561;
 				class CustomData
 				{
 					type="Sync";
@@ -56206,7 +56330,7 @@ class Mission
 			class Item113
 			{
 				linkID=113;
-				item0=16562;
+				item0=16560;
 				item1=16561;
 				class CustomData
 				{
@@ -56216,8 +56340,8 @@ class Mission
 			class Item114
 			{
 				linkID=114;
-				item0=16560;
-				item1=16561;
+				item0=16565;
+				item1=16564;
 				class CustomData
 				{
 					type="Sync";
@@ -56226,8 +56350,8 @@ class Mission
 			class Item115
 			{
 				linkID=115;
-				item0=16565;
-				item1=16564;
+				item0=16568;
+				item1=16566;
 				class CustomData
 				{
 					type="Sync";
@@ -56236,7 +56360,7 @@ class Mission
 			class Item116
 			{
 				linkID=116;
-				item0=16568;
+				item0=16567;
 				item1=16566;
 				class CustomData
 				{
@@ -56246,8 +56370,8 @@ class Mission
 			class Item117
 			{
 				linkID=117;
-				item0=16567;
-				item1=16566;
+				item0=16574;
+				item1=16572;
 				class CustomData
 				{
 					type="Sync";
@@ -56256,7 +56380,7 @@ class Mission
 			class Item118
 			{
 				linkID=118;
-				item0=16574;
+				item0=16573;
 				item1=16572;
 				class CustomData
 				{
@@ -56266,8 +56390,8 @@ class Mission
 			class Item119
 			{
 				linkID=119;
-				item0=16573;
-				item1=16572;
+				item0=16577;
+				item1=16575;
 				class CustomData
 				{
 					type="Sync";
@@ -56276,7 +56400,7 @@ class Mission
 			class Item120
 			{
 				linkID=120;
-				item0=16577;
+				item0=16576;
 				item1=16575;
 				class CustomData
 				{
@@ -56286,8 +56410,8 @@ class Mission
 			class Item121
 			{
 				linkID=121;
-				item0=16576;
-				item1=16575;
+				item0=16581;
+				item1=16580;
 				class CustomData
 				{
 					type="Sync";
@@ -56296,7 +56420,7 @@ class Mission
 			class Item122
 			{
 				linkID=122;
-				item0=16581;
+				item0=16579;
 				item1=16580;
 				class CustomData
 				{
@@ -56306,8 +56430,8 @@ class Mission
 			class Item123
 			{
 				linkID=123;
-				item0=16579;
-				item1=16580;
+				item0=16584;
+				item1=16583;
 				class CustomData
 				{
 					type="Sync";
@@ -56316,7 +56440,7 @@ class Mission
 			class Item124
 			{
 				linkID=124;
-				item0=16584;
+				item0=16582;
 				item1=16583;
 				class CustomData
 				{
@@ -56326,8 +56450,8 @@ class Mission
 			class Item125
 			{
 				linkID=125;
-				item0=16582;
-				item1=16583;
+				item0=16611;
+				item1=16610;
 				class CustomData
 				{
 					type="Sync";
@@ -56336,7 +56460,7 @@ class Mission
 			class Item126
 			{
 				linkID=126;
-				item0=16611;
+				item0=16612;
 				item1=16610;
 				class CustomData
 				{
@@ -56346,8 +56470,8 @@ class Mission
 			class Item127
 			{
 				linkID=127;
-				item0=16612;
-				item1=16610;
+				item0=16644;
+				item1=16643;
 				class CustomData
 				{
 					type="Sync";
@@ -56356,7 +56480,7 @@ class Mission
 			class Item128
 			{
 				linkID=128;
-				item0=16644;
+				item0=16645;
 				item1=16643;
 				class CustomData
 				{
@@ -56366,8 +56490,8 @@ class Mission
 			class Item129
 			{
 				linkID=129;
-				item0=16645;
-				item1=16643;
+				item0=16647;
+				item1=16646;
 				class CustomData
 				{
 					type="Sync";
@@ -56376,7 +56500,7 @@ class Mission
 			class Item130
 			{
 				linkID=130;
-				item0=16647;
+				item0=16648;
 				item1=16646;
 				class CustomData
 				{
@@ -56386,8 +56510,8 @@ class Mission
 			class Item131
 			{
 				linkID=131;
-				item0=16648;
-				item1=16646;
+				item0=16650;
+				item1=16649;
 				class CustomData
 				{
 					type="Sync";
@@ -56396,8 +56520,8 @@ class Mission
 			class Item132
 			{
 				linkID=132;
-				item0=16650;
-				item1=16649;
+				item0=16662;
+				item1=16661;
 				class CustomData
 				{
 					type="Sync";
@@ -56406,7 +56530,7 @@ class Mission
 			class Item133
 			{
 				linkID=133;
-				item0=16662;
+				item0=16660;
 				item1=16661;
 				class CustomData
 				{
@@ -56416,8 +56540,8 @@ class Mission
 			class Item134
 			{
 				linkID=134;
-				item0=16660;
-				item1=16661;
+				item0=16669;
+				item1=16668;
 				class CustomData
 				{
 					type="Sync";
@@ -56426,7 +56550,7 @@ class Mission
 			class Item135
 			{
 				linkID=135;
-				item0=16669;
+				item0=16667;
 				item1=16668;
 				class CustomData
 				{
@@ -56436,8 +56560,8 @@ class Mission
 			class Item136
 			{
 				linkID=136;
-				item0=16667;
-				item1=16668;
+				item0=16674;
+				item1=16673;
 				class CustomData
 				{
 					type="Sync";
@@ -56446,7 +56570,7 @@ class Mission
 			class Item137
 			{
 				linkID=137;
-				item0=16674;
+				item0=16672;
 				item1=16673;
 				class CustomData
 				{
@@ -56456,8 +56580,8 @@ class Mission
 			class Item138
 			{
 				linkID=138;
-				item0=16672;
-				item1=16673;
+				item0=16680;
+				item1=16678;
 				class CustomData
 				{
 					type="Sync";
@@ -56466,8 +56590,8 @@ class Mission
 			class Item139
 			{
 				linkID=139;
-				item0=16680;
-				item1=16678;
+				item0=16677;
+				item1=16675;
 				class CustomData
 				{
 					type="Sync";
@@ -56476,8 +56600,8 @@ class Mission
 			class Item140
 			{
 				linkID=140;
-				item0=16677;
-				item1=16675;
+				item0=16688;
+				item1=16687;
 				class CustomData
 				{
 					type="Sync";
@@ -56486,7 +56610,7 @@ class Mission
 			class Item141
 			{
 				linkID=141;
-				item0=16688;
+				item0=16689;
 				item1=16687;
 				class CustomData
 				{
@@ -56496,8 +56620,8 @@ class Mission
 			class Item142
 			{
 				linkID=142;
-				item0=16689;
-				item1=16687;
+				item0=16691;
+				item1=16690;
 				class CustomData
 				{
 					type="Sync";
@@ -56506,7 +56630,7 @@ class Mission
 			class Item143
 			{
 				linkID=143;
-				item0=16691;
+				item0=16692;
 				item1=16690;
 				class CustomData
 				{
@@ -56516,8 +56640,8 @@ class Mission
 			class Item144
 			{
 				linkID=144;
-				item0=16692;
-				item1=16690;
+				item0=16705;
+				item1=16704;
 				class CustomData
 				{
 					type="Sync";
@@ -56526,7 +56650,7 @@ class Mission
 			class Item145
 			{
 				linkID=145;
-				item0=16705;
+				item0=16706;
 				item1=16704;
 				class CustomData
 				{
@@ -56536,8 +56660,8 @@ class Mission
 			class Item146
 			{
 				linkID=146;
-				item0=16706;
-				item1=16704;
+				item0=16731;
+				item1=16729;
 				class CustomData
 				{
 					type="Sync";
@@ -56546,7 +56670,7 @@ class Mission
 			class Item147
 			{
 				linkID=147;
-				item0=16731;
+				item0=16730;
 				item1=16729;
 				class CustomData
 				{
@@ -56556,8 +56680,8 @@ class Mission
 			class Item148
 			{
 				linkID=148;
-				item0=16730;
-				item1=16729;
+				item0=16724;
+				item1=16723;
 				class CustomData
 				{
 					type="Sync";
@@ -56566,7 +56690,7 @@ class Mission
 			class Item149
 			{
 				linkID=149;
-				item0=16724;
+				item0=16725;
 				item1=16723;
 				class CustomData
 				{
@@ -56576,8 +56700,8 @@ class Mission
 			class Item150
 			{
 				linkID=150;
-				item0=16725;
-				item1=16723;
+				item0=16727;
+				item1=16726;
 				class CustomData
 				{
 					type="Sync";
@@ -56586,7 +56710,7 @@ class Mission
 			class Item151
 			{
 				linkID=151;
-				item0=16727;
+				item0=16728;
 				item1=16726;
 				class CustomData
 				{
@@ -56596,8 +56720,8 @@ class Mission
 			class Item152
 			{
 				linkID=152;
-				item0=16728;
-				item1=16726;
+				item0=16741;
+				item1=16740;
 				class CustomData
 				{
 					type="Sync";
@@ -56606,8 +56730,8 @@ class Mission
 			class Item153
 			{
 				linkID=153;
-				item0=16741;
-				item1=16740;
+				item0=16744;
+				item1=16743;
 				class CustomData
 				{
 					type="Sync";
@@ -56616,7 +56740,7 @@ class Mission
 			class Item154
 			{
 				linkID=154;
-				item0=16744;
+				item0=16742;
 				item1=16743;
 				class CustomData
 				{
@@ -56626,8 +56750,8 @@ class Mission
 			class Item155
 			{
 				linkID=155;
-				item0=16742;
-				item1=16743;
+				item0=16745;
+				item1=16740;
 				class CustomData
 				{
 					type="Sync";
@@ -56636,8 +56760,8 @@ class Mission
 			class Item156
 			{
 				linkID=156;
-				item0=16745;
-				item1=16740;
+				item0=16757;
+				item1=16755;
 				class CustomData
 				{
 					type="Sync";
@@ -56646,7 +56770,7 @@ class Mission
 			class Item157
 			{
 				linkID=157;
-				item0=16757;
+				item0=16756;
 				item1=16755;
 				class CustomData
 				{
@@ -56656,8 +56780,8 @@ class Mission
 			class Item158
 			{
 				linkID=158;
-				item0=16756;
-				item1=16755;
+				item0=16760;
+				item1=16758;
 				class CustomData
 				{
 					type="Sync";
@@ -56666,7 +56790,7 @@ class Mission
 			class Item159
 			{
 				linkID=159;
-				item0=16760;
+				item0=16759;
 				item1=16758;
 				class CustomData
 				{
@@ -56676,8 +56800,8 @@ class Mission
 			class Item160
 			{
 				linkID=160;
-				item0=16759;
-				item1=16758;
+				item0=16752;
+				item1=16754;
 				class CustomData
 				{
 					type="Sync";
@@ -56686,7 +56810,7 @@ class Mission
 			class Item161
 			{
 				linkID=161;
-				item0=16752;
+				item0=16753;
 				item1=16754;
 				class CustomData
 				{
@@ -56696,8 +56820,8 @@ class Mission
 			class Item162
 			{
 				linkID=162;
-				item0=16753;
-				item1=16754;
+				item0=16761;
+				item1=16763;
 				class CustomData
 				{
 					type="Sync";
@@ -56706,7 +56830,7 @@ class Mission
 			class Item163
 			{
 				linkID=163;
-				item0=16761;
+				item0=16762;
 				item1=16763;
 				class CustomData
 				{
@@ -56716,8 +56840,8 @@ class Mission
 			class Item164
 			{
 				linkID=164;
-				item0=16762;
-				item1=16763;
+				item0=16795;
+				item1=16794;
 				class CustomData
 				{
 					type="Sync";
@@ -56726,8 +56850,8 @@ class Mission
 			class Item165
 			{
 				linkID=165;
-				item0=16795;
-				item1=16794;
+				item0=16798;
+				item1=16797;
 				class CustomData
 				{
 					type="Sync";
@@ -56736,8 +56860,8 @@ class Mission
 			class Item166
 			{
 				linkID=166;
-				item0=16798;
-				item1=16797;
+				item0=16819;
+				item1=16817;
 				class CustomData
 				{
 					type="Sync";
@@ -56746,7 +56870,7 @@ class Mission
 			class Item167
 			{
 				linkID=167;
-				item0=16819;
+				item0=16818;
 				item1=16817;
 				class CustomData
 				{
@@ -56756,8 +56880,8 @@ class Mission
 			class Item168
 			{
 				linkID=168;
-				item0=16818;
-				item1=16817;
+				item0=16883;
+				item1=16882;
 				class CustomData
 				{
 					type="Sync";
@@ -56766,7 +56890,7 @@ class Mission
 			class Item169
 			{
 				linkID=169;
-				item0=16883;
+				item0=16881;
 				item1=16882;
 				class CustomData
 				{
@@ -56776,8 +56900,8 @@ class Mission
 			class Item170
 			{
 				linkID=170;
-				item0=16881;
-				item1=16882;
+				item0=16888;
+				item1=16887;
 				class CustomData
 				{
 					type="Sync";
@@ -56786,8 +56910,8 @@ class Mission
 			class Item171
 			{
 				linkID=171;
-				item0=16888;
-				item1=16887;
+				item0=16894;
+				item1=16893;
 				class CustomData
 				{
 					type="Sync";
@@ -56796,7 +56920,7 @@ class Mission
 			class Item172
 			{
 				linkID=172;
-				item0=16894;
+				item0=16892;
 				item1=16893;
 				class CustomData
 				{
@@ -56806,8 +56930,8 @@ class Mission
 			class Item173
 			{
 				linkID=173;
-				item0=16892;
-				item1=16893;
+				item0=16897;
+				item1=16898;
 				class CustomData
 				{
 					type="Sync";
@@ -56816,7 +56940,7 @@ class Mission
 			class Item174
 			{
 				linkID=174;
-				item0=16897;
+				item0=16896;
 				item1=16898;
 				class CustomData
 				{
@@ -56826,8 +56950,8 @@ class Mission
 			class Item175
 			{
 				linkID=175;
-				item0=16896;
-				item1=16898;
+				item0=16935;
+				item1=16934;
 				class CustomData
 				{
 					type="Sync";
@@ -56836,8 +56960,8 @@ class Mission
 			class Item176
 			{
 				linkID=176;
-				item0=16935;
-				item1=16934;
+				item0=16934;
+				item1=16936;
 				class CustomData
 				{
 					type="Sync";
@@ -56846,8 +56970,8 @@ class Mission
 			class Item177
 			{
 				linkID=177;
-				item0=16934;
-				item1=16936;
+				item0=16997;
+				item1=16996;
 				class CustomData
 				{
 					type="Sync";
@@ -56856,8 +56980,8 @@ class Mission
 			class Item178
 			{
 				linkID=178;
-				item0=16997;
-				item1=16996;
+				item0=17000;
+				item1=16999;
 				class CustomData
 				{
 					type="Sync";
@@ -56866,7 +56990,7 @@ class Mission
 			class Item179
 			{
 				linkID=179;
-				item0=17000;
+				item0=16998;
 				item1=16999;
 				class CustomData
 				{
@@ -56876,8 +57000,8 @@ class Mission
 			class Item180
 			{
 				linkID=180;
-				item0=16998;
-				item1=16999;
+				item0=17001;
+				item1=16996;
 				class CustomData
 				{
 					type="Sync";
@@ -56886,8 +57010,8 @@ class Mission
 			class Item181
 			{
 				linkID=181;
-				item0=17001;
-				item1=16996;
+				item0=17018;
+				item1=17020;
 				class CustomData
 				{
 					type="Sync";
@@ -56896,7 +57020,7 @@ class Mission
 			class Item182
 			{
 				linkID=182;
-				item0=17018;
+				item0=17019;
 				item1=17020;
 				class CustomData
 				{
@@ -56906,8 +57030,8 @@ class Mission
 			class Item183
 			{
 				linkID=183;
-				item0=17019;
-				item1=17020;
+				item0=17023;
+				item1=17021;
 				class CustomData
 				{
 					type="Sync";
@@ -56916,7 +57040,7 @@ class Mission
 			class Item184
 			{
 				linkID=184;
-				item0=17023;
+				item0=17022;
 				item1=17021;
 				class CustomData
 				{
@@ -56926,8 +57050,8 @@ class Mission
 			class Item185
 			{
 				linkID=185;
-				item0=17022;
-				item1=17021;
+				item0=17026;
+				item1=17024;
 				class CustomData
 				{
 					type="Sync";
@@ -56936,7 +57060,7 @@ class Mission
 			class Item186
 			{
 				linkID=186;
-				item0=17026;
+				item0=17025;
 				item1=17024;
 				class CustomData
 				{
@@ -56946,8 +57070,8 @@ class Mission
 			class Item187
 			{
 				linkID=187;
-				item0=17025;
-				item1=17024;
+				item0=17029;
+				item1=17028;
 				class CustomData
 				{
 					type="Sync";
@@ -56956,7 +57080,7 @@ class Mission
 			class Item188
 			{
 				linkID=188;
-				item0=17029;
+				item0=17027;
 				item1=17028;
 				class CustomData
 				{
@@ -56966,8 +57090,8 @@ class Mission
 			class Item189
 			{
 				linkID=189;
-				item0=17027;
-				item1=17028;
+				item0=17034;
+				item1=17032;
 				class CustomData
 				{
 					type="Sync";
@@ -56976,7 +57100,7 @@ class Mission
 			class Item190
 			{
 				linkID=190;
-				item0=17034;
+				item0=17033;
 				item1=17032;
 				class CustomData
 				{
@@ -56986,8 +57110,8 @@ class Mission
 			class Item191
 			{
 				linkID=191;
-				item0=17033;
-				item1=17032;
+				item0=17145;
+				item1=17144;
 				class CustomData
 				{
 					type="Sync";
@@ -56996,7 +57120,7 @@ class Mission
 			class Item192
 			{
 				linkID=192;
-				item0=17145;
+				item0=17143;
 				item1=17144;
 				class CustomData
 				{
@@ -57006,8 +57130,8 @@ class Mission
 			class Item193
 			{
 				linkID=193;
-				item0=17143;
-				item1=17144;
+				item0=17180;
+				item1=17178;
 				class CustomData
 				{
 					type="Sync";
@@ -57016,7 +57140,7 @@ class Mission
 			class Item194
 			{
 				linkID=194;
-				item0=17180;
+				item0=17179;
 				item1=17178;
 				class CustomData
 				{
@@ -57026,8 +57150,8 @@ class Mission
 			class Item195
 			{
 				linkID=195;
-				item0=17179;
-				item1=17178;
+				item0=17183;
+				item1=17181;
 				class CustomData
 				{
 					type="Sync";
@@ -57036,7 +57160,7 @@ class Mission
 			class Item196
 			{
 				linkID=196;
-				item0=17183;
+				item0=17182;
 				item1=17181;
 				class CustomData
 				{
@@ -57046,8 +57170,8 @@ class Mission
 			class Item197
 			{
 				linkID=197;
-				item0=17182;
-				item1=17181;
+				item0=17186;
+				item1=17184;
 				class CustomData
 				{
 					type="Sync";
@@ -57056,7 +57180,7 @@ class Mission
 			class Item198
 			{
 				linkID=198;
-				item0=17186;
+				item0=17185;
 				item1=17184;
 				class CustomData
 				{
@@ -57066,8 +57190,8 @@ class Mission
 			class Item199
 			{
 				linkID=199;
-				item0=17185;
-				item1=17184;
+				item0=17189;
+				item1=17187;
 				class CustomData
 				{
 					type="Sync";
@@ -57076,7 +57200,7 @@ class Mission
 			class Item200
 			{
 				linkID=200;
-				item0=17189;
+				item0=17188;
 				item1=17187;
 				class CustomData
 				{
@@ -57086,8 +57210,8 @@ class Mission
 			class Item201
 			{
 				linkID=201;
-				item0=17188;
-				item1=17187;
+				item0=17794;
+				item1=17792;
 				class CustomData
 				{
 					type="Sync";
@@ -57096,7 +57220,7 @@ class Mission
 			class Item202
 			{
 				linkID=202;
-				item0=17794;
+				item0=17793;
 				item1=17792;
 				class CustomData
 				{
@@ -57106,8 +57230,8 @@ class Mission
 			class Item203
 			{
 				linkID=203;
-				item0=17793;
-				item1=17792;
+				item0=17809;
+				item1=17807;
 				class CustomData
 				{
 					type="Sync";
@@ -57116,7 +57240,7 @@ class Mission
 			class Item204
 			{
 				linkID=204;
-				item0=17809;
+				item0=17808;
 				item1=17807;
 				class CustomData
 				{
@@ -57126,8 +57250,8 @@ class Mission
 			class Item205
 			{
 				linkID=205;
-				item0=17808;
-				item1=17807;
+				item0=15263;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -57136,8 +57260,8 @@ class Mission
 			class Item206
 			{
 				linkID=206;
-				item0=15263;
-				item1=823;
+				item0=17812;
+				item1=17810;
 				class CustomData
 				{
 					type="Sync";
@@ -57146,7 +57270,7 @@ class Mission
 			class Item207
 			{
 				linkID=207;
-				item0=17812;
+				item0=17811;
 				item1=17810;
 				class CustomData
 				{
@@ -57156,8 +57280,8 @@ class Mission
 			class Item208
 			{
 				linkID=208;
-				item0=17811;
-				item1=17810;
+				item0=17815;
+				item1=17813;
 				class CustomData
 				{
 					type="Sync";
@@ -57166,7 +57290,7 @@ class Mission
 			class Item209
 			{
 				linkID=209;
-				item0=17815;
+				item0=17814;
 				item1=17813;
 				class CustomData
 				{
@@ -57176,8 +57300,8 @@ class Mission
 			class Item210
 			{
 				linkID=210;
-				item0=17814;
-				item1=17813;
+				item0=17819;
+				item1=17817;
 				class CustomData
 				{
 					type="Sync";
@@ -57186,7 +57310,7 @@ class Mission
 			class Item211
 			{
 				linkID=211;
-				item0=17819;
+				item0=17818;
 				item1=17817;
 				class CustomData
 				{
@@ -57196,8 +57320,8 @@ class Mission
 			class Item212
 			{
 				linkID=212;
-				item0=17818;
-				item1=17817;
+				item0=17822;
+				item1=17820;
 				class CustomData
 				{
 					type="Sync";
@@ -57206,7 +57330,7 @@ class Mission
 			class Item213
 			{
 				linkID=213;
-				item0=17822;
+				item0=17821;
 				item1=17820;
 				class CustomData
 				{
@@ -57216,8 +57340,8 @@ class Mission
 			class Item214
 			{
 				linkID=214;
-				item0=17821;
-				item1=17820;
+				item0=17825;
+				item1=17823;
 				class CustomData
 				{
 					type="Sync";
@@ -57226,7 +57350,7 @@ class Mission
 			class Item215
 			{
 				linkID=215;
-				item0=17825;
+				item0=17824;
 				item1=17823;
 				class CustomData
 				{
@@ -57236,8 +57360,8 @@ class Mission
 			class Item216
 			{
 				linkID=216;
-				item0=17824;
-				item1=17823;
+				item0=17828;
+				item1=17826;
 				class CustomData
 				{
 					type="Sync";
@@ -57246,7 +57370,7 @@ class Mission
 			class Item217
 			{
 				linkID=217;
-				item0=17828;
+				item0=17827;
 				item1=17826;
 				class CustomData
 				{
@@ -57256,8 +57380,8 @@ class Mission
 			class Item218
 			{
 				linkID=218;
-				item0=17827;
-				item1=17826;
+				item0=17842;
+				item1=17840;
 				class CustomData
 				{
 					type="Sync";
@@ -57266,7 +57390,7 @@ class Mission
 			class Item219
 			{
 				linkID=219;
-				item0=17842;
+				item0=17841;
 				item1=17840;
 				class CustomData
 				{
@@ -57276,8 +57400,8 @@ class Mission
 			class Item220
 			{
 				linkID=220;
-				item0=17841;
-				item1=17840;
+				item0=17845;
+				item1=17843;
 				class CustomData
 				{
 					type="Sync";
@@ -57286,7 +57410,7 @@ class Mission
 			class Item221
 			{
 				linkID=221;
-				item0=17845;
+				item0=17844;
 				item1=17843;
 				class CustomData
 				{
@@ -57296,8 +57420,8 @@ class Mission
 			class Item222
 			{
 				linkID=222;
-				item0=17844;
-				item1=17843;
+				item0=17849;
+				item1=17847;
 				class CustomData
 				{
 					type="Sync";
@@ -57306,7 +57430,7 @@ class Mission
 			class Item223
 			{
 				linkID=223;
-				item0=17849;
+				item0=17848;
 				item1=17847;
 				class CustomData
 				{
@@ -57316,8 +57440,8 @@ class Mission
 			class Item224
 			{
 				linkID=224;
-				item0=17848;
-				item1=17847;
+				item0=17855;
+				item1=17853;
 				class CustomData
 				{
 					type="Sync";
@@ -57326,7 +57450,7 @@ class Mission
 			class Item225
 			{
 				linkID=225;
-				item0=17855;
+				item0=17854;
 				item1=17853;
 				class CustomData
 				{
@@ -57336,8 +57460,8 @@ class Mission
 			class Item226
 			{
 				linkID=226;
-				item0=17854;
-				item1=17853;
+				item0=17858;
+				item1=17856;
 				class CustomData
 				{
 					type="Sync";
@@ -57346,7 +57470,7 @@ class Mission
 			class Item227
 			{
 				linkID=227;
-				item0=17858;
+				item0=17857;
 				item1=17856;
 				class CustomData
 				{
@@ -57356,8 +57480,8 @@ class Mission
 			class Item228
 			{
 				linkID=228;
-				item0=17857;
-				item1=17856;
+				item0=17861;
+				item1=17859;
 				class CustomData
 				{
 					type="Sync";
@@ -57366,7 +57490,7 @@ class Mission
 			class Item229
 			{
 				linkID=229;
-				item0=17861;
+				item0=17860;
 				item1=17859;
 				class CustomData
 				{
@@ -57376,8 +57500,8 @@ class Mission
 			class Item230
 			{
 				linkID=230;
-				item0=17860;
-				item1=17859;
+				item0=17864;
+				item1=17862;
 				class CustomData
 				{
 					type="Sync";
@@ -57386,7 +57510,7 @@ class Mission
 			class Item231
 			{
 				linkID=231;
-				item0=17864;
+				item0=17863;
 				item1=17862;
 				class CustomData
 				{
@@ -57396,8 +57520,8 @@ class Mission
 			class Item232
 			{
 				linkID=232;
-				item0=17863;
-				item1=17862;
+				item0=17867;
+				item1=17865;
 				class CustomData
 				{
 					type="Sync";
@@ -57406,7 +57530,7 @@ class Mission
 			class Item233
 			{
 				linkID=233;
-				item0=17867;
+				item0=17866;
 				item1=17865;
 				class CustomData
 				{
@@ -57416,8 +57540,8 @@ class Mission
 			class Item234
 			{
 				linkID=234;
-				item0=17866;
-				item1=17865;
+				item0=17870;
+				item1=17868;
 				class CustomData
 				{
 					type="Sync";
@@ -57426,7 +57550,7 @@ class Mission
 			class Item235
 			{
 				linkID=235;
-				item0=17870;
+				item0=17869;
 				item1=17868;
 				class CustomData
 				{
@@ -57436,8 +57560,8 @@ class Mission
 			class Item236
 			{
 				linkID=236;
-				item0=17869;
-				item1=17868;
+				item0=17876;
+				item1=17874;
 				class CustomData
 				{
 					type="Sync";
@@ -57446,7 +57570,7 @@ class Mission
 			class Item237
 			{
 				linkID=237;
-				item0=17876;
+				item0=17875;
 				item1=17874;
 				class CustomData
 				{
@@ -57456,8 +57580,8 @@ class Mission
 			class Item238
 			{
 				linkID=238;
-				item0=17875;
-				item1=17874;
+				item0=17882;
+				item1=17880;
 				class CustomData
 				{
 					type="Sync";
@@ -57466,7 +57590,7 @@ class Mission
 			class Item239
 			{
 				linkID=239;
-				item0=17882;
+				item0=17881;
 				item1=17880;
 				class CustomData
 				{
@@ -57476,8 +57600,8 @@ class Mission
 			class Item240
 			{
 				linkID=240;
-				item0=17881;
-				item1=17880;
+				item0=17888;
+				item1=17886;
 				class CustomData
 				{
 					type="Sync";
@@ -57486,7 +57610,7 @@ class Mission
 			class Item241
 			{
 				linkID=241;
-				item0=17888;
+				item0=17887;
 				item1=17886;
 				class CustomData
 				{
@@ -57496,8 +57620,8 @@ class Mission
 			class Item242
 			{
 				linkID=242;
-				item0=17887;
-				item1=17886;
+				item0=17896;
+				item1=17894;
 				class CustomData
 				{
 					type="Sync";
@@ -57506,7 +57630,7 @@ class Mission
 			class Item243
 			{
 				linkID=243;
-				item0=17896;
+				item0=17895;
 				item1=17894;
 				class CustomData
 				{
@@ -57516,8 +57640,8 @@ class Mission
 			class Item244
 			{
 				linkID=244;
-				item0=17895;
-				item1=17894;
+				item0=17899;
+				item1=17897;
 				class CustomData
 				{
 					type="Sync";
@@ -57526,7 +57650,7 @@ class Mission
 			class Item245
 			{
 				linkID=245;
-				item0=17899;
+				item0=17898;
 				item1=17897;
 				class CustomData
 				{
@@ -57536,8 +57660,8 @@ class Mission
 			class Item246
 			{
 				linkID=246;
-				item0=17898;
-				item1=17897;
+				item0=17932;
+				item1=17930;
 				class CustomData
 				{
 					type="Sync";
@@ -57546,7 +57670,7 @@ class Mission
 			class Item247
 			{
 				linkID=247;
-				item0=17932;
+				item0=17931;
 				item1=17930;
 				class CustomData
 				{
@@ -57556,8 +57680,8 @@ class Mission
 			class Item248
 			{
 				linkID=248;
-				item0=17931;
-				item1=17930;
+				item0=15215;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -57566,7 +57690,7 @@ class Mission
 			class Item249
 			{
 				linkID=249;
-				item0=15215;
+				item0=13694;
 				item1=823;
 				class CustomData
 				{
@@ -57576,7 +57700,7 @@ class Mission
 			class Item250
 			{
 				linkID=250;
-				item0=13694;
+				item0=13695;
 				item1=823;
 				class CustomData
 				{
@@ -57586,7 +57710,7 @@ class Mission
 			class Item251
 			{
 				linkID=251;
-				item0=13695;
+				item0=7188;
 				item1=823;
 				class CustomData
 				{
@@ -57596,7 +57720,7 @@ class Mission
 			class Item252
 			{
 				linkID=252;
-				item0=7188;
+				item0=7189;
 				item1=823;
 				class CustomData
 				{
@@ -57606,7 +57730,7 @@ class Mission
 			class Item253
 			{
 				linkID=253;
-				item0=7189;
+				item0=14986;
 				item1=823;
 				class CustomData
 				{
@@ -57616,7 +57740,7 @@ class Mission
 			class Item254
 			{
 				linkID=254;
-				item0=14986;
+				item0=16358;
 				item1=823;
 				class CustomData
 				{
@@ -57626,7 +57750,7 @@ class Mission
 			class Item255
 			{
 				linkID=255;
-				item0=16358;
+				item0=16364;
 				item1=823;
 				class CustomData
 				{
@@ -57636,7 +57760,7 @@ class Mission
 			class Item256
 			{
 				linkID=256;
-				item0=16364;
+				item0=16367;
 				item1=823;
 				class CustomData
 				{
@@ -57646,7 +57770,7 @@ class Mission
 			class Item257
 			{
 				linkID=257;
-				item0=16367;
+				item0=16370;
 				item1=823;
 				class CustomData
 				{
@@ -57656,7 +57780,7 @@ class Mission
 			class Item258
 			{
 				linkID=258;
-				item0=16370;
+				item0=16373;
 				item1=823;
 				class CustomData
 				{
@@ -57666,7 +57790,7 @@ class Mission
 			class Item259
 			{
 				linkID=259;
-				item0=16373;
+				item0=16376;
 				item1=823;
 				class CustomData
 				{
@@ -57676,7 +57800,7 @@ class Mission
 			class Item260
 			{
 				linkID=260;
-				item0=16376;
+				item0=17149;
 				item1=823;
 				class CustomData
 				{
@@ -57686,7 +57810,7 @@ class Mission
 			class Item261
 			{
 				linkID=261;
-				item0=17149;
+				item0=2637;
 				item1=823;
 				class CustomData
 				{
@@ -57696,7 +57820,7 @@ class Mission
 			class Item262
 			{
 				linkID=262;
-				item0=2637;
+				item0=2639;
 				item1=823;
 				class CustomData
 				{
@@ -57706,7 +57830,7 @@ class Mission
 			class Item263
 			{
 				linkID=263;
-				item0=2639;
+				item0=8411;
 				item1=823;
 				class CustomData
 				{
@@ -57716,7 +57840,7 @@ class Mission
 			class Item264
 			{
 				linkID=264;
-				item0=8411;
+				item0=8412;
 				item1=823;
 				class CustomData
 				{
@@ -57726,7 +57850,7 @@ class Mission
 			class Item265
 			{
 				linkID=265;
-				item0=8412;
+				item0=8413;
 				item1=823;
 				class CustomData
 				{
@@ -57736,7 +57860,7 @@ class Mission
 			class Item266
 			{
 				linkID=266;
-				item0=8413;
+				item0=8414;
 				item1=823;
 				class CustomData
 				{
@@ -57746,7 +57870,7 @@ class Mission
 			class Item267
 			{
 				linkID=267;
-				item0=8414;
+				item0=15222;
 				item1=823;
 				class CustomData
 				{
@@ -57756,7 +57880,7 @@ class Mission
 			class Item268
 			{
 				linkID=268;
-				item0=15222;
+				item0=16123;
 				item1=823;
 				class CustomData
 				{
@@ -57766,7 +57890,7 @@ class Mission
 			class Item269
 			{
 				linkID=269;
-				item0=16123;
+				item0=18147;
 				item1=823;
 				class CustomData
 				{
@@ -57776,7 +57900,7 @@ class Mission
 			class Item270
 			{
 				linkID=270;
-				item0=18147;
+				item0=16595;
 				item1=823;
 				class CustomData
 				{
@@ -57786,7 +57910,7 @@ class Mission
 			class Item271
 			{
 				linkID=271;
-				item0=16595;
+				item0=16596;
 				item1=823;
 				class CustomData
 				{
@@ -57796,7 +57920,7 @@ class Mission
 			class Item272
 			{
 				linkID=272;
-				item0=16596;
+				item0=16597;
 				item1=823;
 				class CustomData
 				{
@@ -57806,7 +57930,7 @@ class Mission
 			class Item273
 			{
 				linkID=273;
-				item0=16597;
+				item0=16598;
 				item1=823;
 				class CustomData
 				{
@@ -57816,7 +57940,7 @@ class Mission
 			class Item274
 			{
 				linkID=274;
-				item0=16598;
+				item0=16736;
 				item1=823;
 				class CustomData
 				{
@@ -57826,7 +57950,7 @@ class Mission
 			class Item275
 			{
 				linkID=275;
-				item0=16736;
+				item0=16739;
 				item1=823;
 				class CustomData
 				{
@@ -57836,7 +57960,7 @@ class Mission
 			class Item276
 			{
 				linkID=276;
-				item0=16739;
+				item0=17003;
 				item1=823;
 				class CustomData
 				{
@@ -57846,7 +57970,7 @@ class Mission
 			class Item277
 			{
 				linkID=277;
-				item0=17003;
+				item0=7190;
 				item1=823;
 				class CustomData
 				{
@@ -57856,7 +57980,7 @@ class Mission
 			class Item278
 			{
 				linkID=278;
-				item0=7190;
+				item0=17935;
 				item1=823;
 				class CustomData
 				{
@@ -57866,7 +57990,7 @@ class Mission
 			class Item279
 			{
 				linkID=279;
-				item0=17935;
+				item0=17939;
 				item1=823;
 				class CustomData
 				{
@@ -57876,7 +58000,7 @@ class Mission
 			class Item280
 			{
 				linkID=280;
-				item0=17939;
+				item0=17940;
 				item1=823;
 				class CustomData
 				{
@@ -57886,7 +58010,7 @@ class Mission
 			class Item281
 			{
 				linkID=281;
-				item0=17940;
+				item0=17941;
 				item1=823;
 				class CustomData
 				{
@@ -57896,7 +58020,7 @@ class Mission
 			class Item282
 			{
 				linkID=282;
-				item0=17941;
+				item0=17150;
 				item1=823;
 				class CustomData
 				{
@@ -57906,7 +58030,7 @@ class Mission
 			class Item283
 			{
 				linkID=283;
-				item0=17150;
+				item0=18737;
 				item1=823;
 				class CustomData
 				{
@@ -57916,7 +58040,7 @@ class Mission
 			class Item284
 			{
 				linkID=284;
-				item0=18737;
+				item0=18738;
 				item1=823;
 				class CustomData
 				{
@@ -57926,7 +58050,7 @@ class Mission
 			class Item285
 			{
 				linkID=285;
-				item0=18738;
+				item0=18739;
 				item1=823;
 				class CustomData
 				{
@@ -57936,7 +58060,7 @@ class Mission
 			class Item286
 			{
 				linkID=286;
-				item0=18739;
+				item0=18740;
 				item1=823;
 				class CustomData
 				{
@@ -57946,7 +58070,7 @@ class Mission
 			class Item287
 			{
 				linkID=287;
-				item0=18740;
+				item0=18741;
 				item1=823;
 				class CustomData
 				{
@@ -57956,7 +58080,7 @@ class Mission
 			class Item288
 			{
 				linkID=288;
-				item0=18741;
+				item0=17961;
 				item1=823;
 				class CustomData
 				{
@@ -57966,7 +58090,7 @@ class Mission
 			class Item289
 			{
 				linkID=289;
-				item0=17961;
+				item0=17962;
 				item1=823;
 				class CustomData
 				{
@@ -57976,7 +58100,7 @@ class Mission
 			class Item290
 			{
 				linkID=290;
-				item0=17962;
+				item0=17963;
 				item1=823;
 				class CustomData
 				{
@@ -57986,7 +58110,7 @@ class Mission
 			class Item291
 			{
 				linkID=291;
-				item0=17963;
+				item0=17964;
 				item1=823;
 				class CustomData
 				{
@@ -57996,8 +58120,8 @@ class Mission
 			class Item292
 			{
 				linkID=292;
-				item0=17964;
-				item1=823;
+				item0=16797;
+				item1=17967;
 				class CustomData
 				{
 					type="Sync";
@@ -58006,8 +58130,8 @@ class Mission
 			class Item293
 			{
 				linkID=293;
-				item0=16797;
-				item1=17967;
+				item0=16794;
+				item1=17965;
 				class CustomData
 				{
 					type="Sync";
@@ -58016,8 +58140,8 @@ class Mission
 			class Item294
 			{
 				linkID=294;
-				item0=16794;
-				item1=17965;
+				item0=18270;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58026,7 +58150,7 @@ class Mission
 			class Item295
 			{
 				linkID=295;
-				item0=18270;
+				item0=18271;
 				item1=823;
 				class CustomData
 				{
@@ -58036,7 +58160,7 @@ class Mission
 			class Item296
 			{
 				linkID=296;
-				item0=18271;
+				item0=17969;
 				item1=823;
 				class CustomData
 				{
@@ -58046,7 +58170,7 @@ class Mission
 			class Item297
 			{
 				linkID=297;
-				item0=17969;
+				item0=17978;
 				item1=823;
 				class CustomData
 				{
@@ -58056,7 +58180,7 @@ class Mission
 			class Item298
 			{
 				linkID=298;
-				item0=17978;
+				item0=17977;
 				item1=823;
 				class CustomData
 				{
@@ -58066,7 +58190,7 @@ class Mission
 			class Item299
 			{
 				linkID=299;
-				item0=17977;
+				item0=17976;
 				item1=823;
 				class CustomData
 				{
@@ -58076,7 +58200,7 @@ class Mission
 			class Item300
 			{
 				linkID=300;
-				item0=17976;
+				item0=18063;
 				item1=823;
 				class CustomData
 				{
@@ -58086,8 +58210,8 @@ class Mission
 			class Item301
 			{
 				linkID=301;
-				item0=18063;
-				item1=823;
+				item0=18144;
+				item1=18142;
 				class CustomData
 				{
 					type="Sync";
@@ -58096,7 +58220,7 @@ class Mission
 			class Item302
 			{
 				linkID=302;
-				item0=18144;
+				item0=18143;
 				item1=18142;
 				class CustomData
 				{
@@ -58106,8 +58230,8 @@ class Mission
 			class Item303
 			{
 				linkID=303;
-				item0=18143;
-				item1=18142;
+				item0=17901;
+				item1=264;
 				class CustomData
 				{
 					type="Sync";
@@ -58116,8 +58240,8 @@ class Mission
 			class Item304
 			{
 				linkID=304;
-				item0=17901;
-				item1=264;
+				item0=16563;
+				item1=16564;
 				class CustomData
 				{
 					type="Sync";
@@ -58126,8 +58250,8 @@ class Mission
 			class Item305
 			{
 				linkID=305;
-				item0=16563;
-				item1=16564;
+				item0=14796;
+				item1=264;
 				class CustomData
 				{
 					type="Sync";
@@ -58136,8 +58260,8 @@ class Mission
 			class Item306
 			{
 				linkID=306;
-				item0=14796;
-				item1=264;
+				item0=17002;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58146,7 +58270,7 @@ class Mission
 			class Item307
 			{
 				linkID=307;
-				item0=17002;
+				item0=17142;
 				item1=823;
 				class CustomData
 				{
@@ -58156,7 +58280,7 @@ class Mission
 			class Item308
 			{
 				linkID=308;
-				item0=17142;
+				item0=18196;
 				item1=823;
 				class CustomData
 				{
@@ -58166,8 +58290,8 @@ class Mission
 			class Item309
 			{
 				linkID=309;
-				item0=18196;
-				item1=823;
+				item0=16649;
+				item1=18200;
 				class CustomData
 				{
 					type="Sync";
@@ -58176,8 +58300,8 @@ class Mission
 			class Item310
 			{
 				linkID=310;
-				item0=16649;
-				item1=18200;
+				item0=16675;
+				item1=18202;
 				class CustomData
 				{
 					type="Sync";
@@ -58186,8 +58310,8 @@ class Mission
 			class Item311
 			{
 				linkID=311;
-				item0=16675;
-				item1=18202;
+				item0=16678;
+				item1=18201;
 				class CustomData
 				{
 					type="Sync";
@@ -58196,8 +58320,8 @@ class Mission
 			class Item312
 			{
 				linkID=312;
-				item0=16678;
-				item1=18201;
+				item0=18215;
+				item1=18216;
 				class CustomData
 				{
 					type="Sync";
@@ -58206,8 +58330,8 @@ class Mission
 			class Item313
 			{
 				linkID=313;
-				item0=18215;
-				item1=18216;
+				item0=18216;
+				item1=18217;
 				class CustomData
 				{
 					type="Sync";
@@ -58216,8 +58340,8 @@ class Mission
 			class Item314
 			{
 				linkID=314;
-				item0=18216;
-				item1=18217;
+				item0=18210;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58226,8 +58350,8 @@ class Mission
 			class Item315
 			{
 				linkID=315;
-				item0=18210;
-				item1=823;
+				item0=18239;
+				item1=18240;
 				class CustomData
 				{
 					type="Sync";
@@ -58236,8 +58360,8 @@ class Mission
 			class Item316
 			{
 				linkID=316;
-				item0=18239;
-				item1=18240;
+				item0=18240;
+				item1=18241;
 				class CustomData
 				{
 					type="Sync";
@@ -58246,8 +58370,8 @@ class Mission
 			class Item317
 			{
 				linkID=317;
-				item0=18240;
-				item1=18241;
+				item0=16767;
+				item1=264;
 				class CustomData
 				{
 					type="Sync";
@@ -58256,7 +58380,7 @@ class Mission
 			class Item318
 			{
 				linkID=318;
-				item0=16767;
+				item0=16764;
 				item1=264;
 				class CustomData
 				{
@@ -58266,8 +58390,8 @@ class Mission
 			class Item319
 			{
 				linkID=319;
-				item0=16764;
-				item1=264;
+				item0=18245;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58276,7 +58400,7 @@ class Mission
 			class Item320
 			{
 				linkID=320;
-				item0=18245;
+				item0=18244;
 				item1=823;
 				class CustomData
 				{
@@ -58286,8 +58410,8 @@ class Mission
 			class Item321
 			{
 				linkID=321;
-				item0=18244;
-				item1=823;
+				item0=18251;
+				item1=18250;
 				class CustomData
 				{
 					type="Sync";
@@ -58296,7 +58420,7 @@ class Mission
 			class Item322
 			{
 				linkID=322;
-				item0=18251;
+				item0=18252;
 				item1=18250;
 				class CustomData
 				{
@@ -58306,8 +58430,8 @@ class Mission
 			class Item323
 			{
 				linkID=323;
-				item0=18252;
-				item1=18250;
+				item0=18259;
+				item1=264;
 				class CustomData
 				{
 					type="Sync";
@@ -58316,8 +58440,8 @@ class Mission
 			class Item324
 			{
 				linkID=324;
-				item0=18259;
-				item1=264;
+				item0=16887;
+				item1=16886;
 				class CustomData
 				{
 					type="Sync";
@@ -58326,8 +58450,8 @@ class Mission
 			class Item325
 			{
 				linkID=325;
-				item0=16887;
-				item1=16886;
+				item0=16529;
+				item1=18293;
 				class CustomData
 				{
 					type="Sync";
@@ -58336,8 +58460,8 @@ class Mission
 			class Item326
 			{
 				linkID=326;
-				item0=16529;
-				item1=18293;
+				item0=16804;
+				item1=264;
 				class CustomData
 				{
 					type="Sync";
@@ -58346,8 +58470,8 @@ class Mission
 			class Item327
 			{
 				linkID=327;
-				item0=16804;
-				item1=264;
+				item0=18376;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58356,7 +58480,7 @@ class Mission
 			class Item328
 			{
 				linkID=328;
-				item0=18376;
+				item0=18377;
 				item1=823;
 				class CustomData
 				{
@@ -58366,7 +58490,7 @@ class Mission
 			class Item329
 			{
 				linkID=329;
-				item0=18377;
+				item0=18378;
 				item1=823;
 				class CustomData
 				{
@@ -58376,7 +58500,7 @@ class Mission
 			class Item330
 			{
 				linkID=330;
-				item0=18378;
+				item0=18379;
 				item1=823;
 				class CustomData
 				{
@@ -58386,7 +58510,7 @@ class Mission
 			class Item331
 			{
 				linkID=331;
-				item0=18379;
+				item0=18380;
 				item1=823;
 				class CustomData
 				{
@@ -58396,7 +58520,7 @@ class Mission
 			class Item332
 			{
 				linkID=332;
-				item0=18380;
+				item0=18381;
 				item1=823;
 				class CustomData
 				{
@@ -58406,8 +58530,8 @@ class Mission
 			class Item333
 			{
 				linkID=333;
-				item0=18381;
-				item1=823;
+				item0=18387;
+				item1=18391;
 				class CustomData
 				{
 					type="Sync";
@@ -58416,7 +58540,7 @@ class Mission
 			class Item334
 			{
 				linkID=334;
-				item0=18387;
+				item0=18389;
 				item1=18391;
 				class CustomData
 				{
@@ -58426,8 +58550,8 @@ class Mission
 			class Item335
 			{
 				linkID=335;
-				item0=18389;
-				item1=18391;
+				item0=18388;
+				item1=18392;
 				class CustomData
 				{
 					type="Sync";
@@ -58436,7 +58560,7 @@ class Mission
 			class Item336
 			{
 				linkID=336;
-				item0=18388;
+				item0=18390;
 				item1=18392;
 				class CustomData
 				{
@@ -58446,8 +58570,8 @@ class Mission
 			class Item337
 			{
 				linkID=337;
-				item0=18390;
-				item1=18392;
+				item0=18423;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58456,8 +58580,8 @@ class Mission
 			class Item338
 			{
 				linkID=338;
-				item0=18423;
-				item1=823;
+				item0=18505;
+				item1=18504;
 				class CustomData
 				{
 					type="Sync";
@@ -58466,7 +58590,7 @@ class Mission
 			class Item339
 			{
 				linkID=339;
-				item0=18505;
+				item0=18503;
 				item1=18504;
 				class CustomData
 				{
@@ -58476,8 +58600,8 @@ class Mission
 			class Item340
 			{
 				linkID=340;
-				item0=18503;
-				item1=18504;
+				item0=18766;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58486,7 +58610,7 @@ class Mission
 			class Item341
 			{
 				linkID=341;
-				item0=18766;
+				item0=18507;
 				item1=823;
 				class CustomData
 				{
@@ -58496,8 +58620,8 @@ class Mission
 			class Item342
 			{
 				linkID=342;
-				item0=18507;
-				item1=823;
+				item0=18577;
+				item1=18581;
 				class CustomData
 				{
 					type="Sync";
@@ -58506,7 +58630,7 @@ class Mission
 			class Item343
 			{
 				linkID=343;
-				item0=18577;
+				item0=18579;
 				item1=18581;
 				class CustomData
 				{
@@ -58516,8 +58640,8 @@ class Mission
 			class Item344
 			{
 				linkID=344;
-				item0=18579;
-				item1=18581;
+				item0=18578;
+				item1=18582;
 				class CustomData
 				{
 					type="Sync";
@@ -58526,7 +58650,7 @@ class Mission
 			class Item345
 			{
 				linkID=345;
-				item0=18578;
+				item0=18580;
 				item1=18582;
 				class CustomData
 				{
@@ -58536,8 +58660,8 @@ class Mission
 			class Item346
 			{
 				linkID=346;
-				item0=18580;
-				item1=18582;
+				item0=18586;
+				item1=18602;
 				class CustomData
 				{
 					type="Sync";
@@ -58546,8 +58670,8 @@ class Mission
 			class Item347
 			{
 				linkID=347;
-				item0=18586;
-				item1=18602;
+				item0=18587;
+				item1=18603;
 				class CustomData
 				{
 					type="Sync";
@@ -58556,8 +58680,8 @@ class Mission
 			class Item348
 			{
 				linkID=348;
-				item0=18587;
-				item1=18603;
+				item0=18588;
+				item1=18604;
 				class CustomData
 				{
 					type="Sync";
@@ -58566,8 +58690,8 @@ class Mission
 			class Item349
 			{
 				linkID=349;
-				item0=18588;
-				item1=18604;
+				item0=18589;
+				item1=18605;
 				class CustomData
 				{
 					type="Sync";
@@ -58576,8 +58700,8 @@ class Mission
 			class Item350
 			{
 				linkID=350;
-				item0=18589;
-				item1=18605;
+				item0=18585;
+				item1=18601;
 				class CustomData
 				{
 					type="Sync";
@@ -58586,8 +58710,8 @@ class Mission
 			class Item351
 			{
 				linkID=351;
-				item0=18585;
-				item1=18601;
+				item0=18604;
+				item1=18598;
 				class CustomData
 				{
 					type="Sync";
@@ -58596,8 +58720,8 @@ class Mission
 			class Item352
 			{
 				linkID=352;
-				item0=18604;
-				item1=18598;
+				item0=18605;
+				item1=18597;
 				class CustomData
 				{
 					type="Sync";
@@ -58606,8 +58730,8 @@ class Mission
 			class Item353
 			{
 				linkID=353;
-				item0=18605;
-				item1=18597;
+				item0=18602;
+				item1=18596;
 				class CustomData
 				{
 					type="Sync";
@@ -58616,8 +58740,8 @@ class Mission
 			class Item354
 			{
 				linkID=354;
-				item0=18602;
-				item1=18596;
+				item0=18603;
+				item1=18595;
 				class CustomData
 				{
 					type="Sync";
@@ -58626,8 +58750,8 @@ class Mission
 			class Item355
 			{
 				linkID=355;
-				item0=18603;
-				item1=18595;
+				item0=18601;
+				item1=18599;
 				class CustomData
 				{
 					type="Sync";
@@ -58636,8 +58760,8 @@ class Mission
 			class Item356
 			{
 				linkID=356;
-				item0=18601;
-				item1=18599;
+				item0=18607;
+				item1=18610;
 				class CustomData
 				{
 					type="Sync";
@@ -58646,8 +58770,8 @@ class Mission
 			class Item357
 			{
 				linkID=357;
-				item0=18607;
-				item1=18610;
+				item0=18610;
+				item1=18609;
 				class CustomData
 				{
 					type="Sync";
@@ -58656,8 +58780,8 @@ class Mission
 			class Item358
 			{
 				linkID=358;
-				item0=18610;
-				item1=18609;
+				item0=18654;
+				item1=18657;
 				class CustomData
 				{
 					type="Sync";
@@ -58666,7 +58790,7 @@ class Mission
 			class Item359
 			{
 				linkID=359;
-				item0=18654;
+				item0=18656;
 				item1=18657;
 				class CustomData
 				{
@@ -58676,8 +58800,8 @@ class Mission
 			class Item360
 			{
 				linkID=360;
-				item0=18656;
-				item1=18657;
+				item0=18659;
+				item1=18658;
 				class CustomData
 				{
 					type="Sync";
@@ -58686,7 +58810,7 @@ class Mission
 			class Item361
 			{
 				linkID=361;
-				item0=18659;
+				item0=18660;
 				item1=18658;
 				class CustomData
 				{
@@ -58696,8 +58820,8 @@ class Mission
 			class Item362
 			{
 				linkID=362;
-				item0=18660;
-				item1=18658;
+				item0=18662;
+				item1=18661;
 				class CustomData
 				{
 					type="Sync";
@@ -58706,7 +58830,7 @@ class Mission
 			class Item363
 			{
 				linkID=363;
-				item0=18662;
+				item0=18663;
 				item1=18661;
 				class CustomData
 				{
@@ -58716,8 +58840,8 @@ class Mission
 			class Item364
 			{
 				linkID=364;
-				item0=18663;
-				item1=18661;
+				item0=18665;
+				item1=18664;
 				class CustomData
 				{
 					type="Sync";
@@ -58726,7 +58850,7 @@ class Mission
 			class Item365
 			{
 				linkID=365;
-				item0=18665;
+				item0=18666;
 				item1=18664;
 				class CustomData
 				{
@@ -58736,8 +58860,8 @@ class Mission
 			class Item366
 			{
 				linkID=366;
-				item0=18666;
-				item1=18664;
+				item0=18668;
+				item1=18667;
 				class CustomData
 				{
 					type="Sync";
@@ -58746,7 +58870,7 @@ class Mission
 			class Item367
 			{
 				linkID=367;
-				item0=18668;
+				item0=18669;
 				item1=18667;
 				class CustomData
 				{
@@ -58756,8 +58880,8 @@ class Mission
 			class Item368
 			{
 				linkID=368;
-				item0=18669;
-				item1=18667;
+				item0=18672;
+				item1=18678;
 				class CustomData
 				{
 					type="Sync";
@@ -58766,7 +58890,7 @@ class Mission
 			class Item369
 			{
 				linkID=369;
-				item0=18672;
+				item0=18675;
 				item1=18678;
 				class CustomData
 				{
@@ -58776,8 +58900,8 @@ class Mission
 			class Item370
 			{
 				linkID=370;
-				item0=18675;
-				item1=18678;
+				item0=18673;
+				item1=18679;
 				class CustomData
 				{
 					type="Sync";
@@ -58786,7 +58910,7 @@ class Mission
 			class Item371
 			{
 				linkID=371;
-				item0=18673;
+				item0=18676;
 				item1=18679;
 				class CustomData
 				{
@@ -58796,8 +58920,8 @@ class Mission
 			class Item372
 			{
 				linkID=372;
-				item0=18676;
-				item1=18679;
+				item0=18674;
+				item1=18680;
 				class CustomData
 				{
 					type="Sync";
@@ -58806,7 +58930,7 @@ class Mission
 			class Item373
 			{
 				linkID=373;
-				item0=18674;
+				item0=18677;
 				item1=18680;
 				class CustomData
 				{
@@ -58816,8 +58940,8 @@ class Mission
 			class Item374
 			{
 				linkID=374;
-				item0=18677;
-				item1=18680;
+				item0=18686;
+				item1=18688;
 				class CustomData
 				{
 					type="Sync";
@@ -58826,7 +58950,7 @@ class Mission
 			class Item375
 			{
 				linkID=375;
-				item0=18686;
+				item0=18687;
 				item1=18688;
 				class CustomData
 				{
@@ -58836,8 +58960,8 @@ class Mission
 			class Item376
 			{
 				linkID=376;
-				item0=18687;
-				item1=18688;
+				item0=18701;
+				item1=18703;
 				class CustomData
 				{
 					type="Sync";
@@ -58846,7 +58970,7 @@ class Mission
 			class Item377
 			{
 				linkID=377;
-				item0=18701;
+				item0=18702;
 				item1=18703;
 				class CustomData
 				{
@@ -58856,8 +58980,8 @@ class Mission
 			class Item378
 			{
 				linkID=378;
-				item0=18702;
-				item1=18703;
+				item0=18705;
+				item1=18708;
 				class CustomData
 				{
 					type="Sync";
@@ -58866,8 +58990,8 @@ class Mission
 			class Item379
 			{
 				linkID=379;
-				item0=18705;
-				item1=18708;
+				item0=18708;
+				item1=18707;
 				class CustomData
 				{
 					type="Sync";
@@ -58876,8 +59000,8 @@ class Mission
 			class Item380
 			{
 				linkID=380;
-				item0=18708;
-				item1=18707;
+				item0=18706;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58886,8 +59010,8 @@ class Mission
 			class Item381
 			{
 				linkID=381;
-				item0=18706;
-				item1=823;
+				item0=18718;
+				item1=18720;
 				class CustomData
 				{
 					type="Sync";
@@ -58896,7 +59020,7 @@ class Mission
 			class Item382
 			{
 				linkID=382;
-				item0=18718;
+				item0=18719;
 				item1=18720;
 				class CustomData
 				{
@@ -58906,8 +59030,8 @@ class Mission
 			class Item383
 			{
 				linkID=383;
-				item0=18719;
-				item1=18720;
+				item0=18764;
+				item1=18765;
 				class CustomData
 				{
 					type="Sync";
@@ -58916,8 +59040,8 @@ class Mission
 			class Item384
 			{
 				linkID=384;
-				item0=18764;
-				item1=18765;
+				item0=18765;
+				item1=18762;
 				class CustomData
 				{
 					type="Sync";
@@ -58926,8 +59050,8 @@ class Mission
 			class Item385
 			{
 				linkID=385;
-				item0=18765;
-				item1=18762;
+				item0=18768;
+				item1=18767;
 				class CustomData
 				{
 					type="Sync";
@@ -58936,8 +59060,8 @@ class Mission
 			class Item386
 			{
 				linkID=386;
-				item0=18768;
-				item1=18767;
+				item0=18767;
+				item1=18770;
 				class CustomData
 				{
 					type="Sync";
@@ -58946,8 +59070,8 @@ class Mission
 			class Item387
 			{
 				linkID=387;
-				item0=18767;
-				item1=18770;
+				item0=18769;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58956,8 +59080,8 @@ class Mission
 			class Item388
 			{
 				linkID=388;
-				item0=18769;
-				item1=823;
+				item0=18618;
+				item1=264;
 				class CustomData
 				{
 					type="Sync";
@@ -58966,8 +59090,8 @@ class Mission
 			class Item389
 			{
 				linkID=389;
-				item0=18618;
-				item1=264;
+				item0=18786;
+				item1=18788;
 				class CustomData
 				{
 					type="Sync";
@@ -58976,8 +59100,8 @@ class Mission
 			class Item390
 			{
 				linkID=390;
-				item0=18786;
-				item1=18788;
+				item0=18788;
+				item1=18787;
 				class CustomData
 				{
 					type="Sync";
@@ -58986,8 +59110,8 @@ class Mission
 			class Item391
 			{
 				linkID=391;
-				item0=18788;
-				item1=18787;
+				item0=18608;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";
@@ -58996,7 +59120,7 @@ class Mission
 			class Item392
 			{
 				linkID=392;
-				item0=18608;
+				item0=18592;
 				item1=823;
 				class CustomData
 				{
@@ -59006,7 +59130,7 @@ class Mission
 			class Item393
 			{
 				linkID=393;
-				item0=18592;
+				item0=18242;
 				item1=823;
 				class CustomData
 				{
@@ -59016,7 +59140,7 @@ class Mission
 			class Item394
 			{
 				linkID=394;
-				item0=18242;
+				item0=18763;
 				item1=823;
 				class CustomData
 				{
@@ -59026,7 +59150,7 @@ class Mission
 			class Item395
 			{
 				linkID=395;
-				item0=18763;
+				item0=18822;
 				item1=823;
 				class CustomData
 				{
@@ -59036,8 +59160,8 @@ class Mission
 			class Item396
 			{
 				linkID=396;
-				item0=18822;
-				item1=823;
+				item0=19344;
+				item1=19346;
 				class CustomData
 				{
 					type="Sync";
@@ -59046,8 +59170,8 @@ class Mission
 			class Item397
 			{
 				linkID=397;
-				item0=19344;
-				item1=19346;
+				item0=19346;
+				item1=19345;
 				class CustomData
 				{
 					type="Sync";
@@ -59056,8 +59180,8 @@ class Mission
 			class Item398
 			{
 				linkID=398;
-				item0=19346;
-				item1=19345;
+				item0=19559;
+				item1=823;
 				class CustomData
 				{
 					type="Sync";

--- a/mission/config/subconfigs/buildables.hpp
+++ b/mission/config/subconfigs/buildables.hpp
@@ -820,7 +820,7 @@ class Land_vn_b_trench_tee_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_tee_01";
+			object_class = "vn_b_trench_tee_01_part1";
 		};
 		class final_state
 		{
@@ -882,7 +882,7 @@ class Land_vn_b_trench_stair_02
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_stair_02";
+			object_class = "vn_b_trench_stair_02_part1";
 		};
 		class final_state
 		{
@@ -1038,7 +1038,7 @@ class Land_vn_b_trench_firing_05
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_firing_05";
+			object_class = "vn_b_trench_firing_05_part1";
 		};
 		class final_state
 		{
@@ -1070,7 +1070,7 @@ class Land_vn_b_trench_firing_04
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_firing_04";
+			object_class = "vn_b_trench_firing_03_part1";
 		};
 		class final_state
 		{
@@ -1134,7 +1134,7 @@ class Land_vn_b_trench_firing_02
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_firing_02";
+			object_class = "vn_b_trench_firing_02_part1";
 		};
 		class final_state
 		{
@@ -1165,7 +1165,7 @@ class Land_vn_b_trench_firing_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_firing_01";
+			object_class = "vn_b_trench_firing_01_part1";
 		};
 		class final_state
 		{
@@ -1229,7 +1229,7 @@ class Land_vn_b_trench_end_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_end_01";
+			object_class = "vn_b_trench_end_01_part1";
 		};
 		class final_state
 		{
@@ -1261,7 +1261,7 @@ class Land_vn_b_trench_cross_02
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_cross_02";
+			object_class = "vn_b_trench_cross_02_part1";
 		};
 		class final_state
 		{
@@ -1293,7 +1293,7 @@ class Land_vn_b_trench_cross_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_cross_01";
+			object_class = "vn_b_trench_cross_01_part1";
 		};
 		class final_state
 		{
@@ -1485,7 +1485,7 @@ class Land_vn_b_trench_bunker_04_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_04_01";
+			object_class = "vn_b_trench_bunker_04_01_part1";
 		};
 		class final_state
 		{
@@ -1553,7 +1553,7 @@ class Land_vn_b_trench_bunker_03_03
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_03_03";
+			object_class = "vn_b_trench_bunker_03_03_part1";
 		};
 		class final_state
 		{
@@ -1624,7 +1624,7 @@ class Land_vn_b_trench_bunker_03_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_03_01";
+			object_class = "vn_b_trench_bunker_03_01_part1";
 		};
 		class final_state
 		{
@@ -1663,7 +1663,7 @@ class Land_vn_b_trench_bunker_02_04
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_02_04";
+			object_class = "vn_b_trench_bunker_02_04_part1";
 		};
 		class final_state
 		{
@@ -1702,7 +1702,7 @@ class Land_vn_b_trench_bunker_02_03
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_02_03";
+			object_class = "vn_b_trench_bunker_02_03_part1";
 		};
 		class final_state
 		{
@@ -1741,7 +1741,7 @@ class Land_vn_b_trench_bunker_02_02
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_02_02";
+			object_class = "vn_b_trench_bunker_02_02_part1";
 		};
 		class final_state
 		{
@@ -1780,7 +1780,7 @@ class Land_vn_b_trench_bunker_02_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_02_01";
+			object_class = "vn_b_trench_bunker_02_01_part1";
 		};
 		class final_state
 		{
@@ -1819,7 +1819,7 @@ class Land_vn_b_trench_bunker_01_03
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_01_03";
+			object_class = "vn_b_trench_bunker_01_03_part1";
 		};
 		class final_state
 		{
@@ -1917,7 +1917,7 @@ class Land_vn_b_trench_bunker_01_02
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_01_02";
+			object_class = "vn_b_trench_bunker_01_02_part1";
 		};
 		class final_state
 		{
@@ -1949,7 +1949,7 @@ class Land_vn_b_trench_bunker_01_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_bunker_01_01";
+			object_class = "vn_b_trench_bunker_01_01_part1";
 		};
 		class final_state
 		{
@@ -1985,7 +1985,7 @@ class Land_vn_b_trench_90_02
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_90_02";
+			object_class = "vn_b_trench_90_02_part1";
 		};
 		class final_state
 		{
@@ -2017,7 +2017,7 @@ class Land_vn_b_trench_90_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_90_01";
+			object_class = "vn_b_trench_90_01_part1";
 		};
 		class final_state
 		{
@@ -2049,7 +2049,7 @@ class Land_vn_b_trench_45_02
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_45_02";
+			object_class = "vn_b_trench_45_02_part1";
 		};
 		class final_state
 		{
@@ -2081,7 +2081,7 @@ class Land_vn_b_trench_45_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_45_01";
+			object_class = "vn_b_trench_45_01_part1";
 		};
 		class final_state
 		{
@@ -2113,7 +2113,7 @@ class Land_vn_b_trench_20_02
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_20_02";
+			object_class = "vn_b_trench_20_02_part1";
 		};
 		class final_state
 		{
@@ -2145,7 +2145,7 @@ class Land_vn_b_trench_20_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_20_01";
+			object_class = "vn_b_trench_20_01_part1";
 		};
 		class final_state
 		{
@@ -2176,7 +2176,7 @@ class Land_vn_b_trench_05_03
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_05_03";
+			object_class = "Land_vn_b_trench_05_03"; //dont put part1 here
 		};
 		class final_state
 		{
@@ -2207,7 +2207,7 @@ class Land_vn_b_trench_05_02
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_05_02";
+			object_class = "vn_b_trench_05_02_part1";
 		};
 		class final_state
 		{
@@ -2238,7 +2238,7 @@ class Land_vn_b_trench_05_01
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_trench_05_01";
+			object_class = "vn_b_trench_05_01_part1";
 		};
 		class final_state
 		{
@@ -2816,11 +2816,11 @@ class Land_vn_b_tower_01
 	{
 		class initial_state
 		{
-			object_class = "Land_vn_b_tower_01";
+			object_class = "vn_b_tower_01_part0";
 		};
 		class middle_state
 		{
-			object_class = "Land_vn_b_tower_01";
+			object_class = "vn_b_tower_01_part1";
 		};
 		class final_state
 		{


### PR DESCRIPTION
Update middle_state object_class for trench and tower buildables Replaces the object_class values in the middle_state of various trench and tower buildable classes to use the correct *_part1 (or *_part0 for initial_state) object names. This ensures proper referencing of partial build states and fixes inconsistencies in the buildable configuration.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/70a23df6-9fdc-4341-9fa2-d09a0aa146b3" />