### PR TITLE
Updated Arsenal and Crates

### DIFF
--- a/mission/config/arsenal.hpp
+++ b/mission/config/arsenal.hpp
@@ -35,1562 +35,1600 @@ class vn_whitelisted_arsenal_loadouts
 				Entry:	
 					{ "vn_dp28", 							{ 3,-1,-1, 6}}
 		*/
-		weapons[] =
-		{
-			//Rifles
-			//BluFor
-			{"vn_m40a1", 							{-1, 0, 0,-1}},	//	M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
-			{"vn_m40a1_sniper", 					{-1, 0, 0,-1}},	//	M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
-			{"vn_m40a1_sniper_sd", 					{-1, 0, 0,-1}},	//	M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
-			{"vn_m40a1_nvg", 						{-1, 0, 0,-1}},	//	M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
-			{"vn_m40a1_nvg_sd", 					{-1, 0, 0,-1}},	//	M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
-			{"vn_m40a1_camo", 						{-1, 0, 0,-1}},	//	M40 Sniper Rifle, camo polymer body, firing 7.62x51mm match-grade ammunition
-			{"vn_m14", 								{-1, 0, 0,-1}},	//	M14 selective-fire rifle firing 7.62mm ammunition in 20-round mags
-			{"vn_m14_sd", 							{-1, 0, 0,-1}},	//	M14 selective-fire rifle firing 7.62mm ammunition in 20-round mags
-			{"vn_m14_bayo", 						{-1, 0, 0,-1}},	//	M14 selective-fire rifle firing 7.62mm ammunition in 20-round mags
-			{"vn_m14_camo", 						{-1, 0, 0,-1}},	//	M14 selective-fire rifle firing 7.62mm ammunition in 20-round mags, with camo tape
-			{"vn_m21", 								{-1, 0, 0,-1}},	//	XM21 sniper rifle firing 7.62mm ammunition in 20-round mags. Fitted with a 3x to 9x Adjustable Ranging Telescope
-			{"vn_m21_sd", 							{-1, 0, 0,-1}},	//	XM21 sniper rifle firing 7.62mm ammunition in 20-round mags. Fitted with a 3x to 9x Adjustable Ranging Telescope
-			{"vn_m21_nvg", 							{-1, 0, 0,-1}},	//	XM21 sniper rifle firing 7.62mm ammunition in 20-round mags. Fitted with a 3x to 9x Adjustable Ranging Telescope
-			{"vn_m21_nvg_sd", 						{-1, 0, 0,-1}},	//	XM21 sniper rifle firing 7.62mm ammunition in 20-round mags. Fitted with a 3x to 9x Adjustable Ranging Telescope
-			{"vn_m1_garand", 						{-1, 0, 0,-1}},	//	M1 Garand 7.62x63mm Rifle
-			{"vn_m1_garand_sniper", 				{-1, 0, 0,-1}},	//	M1 Garand 7.62x63mm Rifle
-			{"vn_m1_garand_bayo", 					{-1, 0, 0,-1}},	//	M1 Garand 7.62x63mm Rifle
-			{"vn_m1_garand_gl", 					{-1, 0, 1,-1}},	//	M1 Garand 7.62x63mm Rifle, fitted with an M8 22mm rifle grenade
-			{"vn_m14a1", 							{-1, 0,-1,-1}},	//	M14A1 7.62mm automatic rifle
-			{"vn_m14a1_bipod", 						{-1, 0,-1,-1}},	//	M14A1 7.62mm automatic rifle
-			{"vn_m14a1_sniper", 					{-1, 0,-1,-1}},	//	M14A1 7.62mm automatic rifle
-			{"vn_m14a1_nvg", 						{-1, 0,-1,-1}},	//	M14A1 7.62mm automatic rifle
-			{"vn_m14a1_camo", 						{-1, 0,-1,-1}},	//	M14A1 7.62mm automatic rifle, fitted with a bipod and camo paint
-			{"vn_m14a1_shorty", 					{-1, 0, 4,-1}},	//	M14A1 cut short for use by SOG recon
-			{"vn_m14a1_shorty_fs", 					{-1, 0, 5,-1}},	//	M14A1 cut short for use by SOG recon, with added front sight
-			{"vn_m1903", 							{ 0, 0, 0, 0}},	//	M1903 5-shot, clip-fed, 7.62x65 rifle
-			{"vn_m1903_sniper", 					{ 0, 0, 0, 0}},	//	M1903 5-shot, clip-fed, 7.62x65 rifle
-			{"vn_m1903_bayo", 						{ 0, 0, 0, 0}},	//	M1903 5-shot, clip-fed, 7.62x65 rifle
-			{"vn_m1903_gl", 						{ 0, 0, 2, 2}},	//	M1903 5-shot, clip-fed, 7.62x65 rifle fitted with an M8 22mm rifle grenade
-			{"vn_m36",								{ 0, 0, 0, 0}},	//	M36 5-shot, clip-fed, 7.5x54mm rifle
-			{"vn_m36_bayo", 						{ 0, 0, 0, 0}},	//	M36 5-shot, clip-fed, 7.5x54mm rifle
-			{"vn_m36_camo", 						{ 0, 0, 0, 0}},	//	M36 5-shot, clip-fed, 7.5x54mm rifle
-			{"vn_l1a1_01", 							{-1, 0, 1,-1}},	//	Australian L1A1 7.62mm Rifle
-			{"vn_l1a1_01_mrk", 						{-1, 0, 1,-1}},	//	Australian L1A1 7.62mm Rifle
-			{"vn_l1a1_01_bayo", 					{-1, 0, 1,-1}},	//	Australian L1A1 7.62mm Rifle
-			{"vn_l1a1_01_camo", 					{-1, 0, 1,-1}},	//	Australian L1A1 7.62mm Rifle, fitted with camo tape
-			{"vn_l1a1_01_gl", 						{-1, 0, 2,-1}},	//	Australian L1A1 7.62mm Rifle, fitted with a 22mm rifle grenade adapter
-			{"vn_l1a1_02", 							{-1, 0, 1,-1}},	//	New Zealand L1A1 7.62mm Rifle
-			{"vn_l1a1_02_mrk", 						{-1, 0, 1,-1}},	//	New Zealand L1A1 7.62mm Rifle
-			{"vn_l1a1_02_bayo", 					{-1, 0, 1,-1}},	//	New Zealand L1A1 7.62mm Rifle
-			{"vn_l1a1_02_camo", 					{-1, 0, 2,-1}},	//	New Zealand L1A1 7.62mm Rifle, fitted with camo tape
-			{"vn_l1a1_02_gl", 						{-1, 0, 3,-1}},	//	New Zealand L1A1 7.62mm Rifle, fitted with a 22mm rifle grenade adapter
-			{"vn_l1a1_03", 							{-1, 0, 4,-1}},	//	SAS L1A1 7.62mm Rifle, fitted with foregrip
-			{"vn_l1a1_03_camo", 					{-1, 0, 5,-1}},	//	SAS L1A1 7.62mm Rifle, fitted with foregrip and camo paint
-			{"vn_l1a1_xm148", 						{-1, 0, 4,-1}},	//	L1A1 7.62mm Rifle, fitted with an XM148 40mm grenade launcher
-			{"vn_l1a1_xm148_camo", 					{-1, 0, 5,-1}},	//	L1A1 7.62mm Rifle, fitted with an XM148 40mm grenade launcher and camo paint
-			//OpFor
-			{"vn_sks", 								{ 0,-1, 0,-1}},	//	SKS semi-automatic rifle with folding bayonet. Chambered in 10-round clips of 7.62x39mm
-			{"vn_sks_sniper", 						{ 0,-1, 0,-1}},	//	SKS semi-automatic rifle with folding bayonet. Chambered in 10-round clips of 7.62x39mm
-			{"vn_sks_bayo", 						{ 0,-1, 0,-1}},	//	SKS semi-automatic rifle with folding bayonet. Chambered in 10-round clips of 7.62x39mm
-			{"vn_sks_gl", 							{ 0,-1, 0,-1}},	//	SKS semi-automatic rifle with folding bayonet. Chambered in 10-round clips of 7.62x39mm. Fitted with 22mm rifle grenade
-			{"vn_m1891", 							{ 0,-1, 0,-1}},	//	M1891 5-shot, clip-fed, 7.62x54mmR rifle
-			{"vn_m1891_bayo", 						{ 0,-1, 0,-1}},	//	M1891 5-shot, clip-fed, 7.62x54mmR rifle
-			{"vn_m38", 								{ 0,-1, 0,-1}},	//	M38 5-shot, clip-fed, 7.62x54mmR rifle
-			{"vn_m38_bayo", 						{ 0,-1, 0,-1}},	//	M38 5-shot, clip-fed, 7.62x54mmR rifle
-			{"vn_m9130", 							{ 0,-1, 0,-1}},	//	M91/30 5-shot, clip-fed, 7.62x54mmR rifle
-			{"vn_m9130_sniper", 					{ 0,-1, 0,-1}},	//	M91/30 5-shot, clip-fed, 7.62x54mmR rifle
-			{"vn_m9130_bayo", 						{ 0,-1, 0,-1}},	//	M91/30 5-shot, clip-fed, 7.62x54mmR rifle
-			{"vn_vz54", 							{ 0,-1,-1,-1}},	//	VZ54 7.62mm Rifle
-			{"vn_vz54_sniper", 						{ 0,-1,-1,-1}},	//	VZ54 7.62mm Rifle
-			{"vn_vz54_sniper_camo", 				{ 0,-1,-1,-1}},	//	VZ54 7.62mm Rifle
-			{"vn_svd", 								{ 0,-1,-1,-1}},	//	SVD 7.62x54mm semi-automatic marksman rifle
-			{"vn_svd_sniper", 						{ 0,-1,-1,-1}},	//	SVD 7.62x54mm semi-automatic marksman rifle
-			{"vn_svd_sniper_camo", 					{ 0,-1,-1,-1}},	//	SVD 7.62x54mm semi-automatic marksman rifle
-			{"vn_k98k", 							{ 0,-1, 0, 0}},	//	K98K 5-shot, clip-fed, 7.92x57mm rifle
-			{"vn_k98k_bayo", 						{ 0,-1, 0, 0}},	//	K98K 5-shot, clip-fed, 7.92x57mm rifle
-			{"vn_k98k_mrk", 						{ 0,-1, 0, 0}},	//	K98K 5-shot, clip-fed, 7.92x57mm rifle
-			{"vn_k98k_mrk_camo", 					{ 0,-1, 0, 0}},	//	K98K 5-shot, clip-fed, 7.92x57mm rifle
-			//Assault Rifles
-			//BluFor
-			{"vn_m16", 								{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle. 20-round mag
-			{"vn_m16_muzzle", 						{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle. 20-round mag
-			{"vn_m16_camo", 						{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG camo version
-			{"vn_m16_bayo", 						{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG camo version
-			{"vn_m16_sd", 							{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG camo version
-			{"vn_m16_mrk", 							{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG camo version
-			{"vn_m16_mrk_sd", 						{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG camo version
-			{"vn_m16_sniper", 						{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG camo version
-			{"vn_m16_sniper_sd", 					{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG camo version
-			{"vn_m16_nvg", 							{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG camo version
-			{"vn_m16_nvg_sd", 						{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG camo version
-			{"vn_m16_xm148", 						{-1, 0, 0,-1}},	//	M16A1 5.56mm Assault Rifle with XM148 single-shot 40mm grenade-launcher attached under the barrel, and camo tape
-			{"vn_m16_m203", 						{-1, 0, 4,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG version fitted with M203 40mm Grenade Launcher
-			{"vn_m16_m203_camo", 					{-1, 0, 6,-1}},	//	M16A1 5.56mm Assault Rifle, SF/SOG version fitted with M203 40mm Grenade Launcher and camo
-			{"vn_m16_usaf", 						{-1, 0, 0,-1}},	//	M16 5.56mm Assault Rifle. USAF version. 20-round mag
-			{"vn_m16_usaf_bayo", 					{-1, 0, 0,-1}},	//	M16 5.56mm Assault Rifle. USAF version. 20-round mag
-			{"vn_m16_usaf_mrk", 					{-1, 0, 0,-1}},	//	M16 5.56mm Assault Rifle. USAF version. 20-round mag
-			{"vn_m16_usaf_sniper", 					{-1, 0, 0,-1}},	//	M16 5.56mm Assault Rifle. USAF version. 20-round mag
-			{"vn_m16_usaf_nvg", 					{-1, 0, 0,-1}},	//	M16 5.56mm Assault Rifle. USAF version. 20-round mag
-			{"vn_gau5a", 							{-1, 0, 2,-1}},	//	GAU-5A/A 5.56mm USAF carbine
-			{"vn_gau5a_mrk", 						{-1, 0, 2,-1}},	//	GAU-5A/A 5.56mm USAF carbine
-			{"vn_m63a", 							{-1, 0, 0,-1}},	//	M63A 5.56mm Automatic Rifle. 30-round mag
-			{"vn_xm16e1", 							{-1, 0, 0,-1}},	//	XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
-			{"vn_xm16e1_bayo", 						{-1, 0, 0,-1}},	//	XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
-			{"vn_xm16e1_mrk", 						{-1, 0, 0,-1}},	//	XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
-			{"vn_xm16e1_sniper", 					{-1, 0, 0,-1}},	//	XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
-			{"vn_xm16e1_xm148", 					{-1, 0, 5,-1}},	//	XM16E1 5.56mm Assault Rifle, fitted with XM148 40mm grenade launcher
-			{"vn_xm16e1_nvg", 						{-1, 0, 0,-1}},	//	XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
-			{"vn_xm177_stock", 						{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG version fitted with an M16 stock
-			{"vn_xm177_stock_camo", 				{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG version fitted with an M16 stock and camo paint
-			{"vn_xm177_short", 						{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, short SF/SOG version with 10 inch barrel
-			{"vn_xm177", 							{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG light version
-			{"vn_xm177_muzzle", 					{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG light version
-			{"vn_xm177_mrk", 						{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG light version
-			{"vn_xm177_sniper", 					{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG light version
-			{"vn_xm177_nvg", 						{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG light version
-			{"vn_xm177_camo", 						{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG version with camo tape
-			{"vn_xm177_fg", 						{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG version fitted with a fore-grip
-			{"vn_xm177_xm148", 						{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG version fitted with XM148 40mm grenade launcher
-			{"vn_xm177_xm148_camo", 				{-1, 0, 0,-1}},	//	XM177E2 5.56mm carbine, SF/SOG version fitted with XM148 40mm grenade launcher and camo paint
-			{"vn_xm177e1", 							{-1, 0, 1,-1}},	//	XM177E1 5.56mm carbine, early SF/SOG light version
-			{"vn_xm177e1_mrk", 						{-1, 0, 1,-1}},	//	XM177E1 5.56mm carbine, early SF/SOG light version
-			{"vn_xm177e1_sniper", 					{-1, 0, 1,-1}},	//	XM177E1 5.56mm carbine, early SF/SOG light version
-			{"vn_xm177e1_nvg", 						{-1, 0, 1,-1}},	//	XM177E1 5.56mm carbine, early SF/SOG light version
-			{"vn_xm177e1_camo", 					{-1, 0, 2,-1}},	//	XM177E1 5.56mm carbine, early SF/SOG light version with camo tape
-			{"vn_xm177_m203", 						{-1, 0, 5,-1}},	//	XM177E2 5.56mm Assault Rifle, SF/SOG version fitted with M203 40mm Grenade Launcher
-			{"vn_xm177_m203_camo", 					{-1, 0, 6,-1}},	//	XM177E2 5.56mm Assault Rifle, SF/SOG camo version fitted with M203 40mm Grenade Launcher
-			//OpFor
-			{"vn_type56", 							{ 0,-1, 0,-1}},	//	Type 56 7.62mm Assault Rifle. Chinese copy of AK-47 with folding cruciform bayonet
-			{"vn_kbkg", 							{ 0,-1,-1, 4}},	//	KBKG 7.62x39mm Assault Rifle
-			{"vn_kbkg_gl", 							{ 0,-1,-1, 6}},	//	KBKG 7.62x39mm, lightweight, easy-to-use selective-fire rifle, fitted with a 22mm rifle grenade
-			{"vn_ak_01", 							{ 0,-1, 4, 2}},	//	AK 7.62x39mm Assault Rifle
-			//Carbine
-			//BluFor
-			{"vn_m2carbine", 						{-1, 0, 0,-1}},	//	M2 Carbine, 7.62x33mm, lightweight, easy-to-use selective-fire rifle
-			{"vn_m2carbine_bayo", 					{-1, 0, 0,-1}},	//	M2 Carbine, 7.62x33mm, lightweight, easy-to-use selective-fire rifle
-			{"vn_m2carbine_sniper", 				{-1, 0, 0,-1}},	//	M2 Carbine, 7.62x33mm, lightweight, easy-to-use selective-fire rifle
-			{"vn_m2carbine_gl", 					{-1, 0, 0,-1}},	//	M2 Carbine, 7.62x33mm, lightweight, easy-to-use selective-fire rifle, fitted with an M8 22mm rifle grenade
-			{"vn_m3carbine", 						{-1, 0, 0,-1}},	//	M3 carbine 7.62x33mm rifle, fitted with a heavy infra-red night-vision scope
-			{"vn_m1carbine_shorty", 				{-1, 0, 6,-1}},	//	M1 Carbine cut short with added scope and rechambered in 9x19mm to take HP magazines, for use by SOG recon
-			{"vn_m1carbine", 						{ 0, 0, 0,-1}},	//	M1 Carbine, 7.62x33mm, lightweight, easy-to-use semi-automatic rifle
-			{"vn_m1carbine_bayo", 					{ 0, 0, 0,-1}},	//	M1 Carbine, 7.62x33mm, lightweight, easy-to-use semi-automatic rifle
-			{"vn_m1carbine_sniper", 				{ 0, 0, 0,-1}},	//	M1 Carbine, 7.62x33mm, lightweight, easy-to-use semi-automatic rifle
-			{"vn_m1carbine_gl", 					{ 0, 0, 0,-1}},	//	M1 Carbine, 7.62x33mm, lightweight, easy-to-use semi-automatic rifle, fitted with an M8 22mm rifle grenade
-			{"vn_m4956", 							{ 0, 0, 0,-1}},	//	M49/56 French semi-automatic 7.5x54mm rifle
-			{"vn_m4956_sniper", 					{ 0, 0, 0,-1}},	//	M49/56 French semi-automatic 7.5x54mm rifle
-			{"vn_m4956_bayo", 						{ 0, 0, 0,-1}},	//	M49/56 French semi-automatic 7.5x54mm rifle
-			{"vn_m4956_gl", 						{ 0, 0, 0,-1}},	//	M49/56 French semi-automatic 7.5x54mm rifle fitted with a 22mm rifle grenade
-			//Machine Guns
-			//BluFor
-			{"vn_m60_shorty", 						{-1, 0, 0,-1}},	//	M60 7.62mm Light Machine Gun with 100-round box and short barrel
-			{"vn_m60_shorty_camo",					{-1, 0, 0,-1}},	//	M60 7.62mm Light Machine Gun with 100-round box, short barrel and camo spray
-			{"vn_m60",								{-1, 0, 0,-1}},	//	M60 7.62mm Light Machine Gun with 100-round box and bipod
-			{"vn_m63a_cdo",							{-1, 0, 0,-1}},	//	M63A 5.56mm Commando. 150-round drum
-			{"vn_m63a_cdo_bipod",					{-1, 0, 0,-1}},	//	M63A 5.56mm Commando. 150-round drum
-			{"vn_m63a_lmg",							{-1, 0, 0,-1}},	//	M63A 5.56mm LMG. 100-round box
-			{"vn_m63a_lmg_bipod",					{-1, 0, 0,-1}},	//	M63A 5.56mm LMG. 100-round box
-			{"vn_m1918",							{-1, 0, 2,-1}},	//	M1918A2 7.62x63mm Light Machine Gun fed by 20 round magazines
-			{"vn_m1918_bipod",						{-1, 0, 2,-1}},	//	M1918A2 7.62x63mm Light Machine Gun fed by 20 round magazines
-			{"vn_l2a1_01",							{-1, 0, 3,-1}},	//	L2A1 7.62mm LMG, fitted with a bipod
-			{"vn_l4",								{-1, 0,-1,-1}},	//	L4 7.62x51mm selective-fire LMG
-			//OpFor
-			{"vn_rpd_shorty",						{ 0,-1, 0,-1}},	//	RPD 7.62mm LMG, with sawn-off barrel, sight, and bipod, carried by El Cid of MACV SOG
-			{"vn_rpd_shorty_01",					{ 0,-1, 0,-1}},	//	RPD 7.62mm LMG, with sawn-off barrel and bipod
-			{"vn_rpd",								{ 0,-1, 0,-1}},	//	RPD 7.62x39mm Light Machine Gun fed by drums containing 100-round belts
-			{"vn_dp28",								{ 0,-1, 0,-1}},	//	DP-27 7.62mm Light Machine Gun with 47 round mag and bipod
-			{"vn_pk",								{ 0,-1, 0,-1}},	//	PK 7.62mm Light Machine Gun with 100-round box and bipod
-			{"vn_mg42",								{ 0,-1,-1, 4}},	//	MG42 7.92x57mm Light Machine Gun fed by 50-round drums or boxes containing 250-round belts
-			//Submachine Guns
-			//BluFor
-			{"vn_m3a1",								{-1, 0, 0,-1}},	//	M3A1 Grease Gun
-			{"vn_m3sd",								{-1, 0, 0,-1}},	//	M3A1 Grease Gun
-			{"vn_m45",								{-1, 0, 0,-1}},	//	M/45 9mm Submachinegun. Swedish SMG with folding stock
-			{"vn_m45_sd",							{-1, 0, 0,-1}},	//	M/45 9mm Submachinegun. Swedish SMG with folding stock
-			{"vn_m45_camo",							{-1, 0, 0,-1}},	//	M/45 9mm Submachinegun. Swedish SMG with camo paint and folding stock
-			{"vn_m45_fold",							{-1, 0, 0,-1}},	//	M/45 9mm Submachinegun. Swedish SMG with folded stock
-			{"vn_mat49",							{-1, 0, 0,-1}},	//	MAT-49
-			{"vn_mat49_sd",							{-1, 0, 0,-1}},	//	MAT-49
-			{"vn_mc10",								{-1, 0, 0,-1}},	//	The MC-10 is a compact, blowback operated machine pistol developed in 1964 chambered in 9mm (or .45ACP)
-			{"vn_mc10_sd",							{-1, 0, 0,-1}},	//	The MC-10 is a compact, blowback operated machine pistol developed in 1964 chambered in 9mm (or .45ACP)
-			{"vn_sten",								{-1, 0, 0, 0}},	//	Sten Mk.II
-			{"vn_sten_sd",							{-1, 0, 0, 0}},	//	Sten Mk.II
-			{"vn_m1928_tommy",						{-1, 0, 0,-1}},	//	The M1928 Tommy Gun is a blowback operated, selective fire U.S. submachinegun chambered in .45 ACP, capable of using a 50 round drum
-			{"vn_m1928a1_tommy",					{-1, 0, 0,-1}},	//	The M1928A1 Tommy Gun is a blowback operated, selective fire U.S. submachinegun chambered in .45 ACP, capable of using a 50 round drum
-			{"vn_m1a1_tommy",						{-1, 0, 0,-1}},	//	The M1A1 Tommy Gun is a blowback operated, selective fire U.S. submachinegun chambered in .45 ACP
-			{"vn_m1a1_tommy_so",					{-1, 0, 0,-1}},	//	The M1A1 Tommy Gun (shorty) is a blowback operated, selective fire U.S. submachinegun chambered in .45 ACP with the butt removed
-			{"vn_mpu",								{-1, 0, 0,-1}},	//	The MPU is a compact, open bolt, blowback operated submachinegun developed in 1954 chambered in 9mm
-			{"vn_mpu_sd",							{-1, 0, 0,-1}},	//	The MPU is a compact, open bolt, blowback operated submachinegun developed in 1954 chambered in 9mm
-			{"vn_f1_smg",							{-1, 0, 2,-1}},	//	F1 9mm SMG
-			{"vn_f1_smg_bayo",						{-1, 0, 2,-1}},	//	F1 9mm SMG
-			{"vn_l2a3",								{-1, 0, 2,-1}},	//	L2A3 9mm Submachinegun.
-			{"vn_l2a3_f",							{-1, 0, 3,-1}},	//	L2A3 9mm Submachinegun. SMG with folded stock
-			{"vn_l34a1",							{-1, 0, 4,-1}},	//	L34A1 9mm Submachinegun with folding stock and integral suppressor.
-			{"vn_l34a1_f",							{-1, 0, 5,-1}},	//	L34A1 9mm Submachinegun with folded stock and integral suppressor.
-			{"vn_l34a1_xm148",						{-1, 0, 6,-1}},	//	L34A1 9mm Submachinegun with folding stock and integral suppressor, with XM148 single-shot 40mm grenade-launcher attached under the barrel.
-			//OpFor
-			{"vn_k50m",								{ 0,-1, 0,-1}},	//	Vietnamese K-50M 7.62mm submachinegun with 35 or 71-round magazine
-			{"vn_mat49_f",							{ 0,-1, 0,-1}},	//	MAT-49 SMG with folded stock
-			{"vn_mat49_vc",							{ 0,-1, 0,-1}},	//	MAT-49 SMG, Viet Cong conversion
-			{"vn_mp40",								{ 0,-1, 0,-1}},	//	The MP40 is a submachinegun chambered for 9—19mm Parabellum cartridge
-			{"vn_pps43",							{ 0,-1, 0,-1}},	//	Polish PPS-43 7.62mm automatic submachinegun with 35-round magazine
-			{"vn_pps52",							{ 0,-1, 0,-1}},	//	Polish PPS-52 7.62mm automatic submachinegun with 35-round magazine
-			{"vn_ppsh41",							{ 0,-1, 0,-1}},	//	Soviet PPSh-41 7.62mm submachinegun with 35 or 71-round magazine
-			{"vn_vz61",								{ 0,-1, 0,-1}},	//	The VZ.61 Skorpion is a select-fire blowback operated Czech machine pistol chambered in .32 ACP
-			{"vn_type64_smg",						{ 0,-1,-1,-1}},	//	Type 64 7.65mm Submachinegun. Chinese SMG with folding stock and integral suppressor.
-			{"vn_type64_f_smg",						{ 0,-1,-1,-1}},	//	Type 64 7.65mm Submachinegun. Chinese SMG with folded stock and integral suppressor.
-			//Shotguns
-			//BluFor
-			{"vn_m1897",							{-1, 0, 0,-1}},	//	Model 1897 12 gauge Trench gun, 6-round mag, capable of slam-firing
-			{"vn_m1897_bayo",						{-1, 0, 0,-1}},	//	Model 1897 12 gauge Trench gun, 6-round mag, capable of slam-firing
-			//OpFor
-			{"vn_izh54",							{ 0,-1, 0,-1}},	//	ISh-54 double-barrelled Shotgun
-			{"vn_izh54_shorty",						{ 0,-1, 0,-1}},	//	ISh-54 double-barrelled Shotgun (Sawn-off)
-			//Sidearm
-			//BluFor
-			{"vn_welrod",							{-1, 0, 0,-1}},	//	Welrod single-shot, suppressed pistol, caliber 7.65x17mm, 8-round mag
-			{"vn_vz61_p",							{-1, 0, 0,-1}},	//	The VZ.61 Skorpion is a select-fire blowback operated Czech machine pistol chambered in .32 ACP, and worn as a sidearm
-			{"vn_fkb1_pm",							{ 0, 0, 0,-1}},	//	PM semi-automatic pistol, 9mm caliber, 8-round mag with FKB-1 Flashlight
-			{"vn_fkb1_pm_sd",						{ 0, 0, 0,-1}},	//	PM semi-automatic pistol, 9mm caliber, 8-round mag with FKB-1 Flashlight
-			{"vn_mx991_m1911",						{ 0, 0, 0,-1}},	//	M1911 .45 caliber semi-automatic pistol, 7-round magazine, with angle-head MX-991 Flashlight
-			{"vn_mx991_m1911_sd",					{ 0, 0, 0,-1}},	//	M1911 .45 caliber semi-automatic pistol, 7-round magazine, with angle-head MX-991 Flashlight
-			{"vn_pm",								{ 0, 0, 0,-1}},	//	PM semi-automatic pistol, 9mm caliber, 8-round mag
-			{"vn_pm_sd",							{ 0, 0, 0,-1}},	//	PM semi-automatic pistol, 9mm caliber, 8-round mag
-			{"vn_tt33",								{ 0, 0, 0,-1}},	//	TT-33 semi-automatic pistol, chambered in 7.62x25mm. 8-round magazine
-			{"vn_hd",								{ 0, 0, 0,-1}},	//	HD suppressed pistol, .22LR caliber, 10-round mag
-			{"vn_hp",								{ 0, 0, 0,-1}},	//	HP 9mm semi-automatic pistol, 13 round mag
-			{"vn_hp_sd",							{ 0, 0, 0,-1}},	//	HP 9mm semi-automatic pistol, 13 round mag
-			{"vn_m1911",							{ 0, 0, 0,-1}},	//	M1911 .45 caliber semi-automatic pistol, 7-round magazine
-			{"vn_m1911_sd",							{ 0, 0, 0,-1}},	//	M1911 .45 caliber semi-automatic pistol, 7-round magazine
-			{"vn_mk22",								{ 0, 0, 0,-1}},	//	Mk22 Mod 0
-			{"vn_mk22_sd",							{ 0, 0, 0,-1}},	//	Mk22 Mod 0
-			{"vn_m10",								{ 0, 0, 0,-1}},	//	Model 10 .38 revolver, 6-round reload
-			{"vn_m10_sd",							{ 0, 0, 0,-1}},	//	Model 10 .38 revolver, 6-round reload
-			{"vn_m1895",							{ 0, 0, 0,-1}},	//	M1895 seven-shot, gas-seal revolver chambered for 7.62x38mmR. The unique gas seal enables use with a suppressor
-			{"vn_m1895_sd",							{ 0, 0, 0,-1}},	//	M1895 seven-shot, gas-seal revolver chambered for 7.62x38mmR. The unique gas seal enables use with a suppressor
-			{"vn_p38s",								{ 0, 0, 0,-1}},	//	.38 Revolver revolver, 6-round reload
-			{"vn_ppk",								{ 0, 0, 2, 0}},	//	PPK 9mm semi-automatic pistol
-			{"vn_ppk_sd",							{ 0, 0, 2, 0}},	//	PPK 9mm semi-automatic pistol
-			{"vn_p38",								{ 0, 0, 1, 1}},	//	P38 9mm semi-automatic pistol
-			{"vn_p38_sd",							{ 0, 0, 1, 1}},	//	P38 9mm semi-automatic pistol
-			{"vn_mk1_udg",							{-1, 0, 0,-1}},	//	The Mk1 Underwater Defence Gun (UDG) is a compact, double action only pepper-box weapon developed in the 1960s with a removable cylinder of six 4.25in darts
-			//OpFor
-			{"vn_m712",								{ 0,-1, 0,-1}},	//	M712 selective-fire pistol, chambered in 7.62x25mm. 20-round magazine
-			{"vn_izh54_p",							{ 0,-1, 0,-1}},	//	ISh-54 double-barrelled Shotgun (Sidearm)
-			{"vn_type64",							{ 0,-1,-1, 6}},	//	Suppressed Type 64 7.65x17mm semi-automatic pistol
-			//Launchers
-			//BluFor
-			{"vn_m72",								{-1, 0, 0,-1}},	//	M72 LAW single-use HEAT rocket
-			{"vn_m79",								{ 0, 0, 0,-1}},	//	M79 Grenade Launcher. Fires 40mm HE grenades, smoke and flares
-			{"vn_m79_p",							{-1, 0, 0,-1}},	//	M79 Grenade Launcher. Sawn-off for close quarters by SOG as a sidearm. Fires 40mm HE grenades, smoke and flares
-			{"vn_m20a1b1_01",						{-1, 0, 3,-1}},	//
-			{"vn_rocket_m128_launcher",				{-1, 0, 0,-1}},	//	Flare Launcher
-			//OpFor
-			{"vn_rpg2",								{ 0,-1, 0,-1}},	//	B40 HEAT rocket
-			{"vn_rpg7",								{ 0,-1, 0,-1}},	//	B41 HEAT rocket
-			{"vn_sa7",								{ 0,-1, 0,-1}},	//	9K32 Strela-2 Anti-Aircraft Missile
-			{"vn_sa7b",								{ 0,-1, 0,-1}},	//	9K32 Strela-2M Anti-Aircraft Missile
-			//Other
-			//BluFor
-			{"vn_mx991",							{ 0, 0, 0,-1}},	//	US Angle-head MX-991 Flashlight, powered by BA-30 1.5v batteries
-			{"vn_mx991_red",						{ 0, 0, 0,-1}},	//	Angle-head MX-991 Flashlight with red lens, powered by BA-30 1.5v batteries
-			{"vn_m127",								{ 0, 0, 0,-1}},	//	M127 single-use flare, white
-			{"vn_camera_01",						{ 0, 0, 1,-1}},	//	SOG 35mm camera carried on clandestine missions by MACV SOG
-			{"vn_fkb1",								{ 0, 0, 0,-1}},	//	Soviet FKB-1 Flashlight, powered by 2xR20 batteries
-			{"vn_fkb1_red",							{ 0, 0, 0,-1}},	//	Soviet FKB-1 Flashlight with red lens, powered by 2xR20 batteries
-			//Melee Weapons:
-			//Blufor
-			{"vn_m_axe_01",							{ 0, 0, 0,-1}},	//
-			{"vn_m_axe_fire",						{ 0, 0, 0,-1}},	//
-			{"vn_m_bayo_carbine",					{ 0, 0, 0,-1}},	//
-			{"vn_m_bayo_m14",						{-1, 0, 0,-1}},	//
-			{"vn_m_bayo_m16",						{-1, 0, 0,-1}},	//
-			{"vn_m_bayo_m1897",						{ 0, 0, 0,-1}},	//
-			{"vn_m_bayo_m4956",						{ 0, 0, 0,-1}},	//
-			{"vn_m_bolo_01",						{ 0, 0, 0,-1}},	//
-			{"vn_m_fighting_knife_01",				{ 0, 0, 0,-1}},	//
-			{"vn_m_hammer",							{ 0, 0, 0,-1}},	//
-			{"vn_m_m51_etool_01",					{-1, 0, 0,-1}},	//
-			{"vn_m_machete_01",						{ 0, 0, 0,-1}},	//
-			{"vn_m_machete_02",						{ 0, 0, 0,-1}},	//
-			{"vn_m_mk2_knife_01",					{-1, 0, 0,-1}},	//
-			{"vn_m_shovel_01",						{ 0, 0, 0,-1}},	//
-			{"vn_m_typeivaxe_01",					{ 0, 0, 0,-1}},	//
-			{"vn_m_wrench_01",						{ 0, 0, 0,-1}},	//
-			{"vn_b_melee_m43_etool_01",				{-1, 0, 0,-1}},	//
-			{"vn_b_melee_m1903",					{ 0, 0, 0, 0}},	//
-			{"vn_b_melee_m36",						{ 0, 0, 0, 0}},	//
-			//OpFor
-			{"vn_b_melee_k98k",						{ 0,-1,-1, 0}},	//
-			{"vn_m_vc_knife_01",					{ 0,-1, 0,-1}},	//
-			//Nickel Steel
-		  /*{"vnx_m77e",							{ 0, 0, 0, 0}},	//
-			{"vnx_m77e_shorty",						{ 0, 0, 0, 0}},	//
-			{"vnx_fm2429",							{ 0, 0, 0, 0}},	//
-			{"vnx_fm2429_aa",						{ 0, 0, 0, 0}},	//
-			{"vnx_gjet",							{ 0, 0, 0, 0}},	//
-			{"vnx_hd_02",							{ 0, 0, 0, 0}},	//
-			{"vnx_l1a1_04",							{ 0, 0, 0, 0}},	//
-			{"vnx_l1a1_04_camo",					{ 0, 0, 0, 0}},	//
-			{"vnx_l1a1_05",							{ 0, 0, 0, 0}},	//
-			{"vnx_l1a1_05_camo",					{ 0, 0, 0, 0}},	//
-			{"vnx_m12_smg",							{ 0, 0, 0, 0}},	//
-			{"vnx_m12_smg_fold",					{ 0, 0, 0, 0}},	//
-			{"vnx_m45_sf",							{ 0, 0, 0, 0}},	//
-			{"vnx_m45_sf_sd",						{ 0, 0, 0, 0}},	//
-			{"vnx_m50_smg",							{ 0, 0, 0, 0}},	//
-			{"vnx_m50_smg_fold",					{ 0, 0, 0, 0}},	//
-			{"vnx_type56_xm148",					{ 0, 0, 0, 0}},	//
-			{"vnx_m_ladle",							{ 0, 0, 0, 0}},	//
-			{"vnx_m_spoon_01",						{ 0, 0, 0, 0}},	//
-			{"vnx_m_spoon_02",						{ 0, 0, 0, 0}},	//
-			{"vnx_m77e_fl_mag",						{ 0, 0, 0, 0}},	//
-			{"vnx_m77e_buck_mag",					{ 0, 0, 0, 0}},	//
-			{"vnx_m77e_so_mag",						{ 0, 0, 0, 0}},	//
-			{"vnx_fm2429_mag",						{ 0, 0, 0, 0}},	//
-			{"vnx_fm2429_t_mag",					{ 0, 0, 0, 0}},	//
-			{"vnx_gjet_mag",						{ 0, 0, 0, 0}},	//
-			{"vnx_hd_02_mag",						{ 0, 0, 0, 0}},	//
-			{"vnx_m12_smg_32_mag",					{ 0, 0, 0, 0}},	//
-			{"vnx_m12_smg_32_t_mag",				{ 0, 0, 0, 0}},	//
-			{"vnx_m12_smg_20_mag",					{ 0, 0, 0, 0}},	//
-			{"vnx_m12_smg_20_t_mag",				{ 0, 0, 0, 0}},	//
-			{"vnx_m50_smg_mag",						{ 0, 0, 0, 0}},	//
-			{"vnx_m50_smg_t_mag",					{ 0, 0, 0, 0}},	//
-			*/
-			//Binoculars
-			//BluFor
-			{"vn_m19_binocs_grey",					{ 0, 0, 0, 0}},	//	Binocular M19 Grey (7x50)
-			{"vn_m19_binocs_grn",					{ 0, 0, 0, 0}},	//	Binocular M19 Green (7x50)
-			{"vn_mk21_binocs",						{ 0, 0, 0, 0}},	//	Binocular Mk21 (7x50)
-			{"vn_anpvs2_binoc",						{-1, 0, 0, 0}},	//	Starlight ANPVS2 (NV)
-			//Blufor
-			//Bayonet/Camo
-			{"vn_b_camo_m14",						{-1, 0, 0,-1}},	//	Camo wrap [M14]
-			{"vn_b_camo_m14a1",						{-1, 0, 0,-1}},	//	Camo wrap [M14A1]
-			{"vn_b_camo_m40a1",						{-1, 0, 0,-1}},	//	Camo wrap [M40]
-			{"vn_b_carbine",						{ 0, 0, 0,-1}},	//	Bayonet M4 [M1/ M2]
-			{"vn_b_m14",							{-1, 0, 0,-1}},	//	Bayonet M6 [M14]
-			{"vn_b_m16",							{-1, 0, 0,-1}},	//	Bayonet M7 [M16]
-			{"vn_b_m1897",							{-1, 0, 0,-1}},	//	Bayonet M1917 [M1897]
-			{"vn_b_m1_garand",						{-1, 0, 1,-1}},	//	Bayonet M5 [M1 Garand]
-			{"vn_b_camo_m1_garand",					{-1, 0, 2,-1}},	//	Camo wrap [M1 Garand]
-			{"vn_bipod_m1918",						{-1, 0, 4,-1}},	//	Bipod [M1918]
-			{"vn_bipod_m16",						{-1, 0, 1,-1}},	//	Bipod [M16]
-			{"vn_bipod_m14",						{-1, 0, 1,-1}},	//	Bipod [M14]
-			{"vn_b_l1a1",							{-1, 0, 1,-1}},	//	Bayonet L1A1 [L1A1/ F1]
-			{"vn_b_m1903",							{ 0, 0, 1, 1}},	//	Bayonet [M1903]
-			{"vn_b_m36",							{ 0, 0, 1, 1}},	//	Bayonet Spike [M36]
-			{"vn_b_camo_m1903",						{ 0, 0, 2, 2}},	//	Camo wrap [M1903]
-			{"vn_b_camo_m36",						{ 0, 0, 2, 2}},	//	Camo wrap [M36]
-			{"vn_bipod_m63a",						{-1, 0, 3,-1}},	//	Bipod [M63A]
- 			{"vn_b_m4956",							{ 0, 0, 0,-1}},	//	Bayonet Model 58 [M49/56]
-			//Suppressor
-			{"vn_s_m14",							{-1, 0, 0,-1}},	//	Suppressor [M14/M40]
-			{"vn_s_m16",							{-1, 0, 0,-1}},	//	Suppressor [M16]
-			{"vn_s_m1895",							{ 0, 0, 0,-1}},	//	Suppressor [M1895]
-			{"vn_s_m1911",							{-1, 0, 0,-1}},	//	Suppressor [M1911]
-			{"vn_s_m3a1",							{-1, 0, 0,-1}},	//	Suppressor [M3]
-			{"vn_s_m45",							{-1, 0, 0,-1}},	//	Suppressor [M/45]
-			{"vn_s_m45_camo",						{-1, 0, 0,-1}},	//	Suppressor [M/45 Camo]
-			{"vn_s_mat49",							{-1, 0, 0,-1}},	//	Suppressor [MAT-49]
-			{"vn_s_mc10",							{-1, 0, 0,-1}},	//	Suppressor [MC-10]
-			{"vn_s_mk22",							{-1, 0, 0,-1}},	//	Suppressor [Mk22]
-			{"vn_s_pm",								{ 0, 0, 0,-1}},	//	Suppressor [PM]
-			{"vn_s_sten",							{-1, 0, 0,-1}},	//	Suppressor [Sten Mk.II]
-			{"vn_s_ppk",							{ 0, 0, 2, 2}},	//	Suppressor 9mm [PPK/ P38]
-			{"vn_s_hp",								{-1, 0, 3,-1}},	//	Suppressor 9mm [HP]
-			{"vn_s_mpu",							{-1, 0, 0,-1}},	//	Suppressor [MPU]
-			//Optics
-			{"vn_o_4x_m16",							{-1, 0, 0,-1}},	//	Optic (M16 4x)
-			{"vn_o_9x_m14",							{-1, 0, 0,-1}},	//	Optic (M14 3-9x)
-			{"vn_o_9x_m16",							{-1, 0, 0,-1}},	//	Optic (M16 3-9x)
-			{"vn_o_9x_m40a1",						{-1, 0, 0,-1}},	//	Optic (M40 3-9x)
-			{"vn_o_9x_m40a1_camo",					{-1, 0, 0,-1}},	//	Optic (M40 3-9x camo)
-			{"vn_o_anpvs2_m14",						{-1, 0, 0,-1}},	//	Scope (AN-PVS2 Starlight) [M14]
-			{"vn_o_anpvs2_m16",						{-1, 0, 0,-1}},	//	Scope (AN-PVS2 Starlight) [XM177/M16]
-			{"vn_o_anpvs2_m40a1",					{-1, 0, 0,-1}},	//	Scope (AN-PVS2 Starlight) [M40]
-			{"vn_o_3x_m84",							{ 0, 0, 0,-1}},	//	Scope (M1/2 Carbine 2.2x)
-			{"vn_o_1x_sp_m16",						{-1, 0, 6,-1}},	//	Optic (M16 SP)
-			{"vn_o_3x_l1a1",						{-1, 0, 2,-1}},	//	Optic (L1A1 3x)
-			{"vn_o_8x_m1903",						{ 0, 0, 1, 1}},	//	Optic [M1903 8x]
-			{"vn_o_m14_front",						{-1, 0, 4,-1}},	//	Optic (M14 Front Sight)
-			{"vn_o_4x_m4956",						{ 0, 0, 0,-1}},	//	Scope (M49/56 3.5x)
-			//OpFor
-			//Bayonet/Camo
-			{"vn_b_sks",							{ 0,-1, 0,-1}},	//	Bayonet Spike [M38]
-			{"vn_b_type56",							{ 0,-1, 0,-1}},	//	Bayonet Spike [Type56]
- 			{"vn_b_camo_vz54",						{ 0,-1,-1,-1}},	//	Camo wrap [VZ54]
-			{"vn_b_camo_svd",						{ 0,-1,-1,-1}},	//	Camo wrap [SVD]
-			{"vn_b_camo_k98k",						{ 0,-1, 2, 2}},	//	Camo wrap [K98K]
-			{"vn_b_k98k",							{ 0,-1, 1, 1}},	//	Bayonet [K98K]
-			{"vn_b_m38",							{ 0,-1, 0,-1}},	//	Bayonet Spike [M38/ M91/30/ M1892]
-			{"vn_b_camo_m9130",						{ 0,-1, 0,-1}},	//	Camo wrap [M9130]
-			//Optic
-			{"vn_o_3x_m9130",						{ 0,-1, 0,-1}},	//	Optic (M91/30 3.5x)
-			{"vn_o_3x_sks",							{ 0,-1, 0,-1}},	//	Optic (SKS 3.5x)
-			{"vn_o_3x_vz54",						{ 0,-1,-1,-1}},	//	Optic (VZ54 2.5x)
-			{"vn_o_4x_svd",							{ 0,-1,-1,-1}},	//	Optic [SVD 4x]
-			{"vn_o_1_5x_k98k",						{ 0,-1, 1, 1}},	//	Optic [K98K 1.5x]
-		};
-		magazines[] =
-		{
-			//Rifle Grenades
-			{"vn_22mm_cs_mag",						{ 0, 0, 0,-1}},	//	22mm CS Riot gas rifle grenade used in SKS, M1 Carbine and M49/56
-			{"vn_22mm_he_mag",						{ 0, 0, 0,-1}},	//	22mm FRAG rifle grenade used in M49/56 rifle
-			{"vn_22mm_lume_mag",					{ 0, 0, 0,-1}},	//	22mm Illumination rifle grenade used in SKS, M1 Carbine and M49/56
-			{"vn_22mm_m17_frag_mag",				{ 0, 0, 0,-1}},	//	M17 22mm FRAG rifle grenade used in M1 Carbine
-			{"vn_22mm_m19_wp_mag",					{ 0, 0, 0,-1}},	//	M19 22mm White Phosphorus rifle grenade used in SKS, M1 Carbine and M49/56
-			{"vn_22mm_m1a2_frag_mag",				{ 0, 0, 0,-1}},	//	M1A2 22mm FRAG rifle grenade used in M1 Carbine
-			{"vn_22mm_m22_smoke_mag",				{ 0, 0, 0,-1}},	//	M22 22mm Smoke rifle grenade used in SKS, M1 Carbine and M49/56
-			{"vn_22mm_m60_frag_mag",				{ 0, 0, 0,-1}},	//	M60 22mm FRAG rifle grenade used in SKS rifle
-			{"vn_22mm_m60_heat_mag",				{ 0, 0, 0,-1}},	//	M60 22mm HEAT rifle grenade used in SKS rifle
-			{"vn_22mm_m9_heat_mag",					{ 0, 0, 0,-1}},	//	M9 22mm HEAT rifle grenade used in M1 Carbine and M49/56
-			{"vn_22mm_m61_frag_mag",				{-1, 0, 0,-1}},	//	M61 22mm FRAG rifle grenade used in L1A1
-			{"vn_22mm_n94_heat_mag",				{-1, 0, 0,-1}},	//	N94 22mm HEAT rifle grenade used in L1A1
-			//OpFor
-			{"vn_20mm_f1n60_frag_mag",				{ 0,-1, 0,-1}},	//	F1N60 20mm FRAG rifle grenade used in KBKG rifle
-			{"vn_20mm_kgn_frag_mag",				{ 0,-1, 0,-1}},	//	KGN 20mm FRAG rifle grenade used in KBKG rifle
-			{"vn_20mm_pgn60_heat_mag",				{ 0,-1, 0,-1}},	//	PGN60 20mm HEAT rifle grenade used in KBKG rifle
-			{"vn_20mm_dgn_wp_mag",					{ 0,-1, 0,-1}},	//	DGN 20mm White Phosphorus rifle grenade used in KBKG, M1 Carbine and M49/56
-			//40mm Ammo
-			{"vn_40mm_m381_he_mag",					{-1, 0, 0,-1}},	//	M381 40mm HE Grenade used in M79, XM148 and M203 Grenade Launchers. 3m arming distance
-			{"vn_40mm_m397_ab_mag",					{-1, 0, 0,-1}},	//	M397 40mm Airburst Grenade used in M79, XM148 and M203 Grenade Launchers
-			{"vn_40mm_m406_he_mag",					{-1, 0, 0,-1}},	//	M406 40mm HE Grenade used in M79, XM148 and M203 Grenade Launchers. 14m arming distance
-			{"vn_40mm_m433_hedp_mag",				{-1, 0, 0,-1}},	//	M433 40mm HEDP Grenade used in M79, XM148 and M203 Grenade Launchers. Range 15m, penetrates 2in RHA steel armour
-			{"vn_40mm_m576_buck_mag",				{-1, 0, 0,-1}},	//	M576 40mm Buckshot round used in M79, XM148 and M203 Grenade Launchers
-			{"vn_40mm_m583_flare_w_mag",			{-1, 0, 0,-1}},	//	M583 40mm Flare (White) used in M79, XM148 and M203 Grenade Launchers
-			{"vn_40mm_m651_cs_mag",					{-1, 0, 0,-1}},	//	M651 40mm CS Gas grenade used in M203, XM148 and M79 grenade launchers
-			{"vn_40mm_m661_flare_g_mag",			{-1, 0, 0,-1}},	//	M661 40mm Flare (Green) used in M79, XM148 and M203 Grenade Launchers
-			{"vn_40mm_m662_flare_r_mag",			{-1, 0, 0,-1}},	//	M662 40mm Flare (Red) used in M79, XM148 and M203 Grenade Launchers
-			{"vn_40mm_m680_smoke_w_mag",			{-1, 0, 0,-1}},	//	M680 40mm Smoke grenade (White) used in M203, XM148 and M79 grenade launchers
-			{"vn_40mm_m682_smoke_r_mag",			{-1, 0, 0,-1}},	//	M682 40mm Smoke grenade (Red) used in M203, XM148 and M79 grenade launchers
-			{"vn_40mm_m695_flare_y_mag",			{-1, 0, 0,-1}},	//	M695 40mm Flare (Yellow) used in M79, XM148 and M203 Grenade Launchers
-			{"vn_40mm_m715_smoke_g_mag",			{-1, 0, 0,-1}},	//	M715 40mm Smoke grenade (Green) used in M203, XM148 and M79 grenade launchers
-			{"vn_40mm_m716_smoke_y_mag",			{-1, 0, 0,-1}},	//	M716 40mm Smoke grenade (Yellow) used in M203, XM148 and M79 grenade launchers
-			{"vn_40mm_m717_smoke_p_mag",			{-1, 0, 0,-1}},	//	M717 40mm Smoke grenade (Purple) used in M203, XM148 and M79 grenade launchers
-			//Rifle Cartridge
-			//Clips
-			{"vn_m40a1_mag",						{-1, 0, 0,-1}},	//	5Rnd. M40 Reload. Caliber: 7.62x51mm. Used in M40 Rifle
-			{"vn_m40a1_t_mag",						{-1, 0, 0,-1}},	//	5Rnd. M40 Reload (Tracer). Caliber: 7.62x51mm. Used in M40 Rifle
-			{"vn_sks_mag",							{ 0, 0, 0,-1}},	//	10Rnd. SKS Clip. Caliber: 7.62x39mm. Used in SKS rifle
-			{"vn_sks_t_mag",						{ 0, 0, 0,-1}},	//	10Rnd. SKS Tracer Clip. Caliber: 7.62x39mm. Used in SKS rifle
-			{"vn_m1_garand_mag",					{-1, 0, 0,-1}},	//	8Rnd. M1 Garand Clip. Caliber: 7.62x63mm. Used in M1 Garand
-			{"vn_m1_garand_t_mag",					{-1, 0, 0,-1}},	//	8Rnd. M1 Garand Clip Caliber: 7.62x63mm. Used in M1 Garand(Tracer)
-			{"vn_m1903_mag",						{ 0, 0, 0,-1}},	//	5Rnd. M1903 Clip. Caliber: 7.62x65mm. Used in M1903 rifle
-			{"vn_m1903_t_mag",						{ 0, 0, 0,-1}},	//	5Rnd. M1903 Tracer Clip. Caliber: 7.62x65mm Used in M1903 rifle
-			{"vn_m36_mag",							{ 0, 0, 0,-1}},	//	5Rnd. M36 Clip. Caliber: 7.5x54mm. Used in M36 rifle
-			{"vn_m36_t_mag",						{ 0, 0, 0,-1}},	//	5Rnd. M36 Tracer Clip. Caliber: 7.5x54mm Used in M36 rifle
-			//OpFor
-			{"vn_m38_mag",							{ 0,-1, 0, 3}},	//	5Rnd. M38 Clip. Caliber: 7.62x54mmR. Used in M38, VZ54, M1891 and M91/30 rifles
-			{"vn_m38_t_mag",						{ 0,-1, 0, 3}},	//	5Rnd. M38 Tracer Clip. Caliber: 7.62x54mmR. Used in M38, VZ54, M1891 and M91/30 rifles
-			{"vn_k98k_mag",							{ 0,-1, 0,-1}},	//	5Rnd. K98K Clip. Caliber: 7.92x57mm. Used in K98K
-			{"vn_k98k_t_mag",						{ 0,-1, 0,-1}},	//	5Rnd. K98K Tracer Clip. Caliber: 7.92x57mm Used in K98K
-			//Mags
-			{"vn_m14_10_mag",						{-1, 0, 0,-1}},	//	10Rnd. M14 Magazine. Caliber: 7.62x51mm. Used in M14 and XM21 Rifles
-			{"vn_m14_10_t_mag",						{-1, 0, 0,-1}},	//	10Rnd. M14 Tracer Magazine. Caliber: 7.62x51mm. Used in M14 and XM21 Rifles
-			{"vn_m14_mag",							{-1, 0, 0,-1}},	//	20Rnd. M14 Magazine. Caliber: 7.62x51mm. Used in M14 and XM21 Rifles
-			{"vn_m14_t_mag",						{-1, 0, 0,-1}},	//	20Rnd. M14 Tracer Magazine. Caliber: 7.62x51mm. Used in M14 and XM21 Rifles
-			{"vn_m16_20_mag",						{-1, 0, 0,-1}},	//	20Rnd. M16 Magazine. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
-			{"vn_m16_20_t_mag",						{-1, 0, 0,-1}},	//	20Rnd. M16 Tracer Magazine. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
-			{"vn_m16_30_mag",						{-1, 0, 0,-1}},	//	30Rnd. M16 Magazine. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
-			{"vn_m16_30_t_mag",						{-1, 0, 0,-1}},	//	30Rnd. M16 Tracer Magazine. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
-			{"vn_m16_40_mag",						{-1, 0, 0,-1}},	//	Dual 20Rnd. M16 Magazines. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
-			{"vn_m16_40_t_mag",						{-1, 0, 0,-1}},	//	Dual 20Rnd. M16 Tracer Magazines. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed
-			{"vn_m4956_10_mag",						{ 0, 0, 0,-1}},	//	10Rnd. M49/56 Carbine Magazine. Caliber: 7.5x54mm. Used in M49/56
-			{"vn_m4956_10_t_mag",					{ 0, 0, 0,-1}},	//	10Rnd. M49/56 Carbine Magazine. Caliber: 7.5x54mm. Used in M49/56. (Tracer)
-			{"vn_hp_sd_mag",						{ 0, 0, 0,-1}},	//	13Rnd. HP magazine. Caliber: 9mm Used in M1 Carbine (Shorty)
-			{"vn_carbine_15_mag",					{ 0, 0, 0,-1}},	//	15Rnd. M1/M2 Carbine. Caliber: 7.62x33mm. Used in M1 and M2 Carbines
-			{"vn_carbine_30_mag",					{ 0, 0, 0,-1}},	//	30Rnd. M1/M2 Carbine Magazine. Caliber: 7.62x33mm. Used in M1 and M2 Carbines
-			{"vn_carbine_15_t_mag",					{ 0, 0, 0,-1}},	//	15Rnd. M1/M2 Carbine Tracer Magazine. Caliber: 7.62x33mm. Used in M1 and M2 Carbines
-			{"vn_carbine_30_t_mag",					{ 0, 0, 0,-1}},	//	30Rnd. M1/M2 Carbine Tracer Magazine. Caliber: 7.62x33mm. Used in M1 and M2 Carbines
-			{"vn_l1a1_10_mag",						{-1, 0, 0,-1}},	//	10Rnd. L1A1/L2A1/L4 Mag. Calibre: 5.56x45mm. Used in L1A1/L2A1/L4
-			{"vn_l1a1_10_t_mag",					{-1, 0, 0,-1}},	//	10Rnd. L1A1/L2A1/L4 Mag. Calibre: 5.56x45mm. Used in L1A1/L2A1/L4 (Tracer)
-			{"vn_l1a1_20_mag",						{-1, 0, 0,-1}},	//	20Rnd. L1A1/L2A1/L4 Mag. Calibre: 7.62x51mm. Used in L1A1/L2A1/L4
-			{"vn_l1a1_20_t_mag",					{-1, 0, 0,-1}},	//	20Rnd. L1A1/L2A1/L4 Mag (Tracer). Calibre: 7.62x51mm. Used in L1A1/L2A1/L4
-			{"vn_l1a1_30_mag",						{-1, 0, 0,-1}},	//	30Rnd. L2A1/L1A1/L4 Mag. Calibre: 7.62x51mm. Used in L2A1/L1A1/L4
-			{"vn_l1a1_30_t_mag",					{-1, 0, 0,-1}},	//	30Rnd. L2A1/L1A1/L4 Tracer Mag. Calibre: 7.62x51mm. Used in L2A1/L1A1/L4
-			{"vn_l1a1_30_02_mag",					{-1, 0, 0,-1}},	//	30Rnd. L2A1/L1A1/L4 Mag Straight. Calibre: 7.62x51mm. Used in L2A1/L1A1/L4
-			{"vn_l1a1_30_02_t_mag",					{-1, 0, 0,-1}},	//	30Rnd. L2A1/L1A1/L4 Straight Tracer Mag. Calibre: 7.62x51mm. Used in L2A1/L1A1/L4
-			{"vn_m1a1_20_mag",						{-1, 0, 0,-1}},	//	20Rnd. M1A1 magazine. Caliber: 11.43x23mm. Used in M1A1 and M1928 Tommy gun
-			{"vn_m1a1_20_t_mag",					{-1, 0, 0,-1}},	//	20Rnd. M1A1 magazine. Caliber: 11.43x23mm. Used in M1A1 and M1928 Tommy gun (Tracer)
-			{"vn_m1a1_30_mag",						{-1, 0, 0,-1}},	//	30Rnd. M1A1 magazine. Caliber: 11.43x23mm. Used in M1A1 and M1928 Tommy gun
-			{"vn_m1a1_30_t_mag",					{-1, 0, 0,-1}},	//	30Rnd. M1A1 magazine. Caliber: 11.43x23mm. Used in M1A1 and M1928 Tommy gun (Tracer)
-			//OpFor
-			{"vn_type56_mag",						{ 0,-1, 0,-1}},	//	30Rnd. Type 56/AK Magazine. Caliber: 7.62x39mm. Used in Type 56/AK, AK and KBKG assault rifle
-			{"vn_type56_t_mag",						{ 0,-1, 0,-1}},	//	30Rnd. Type 56/AK Tracer Magazine. Caliber: 7.62x39mm. Used in Type 56/AK, AK and KBKG assault rifle
-			{"vn_svd_mag",							{ 0,-1, 0,-1}},	//	10Rnd. SVD Mag. Caliber: 7.62x54mm. Used in SVD sniper rifle
-			{"vn_svd_t_mag",						{ 0,-1, 0,-1}},	//	10Rnd. SVD Tracer Magazine. Caliber: 7.62x54mm Used in SVD sniper rifle
-			{"vn_kbkg_mag",							{ 0,-1, 0,-1}},	//	10Rnd. KBKG Mag. Caliber: 7.62x39mm. Used in KBKG, Type 56 and AK rifles
-			{"vn_kbkg_t_mag",						{ 0,-1, 0,-1}},	//	10Rnd. KBKG Tracer Magazine. Caliber: 7.62x39mm Used in KBKG, Type 56 and AK rifles
-			//MG Belts/Mags
-			{"vn_m1918_mag",						{-1, 0, 0,-1}},	//	20Rnd. M1918 Magazine. Calibre: 7.62x63mm. Used in M1918 automatic rifle
-			{"vn_m1918_t_mag",						{-1, 0, 0,-1}},	//	20Rnd. M1918 Tracer Magazine. Calibre: 7.62x63mm. Used in M1918 automatic rifle
-			{"vn_m60_100_mag",						{-1, 0, 0,-1}},	//	100Rnd. M60 Belt. Caliber: 7.62x51mm. Used in M60/ Shorty Machine Guns
-			{"vn_m63a_30_mag",						{-1, 0, 0,-1}},	//	30Rnd. STANAG Magazine. Caliber: 5.56x45mm. Used in M63A assault rifle
-			{"vn_m63a_30_t_mag",					{-1, 0, 0,-1}},	//	30Rnd. STANAG Tracer Magazine. Caliber: 5.56x45mm. Used in M63A assault rifle
-			{"vn_m63a_150_mag",						{-1, 0, 0,-1}},	//	150Rnd. M63A Drum. Caliber: 5.56x45mm. Used in M63A Commando
-			{"vn_m63a_150_t_mag",					{-1, 0, 0,-1}},	//	150Rnd. M63A Drum. Caliber: 5.56x45mm. Used in M63A Commando (Tracer)
-			{"vn_m63a_100_mag",						{-1, 0, 0,-1}},	//	100Rnd. M63A Box. Caliber: 5.56x45mm. Used in M63A LMG
-			{"vn_m63a_100_t_mag",					{-1, 0, 0,-1}},	//	100Rnd. M63A Box. Caliber: 5.56x45mm. Used in M63A LMG (Tracer)
-			//OpFor
-			{"vn_rpd_100_mag",						{ 0,-1, 0,-1}},	//	100Rnd. RPD Belt. Caliber: 7.62x39mm. Used in RPD Light machine gun
-			{"vn_rpd_125_mag",						{ 0,-1, 0,-1}},	//	125Rnd. RPD Belt. Caliber: 7.62x39mm. 1:1 tracer, used by US Special Forces in captured RPD machine guns
-			{"vn_pk_100_mag",						{ 0,-1, 0,-1}},	//	100Rnd. PK Belt. Caliber: 7.62x54mmR. Used in PK machine gun
-			{"vn_dp28_mag",							{ 0,-1, 0,-1}},	//	47Rnd. DP-27 Mag. Caliber: 7.62x54mmR. Used in DP-27 machine gun
-			{"vn_mg42_50_mag",						{ 0,-1, 0,-1}},	//	50Rnd. MG42 Drum. Calibre: 7.92x57mm. Used in MG42 machine gun
-			{"vn_mg42_50_t_mag",					{ 0,-1, 0,-1}},	//	50Rnd. MG42 Tracer Drum. Calibre: 7.92x57mm. Used in MG42 machine gun
-			//Pistol Mags
-			{"vn_hd_mag",							{ 0, 0, 0,-1}},	//	10Rnd. HD magazine. Caliber .22 LR. Used in HD pistol
-			{"vn_hp_mag",							{ 0, 0, 0,-1}},	//	13Rnd. HP magazine. Caliber: 9mm Used in HP pistol
-			{"vn_m1911_mag",						{ 0, 0, 0,-1}},	//	7Rnd. M1911 magazine. Caliber: .45in. Used in M1911 pistol
-			{"vn_m712_mag",							{ 0, 0, 0, 4}},	//	20Rnd. M712 Magazine. Caliber: 7.62x25mm. Used in M712 pistol
-			{"vn_mk22_mag",							{ 0, 0, 0,-1}},	//	14Rnd. Mk22 Magazine. Caliber: 9x19mm. Used in Mk22 Mod 0 pistol
-			{"vn_pm_mag",							{ 0, 0, 0,-1}},	//	8Rnd. PM magazine. Caliber: 9x18mm. Used in PM pistol
-			{"vn_tt33_mag",							{ 0, 0, 0,-1}},	//	8Rnd. TT-33 Magazine. Caliber: 7.62x25mm. Used in TT-33 pistol
-			{"vn_welrod_mag",						{ 0, 0, 0,-1}},	//	8Rnd. Welrod magazine. Caliber 7.65x17mm. Used in Welrod pistol
-			{"vn_vz61_mag",							{ 0, 0, 0,-1}},	//	20Rnd. VZ.61 SMG magazine. Caliber: 7.65x17mm. Used in VZ.61 Skorpion SMG
-			{"vn_vz61_t_mag",						{ 0, 0, 0,-1}},	//	20Rnd. VZ.61 SMG magazine. Caliber: 7.65x17mm. Used in VZ.61 Skorpion SMG (Tracer)
-			{"vn_ppk_mag",							{ 0, 0, 0,-1}},	//	7Rnd. PPK Mag. Caliber: 9x17mm. Used in PPK pistol
-			{"vn_p38_mag",							{ 0, 0, 0,-1}},	//	8Rnd. P38 Mag. Caliber: 9x19mm. Used in P38 pistol
-			//OpFor
-			{"vn_type64_mag",						{ 0,-1, 0,-1}},	//	9Rnd. Type 64 Mag. Caliber: 7.65x17mm. Used in Type 64 pistol
-			//SMG Mags
-			{"vn_m3a1_mag",							{-1, 0, 0,-1}},	//	30Rnd. M3A1 Magazine. Caliber: 11.43x23mm .45 cal. Used in M3A1 Submachinegun
-			{"vn_m3a1_t_mag",						{-1, 0, 0,-1}},	//	30Rnd. M3A1 Tracer Magazine. Caliber: 11.43x23mm .45 cal. Used in M3A1 Submachinegun
-			{"vn_m45_mag",							{-1, 0, 0,-1}},	//	36Rnd. M/45 Magazine. Caliber: 9x19mm. Used in M/45 Submachinegun
-			{"vn_m45_t_mag",						{-1, 0, 0,-1}},	//	36Rnd. M/45 Tracer Magazine. Caliber: 9x19mm. Used in M/45 Submachinegun
-			{"vn_mat49_mag",						{ 0, 0, 0,-1}},	//	32Rnd. MAT-49 Magazine. Caliber: 9x19mm Used in MAT-49 Submachinegun
-			{"vn_mat49_t_mag",						{ 0, 0, 0,-1}},	//	32Rnd. MAT-49 Tracer Magazine. Caliber: 9x19mm Used in MAT-49 Submachinegun
-			{"vn_mc10_mag",							{-1, 0, 0,-1}},	//	32Rnd. MC-10 SMG Magazine. Caliber: 9x19mm. Used in MC-10 SMG
-			{"vn_mc10_t_mag",						{-1, 0, 0,-1}},	//	32Rnd. MC-10 SMG Magazine. Caliber: 9x19mm. Used in MC-10 SMG. (Tracer)
-			{"vn_sten_mag",							{-1, 0, 0,-1}},	//	32Rnd. Sten Mk.II Magazine. Caliber: 9x19mm Used in Sten Mk.II Submachinegun
-			{"vn_sten_t_mag",						{-1, 0, 0,-1}},	//	32Rnd. Sten Mk.II Tracer Magazine. Caliber: 9x19mm Used in Sten Mk.II Submachinegun
-			{"vn_f1_smg_mag",						{-1, 0, 0,-1}},	//	34Rnd. F1/L2A3/L34A1 Mag. Calibre: 9x19mm. Used in F1, L2A3, L34A1 SMG
-			{"vn_f1_smg_t_mag",						{-1, 0, 0,-1}},	//	34Rnd. F1/L2A3/L34A1 Tracer Mag. Calibre: 9x19mm. Used in F1, L2A3, L34A1 SMG
-			{"vn_l34a1_smg_mag",					{-1, 0, 0,-1}},	//	34Rnd. L34A1 Mag. Calibre: 9x19mm Subsonic. Used in F1, L2A3, L34A1 SMG
-			{"vn_l34a1_smg_t_mag",					{-1, 0, 0,-1}},	//	34Rnd. L34A1 Tracer Mag. Calibre: 9x19mm Subsonic. Used in F1, L2A3, L34A1 SMG
-			{"vn_m1928_mag",						{-1, 0, 0,-1}},	//	50Rnd. M1928 magazine. Caliber: 11.43x23mm. Used in M1928 Tommy gun
-			{"vn_m1928_t_mag",						{-1, 0, 0,-1}},	//	50Rnd. M1928 magazine. Caliber: 11.43x23mm. Used in M1928 Tommy gun (Tracer)
-			{"vn_mpu_mag",							{-1, 0, 0,-1}},	//	32Rnd. MPU SMG magazine. Caliber: 9x19mm. Used in MPU SMG
-			{"vn_mpu_t_mag",						{-1, 0, 0,-1}},	//	32Rnd. MPU SMG Magazine. Caliber: 9x19mm. Used in MPU SMG (Tracer)
-			//OpFor
-			{"vn_mat49_vc_mag",						{ 0,-1, 0,-1}},	//	32Rnd. MAT-49 Magazine (VC). Caliber: 7.62x25mm Used in VC converted MAT-49 Submachinegun
-			{"vn_mat49_vc_t_mag",					{ 0,-1, 0,-1}},	//	32Rnd. MAT-49 Tracer Magazine (VC). Caliber: 7.62x25mm Used in VC converted MAT-49 Submachinegun
-			{"vn_type64_smg_mag",					{ 0,-1, 0,-1}},	//	30Rnd. Type 64 SMG Magazine. Caliber: 7.65x25mm Used in Type 64 SMG
-			{"vn_type64_smg_t_mag",					{ 0,-1, 0,-1}},	//	30Rnd. Type 64 SMG Tracer Magazine. Caliber: 7.65x25mm Used in Type 64 SMG
-			{"vn_mp40_mag",							{ 0,-1, 0,-1}},	//	32Rnd. MP40 Mag
-			{"vn_mp40_t_mag",						{ 0,-1, 0,-1}},	//	32Rnd. MP40 Mag (Tracer)
-			{"vn_pps_mag",							{ 0,-1, 0,-1}},	//	35Rnd. PPS Magazine. Caliber: 7.62x25mm. Used in PPS-43 and PPS-52 SMGs
-			{"vn_pps_t_mag",						{ 0,-1, 0,-1}},	//	35Rnd. PPS Tracer Magazine. Caliber: 7.62x25mm. Used in PPS-43 and PPS-52 SMGs
-			{"vn_ppsh41_35_mag",					{ 0,-1, 0,-1}},	//	35Rnd. PPSh-41 Magazine. Caliber: 7.62x25mm Used in PPSh-41 and K-50M Submachineguns
-			{"vn_ppsh41_35_t_mag",					{ 0,-1, 0,-1}},	//	35Rnd. PPSh-41 Tracer Magazine. Caliber: 7.62x25mm Used in PPSh-41 and K-50M Submachineguns
-			{"vn_ppsh41_71_mag",					{ 0,-1, 0,-1}},	//	71Rnd. PPSh-41 Magazine. Caliber: 7.62x25mm Used in PPSh-41 and K-50M Submachineguns
-			{"vn_ppsh41_71_t_mag",					{ 0,-1, 0,-1}},	//	71Rnd. PPSh-41 Tracer Magazine. Caliber: 7.62x25mm Used in PPSh-41 and K-50M Submachineguns
-			//Revolver Ammo
-			{"vn_m10_mag",							{ 0, 0, 0,-1}},	//	6Rnd. .38 revolver. Caliber: .38 revolver. Used in M10 and .38 revolvers
-			{"vn_m1895_mag",						{ 0, 0, 0,-1}},	//	7Rnd. M1895 reload. Caliber 7.62x38mm. Used in Model 1895 revolver
-			{"vn_mk1_udg_mag",						{-1, 0, 0,-1}},	//	6Rnd. Mk1 UDG magazine. Caliber: 4.25in Mk59 dart. Used in Mk1 Underwater Defence Gun
-			//Shotgun Ammo
-			{"vn_m1897_buck_mag",					{-1, 0, 0,-1}},	//	6Rnd. M1897 Reload. Caliber: 12 gauge buckshot. Used in Model 1897 shotgun
-			{"vn_m1897_fl_mag",						{-1, 0, 0,-1}},	//	6Rnd. M1897 Reload. Caliber: 12 gauge flechette. Used in Model 1897 shotgun
-			//OpFor
-			{"vn_izh54_mag",						{ 0,-1, 0,-1}},	//	2Rnd. ISh-54 Reload. Caliber: 12 gauge buckshot. Used in ISh-54 shotgun
-			{"vn_izh54_so_mag",						{ 0,-1, 0,-1}},	//	2Rnd. ISh-54 Sawn-off. Caliber: 12 gauge buckshot. Used in ISh-54 shotgun
-			//Grenades
-			{"vn_v40_grenade_mag",					{-1, 0, 0,-1}},	//	Grenade V40 (Frag)
-			{"vn_m61_grenade_mag",					{-1, 0, 0,-1}},	//	Grenade M61 (Frag)
-			{"vn_m67_grenade_mag",					{-1, 0, 0,-1}},	//	Grenade M67 (Frag)
-			{"vn_m14_grenade_mag",					{-1, 0, 0,-1}},	//	Grenade M14 (Incendiary)
-			{"vn_m14_early_grenade_mag",			{-1,-1,-1,-1}},	//	Grenade M14-A (Incendiary)
-			{"vn_m34_grenade_mag",					{-1, 0, 0,-1}},	//	Grenade M34 (WP)
-			{"vn_m7_grenade_mag",					{-1, 0, 0,-1}},	//	Grenade M7A3 (CS Gas)
-			{"vn_m18_green_mag",					{-1, 0, 0,-1}},	//	Grenade Smoke (Green)
-			{"vn_m18_purple_mag",					{-1, 0, 0,-1}},	//	Grenade Smoke (Purple)
-			{"vn_m18_red_mag",						{-1, 0, 0,-1}},	//	Grenade Smoke (Red)
-			{"vn_m18_white_mag",					{-1, 0, 0,-1}},	//	Grenade Smoke (White)
-			{"vn_m18_yellow_mag",					{-1, 0, 0,-1}},	//	Grenade Smoke (Yellow)
-			{"Chemlight_blue",						{-1, 0, 0,-1}},	//
-			{"Chemlight_green",						{-1, 0, 0,-1}},	//
-			{"Chemlight_yellow",					{-1, 0, 0,-1}},	//
-			//OpFor
-			{"vn_t67_grenade_mag",					{ 0,-1, 0,-1}},	//	Grenade Type67 (Frag)
-			{"vn_chicom_grenade_mag",				{ 0,-1, 0,-1}},	//	Grenade Chicom (Frag)
-			{"vn_rg42_grenade_mag",					{ 0,-1, 0,-1}},	//	Grenade RG-42 (Frag)
-			{"vn_rgd33_grenade_mag",				{ 0,-1, 0,-1}},	//	Grenade RGD-33 (Frag)
-			{"vn_rgd5_grenade_mag",					{ 0,-1, 0,-1}},	//	Grenade RGD-5 (Frag)
-			{"vn_rkg3_grenade_mag",					{ 0,-1, 0,-1}},	//	Grenade RKG-3 (HEAT)
-			{"vn_molotov_grenade_mag",				{ 0,-1, 0, 0}},	//	Grenade (Molotov Cocktail)
-			{"vn_rdg2_mag",							{ 0,-1, 0,-1}},	//	Grenade RDG-2 Smoke (White)
-			{"vn_f1_grenade_mag",					{ 0,-1, 0,-1}},	//	Grenade F-1 (Frag)
-			{"Chemlight_red",						{ 0,-1, 0,-1}},	//
-			//Rockets/Missiles
-			{"vn_m72_mag",							{-1, 0, 0,-1}},	//	M72 66mm HEAT Rocket. Used in M72 single-shot, disposable rocket launcher
-			{"vn_m20a1b1_heat_mag",					{-1, 0, 0,-1}},	//	M28A2 HEAT Rocket. Used in M20A1B1 Super Bazooka
-			{"vn_m20a1b1_wp_mag",					{-1, 0, 0,-1}},	//	M30 WP Rocket. Used in M20A1B1 Super Bazooka
-			//OpFor
-			{"vn_rpg2_mag",							{ 0,-1, 0,-1}},	//	PG-2 82mm HEAT Rocket. Used in B40 hand-held, anti-tank grenade-launcher
-			{"vn_rpg7_mag",							{ 0,-1, 0,-1}},	//	PG-7V 85mm HEAT Rocket. Used in B41 hand-held, anti-tank grenade-launcher
-			{"vn_sa7_mag",							{ 0,-1, 0,-1}},	//	Strela-2 72mm Anti-Aircraft Missile. Used in 9K32 hand-held, anti-aircraft missile system
-			{"vn_sa7b_mag",							{ 0,-1, 0,-1}},	//	Strela-2M 72mm Anti-Aircraft Missile. Used in 9K32 hand-held, anti-aircraft missile system
-			{"vn_rpg2_fuze_mag",					{ 0,-1, 0,-1}},	//	PG-2 82mm Fuze Rocket. Used in B40 hand-held, anti-tank grenade-launcher
-			//Explosives
-			{"vn_mine_m112_remote_mag",				{-1, 0, 0,-1}},	//	M112 Breaching charge
-			{"vn_mine_m14_mag",						{-1, 0, 0,-1}},	//	Mine M14 Toe-popper
-			{"vn_mine_m15_mag",						{-1, 0, 0,-1}},	//	Mine M15 Anti-Tank
-			{"vn_mine_m16_mag",						{-1, 0, 0,-1}},	//	Mine M16 Bounding
-			{"vn_mine_m18_mag",						{-1, 0, 0,-1}},	//	Mine M18 Claymore (Remote)
-			{"vn_mine_m18_range_mag",				{-1, 0, 0,-1}},	//	Mine M18 Claymore (Proximity)
-			{"vn_mine_m18_x3_mag",					{-1, 0, 0,-1}},	//	Mine M18 Claymore x3 (Remote)
-			{"vn_mine_m18_x3_range_mag",			{-1, 0, 0,-1}},	//	Mine M18 Claymore x3 (Proximity)
-			{"vn_mine_satchel_remote_02_mag",		{ 0, 0, 0,-1}},	//	Satchel charge
-			{"vn_mine_tripwire_m16_02_mag",			{-1, 0, 0,-1}},	//	Mine M16 2m tripwire
-			{"vn_mine_tripwire_m16_04_mag",			{-1, 0, 0,-1}},	//	Mine M16 4m tripwire
-			{"vn_mine_tripwire_m49_02_mag",			{-1, 0, 0,-1}},	//	Mine M49A1 2m tripwire (Flare)
-			{"vn_mine_tripwire_m49_04_mag",			{-1, 0, 0,-1}},	//	Mine M49A1 4m tripwire (Flare)
-			{"vn_mine_bangalore_mag",				{-1, 0, 0,-1}},	//	Mine Bangalore (Remote)
-			{"vn_mine_limpet_01_mag",				{-1, 0, 0,-1}},	//	Mine Limpet US (Remote)
-			{"vn_mine_m18_fuze10_mag",				{-1, 0, 0,-1}},	//	Mine M18 Claymore (10s Fuze)
-			{"vn_mine_m18_wp_mag",					{-1, 0, 0,-1}},	//	Mine M18/WP Claymore (Remote)
-			{"vn_mine_m18_wp_range_mag",			{-1, 0, 0,-1}},	//	Mine M18/WP Claymore (Proximity)
-			{"vn_mine_m18_wp_fuze10_mag",			{-1, 0, 0,-1}},	//	Mine M18/WP Claymore (10s Fuze)
-			//OpFor
-			{"vn_mine_ammobox_range_mag",			{ 0,-1, 0,-1}},	//	Mine Ammobox (booby-trapped)
-			{"vn_mine_punji_01_mag",				{ 0,-1, 0,-1}},	//	Trap punji (Large)
-			{"vn_mine_punji_02_mag",				{ 0,-1, 0,-1}},	//	Trap punji (Small)
-			{"vn_mine_punji_03_mag",				{ 0,-1, 0,-1}},	//	Trap punji (Whip)
-			{"vn_mine_tm57_mag",					{ 0,-1, 0,-1}},	//	Mine TM-57 Anti-Tank
-			{"vn_mine_tripwire_arty_mag",			{ 0,-1, 0,-1}},	//	Trap IED 4m tripwire
-			{"vn_mine_tripwire_f1_02_mag",			{ 0, 0, 0,-1}},	//	Trap F-1 2m tripwire
-			{"vn_mine_tripwire_f1_04_mag",			{ 0, 0, 0,-1}},	//	Trap F-1 4m tripwire
-			{"vn_mine_bike_mag",					{ 0,-1, 0,-1}},	//	Mine Bicycle (Remote)
-			{"vn_mine_bike_range_mag",				{ 0,-1, 0,-1}},	//	Mine Bicycle (Proximity)
-			{"vn_mine_cartridge_mag",				{ 0,-1, 0,-1}},	//	Mine Cartridge (Proximity)
-			{"vn_mine_dh10_mag",					{ 0,-1, 0,-1}},	//	Mine DH10 (Remote)
-			{"vn_mine_dh10_range_mag",				{ 0,-1, 0,-1}},	//	Mine DH10 (Proximity)
-			{"vn_mine_jerrycan_mag",				{ 0,-1, 0,-1}},	//	Mine Jerry Can (Remote)
-			{"vn_mine_jerrycan_range_mag",			{ 0,-1, 0,-1}},	//	Mine Jerry Can (Proximity)
-			{"vn_mine_lighter_mag",					{ 0,-1, 0,-1}},	//	Mine Lighter (Proximity)
-			{"vn_mine_mortar_range_mag",			{ 0,-1, 0,-1}},	//	Mine Mortar (Proximity)
-			{"vn_mine_chicom_no8_mag",				{ 0,-1, 0,-1}},	//	Mine No 8 (Proximity)
-			{"vn_mine_pot_mag",						{ 0,-1, 0,-1}},	//	Mine Pot (Remote)
-			{"vn_mine_pot_range_mag",				{ 0,-1, 0,-1}},	//	Mine Pot (Proximity)
-			{"vn_mine_gboard_range_mag",			{ 0,-1, 0,-1}},	//	Trap RGD5 4m (AP)
-			{"vn_mine_punji_04_mag",				{ 0,-1, 0,-1}},	//	Trap punji (Doorway)
-			{"vn_mine_punji_05_mag",				{ 0,-1, 0,-1}},	//	Trap punji (Side Whip Tripwire)
-			{"vn_satchelcharge_02_throw_mag",		{ 0,-1, 0,-1}},	//	Satchel charge (Thrown)
-			{"vn_mine_limpet_02_mag",				{ 0,-1, 0,-1}},	//	Mine Limpet Russian (Remote)
-			//Other
-			{"vn_m127_mag",							{-1, 0, 0,-1}},	//	M127 Flare Launcher
-			{"vn_m128_mag",							{-1, 0, 0,-1}},	//	M128 Flare Launcher (Green)
-			{"vn_m129_mag",							{-1, 0, 0,-1}},	//	M129 Flare Launcher (Red)
-			{"vn_prop_fort_mag",					{ 0, 0, 0, 0}},	//	Sandbag
-			{"MineDetector",						{ 0, 0, 0,-1}},	//	Mine Detector ARMA 3 Modern
-			{"vn_b_item_trapkit",					{ 0, 0, 0,-1}},	//	Trapkit
-			{"vn_b_item_lighter_01",				{ 0, 0, 0,-1}},	//	Lighter
-			{"vn_b_item_cigs_01",					{ 0, 0, 0,-1}},	//	Cigs
-			//Vehicle Ammo
-			{"vn_v_m18r_mag",						{-1,-1, 0,-1}},	//
-			{"vn_v_m61_mag",						{-1,-1, 0,-1}},	//
-			{"vn_v_m7_mag",							{-1,-1, 0,-1}},	//
-			{"vn_v_rdg2_mag",						{-1,-1, 0,-1}},	//
-			{"vn_v_rgd5_mag",						{-1,-1, 0,-1}},	//
-			{"vn_type56_v_12_he_mag",				{-1,-1, 0,-1}},	//
-			{"vn_type56_v_12_heat_mag",				{-1,-1, 0,-1}},	//
-//Food and Drink
-			{"vn_prop_drink_01",					{ 0, 0, 0, 0}},	//
-			{"vn_prop_drink_02",					{ 0, 0, 0, 0}},	//
-			{"vn_prop_drink_03",					{ 0, 0, 0, 0}},	//
-			{"vn_prop_drink_04",					{ 0, 0, 0, 0}},	//
-			{"vn_prop_drink_05",					{ 0, 0, 0, 0}},	//
-			{"vn_prop_drink_06",					{ 0, 0, 0, 0}},	//
-			{"vn_prop_drink_07_01",					{ 0,-1, 0, 0}},	//
-			{"vn_prop_drink_07_02",					{ 0,-1, 0, 0}},	//
-			{"vn_prop_drink_07_03",					{ 0,-1, 0, 0}},	//
-			{"vn_prop_drink_08_01",					{ 0,-1, 0, 0}},	//
-			{"vn_prop_drink_09_01",					{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_01_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_01_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_01_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_02_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_02_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_02_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_02_04",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_02_05",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_02_06",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_02_07",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_box_02_08",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_04",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_05",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_06",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_07",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_08",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_09",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_10",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_11",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_12",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_13",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_14",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_15",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_01_16",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_02_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_02_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_02_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_02_04",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_02_05",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_02_06",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_02_07",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_02_08",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_03_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_03_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_03_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_can_03_04",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_04",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_05",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_06",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_07",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_08",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_09",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_fresh_10",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_lrrp_01_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_lrrp_01_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_lrrp_01_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_lrrp_01_04",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_lrrp_01_05",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_lrrp_01_06",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_lrrp_01_07",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_lrrp_01_08",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_04",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_05",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_06",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_07",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_08",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_09",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_10",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_11",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_12",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_13",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_14",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_15",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_16",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_17",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_01_18",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_02_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_02_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_02_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_02_04",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_02_05",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_meal_02_06",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_pir_01_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_pir_01_02",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_pir_01_03",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_pir_01_04",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_pir_01_05",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_sack_01",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_food_sack_02",				{ 0, 0, 0, 0}},	//
-			//Medication
-			{"vn_prop_med_antibiotics",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_med_antimalaria",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_med_antivenom",				{-1,-1,-1,-1}},	//
-			{"vn_prop_med_dysentery",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_med_painkillers",				{ 0, 0, 0, 0}},	//
-			{"vn_prop_med_wormpowder",				{ 0, 0, 0, 0}},	//
-		};
-		items[] =
-		{
-			//Blufor
-			//Bayonet/Camo
-			{"vn_b_camo_m14",						{-1, 0, 0,-1}},	//	Camo wrap [M14]
-			{"vn_b_camo_m14a1",						{-1, 0, 0,-1}},	//	Camo wrap [M14A1]
-			{"vn_b_camo_m40a1",						{-1, 0, 0,-1}},	//	Camo wrap [M40]
-			{"vn_b_carbine",						{ 0, 0, 0,-1}},	//	Bayonet M4 [M1/ M2]
-			{"vn_b_m14",							{-1, 0, 0,-1}},	//	Bayonet M6 [M14]
-			{"vn_b_m16",							{-1, 0, 0,-1}},	//	Bayonet M7 [M16]
-			{"vn_b_m1897",							{-1, 0, 0,-1}},	//	Bayonet M1917 [M1897]
-			{"vn_b_m1_garand",						{-1, 0, 1,-1}},	//	Bayonet M5 [M1 Garand]
-			{"vn_b_camo_m1_garand",					{-1, 0, 2,-1}},	//	Camo wrap [M1 Garand]
-			{"vn_bipod_m1918",						{-1, 0, 4,-1}},	//	Bipod [M1918]
-			{"vn_bipod_m16",						{-1, 0, 1,-1}},	//	Bipod [M16]
-			{"vn_bipod_m14",						{-1, 0, 1,-1}},	//	Bipod [M14]
-			{"vn_b_l1a1",							{-1, 0, 1,-1}},	//	Bayonet L1A1 [L1A1/ F1]
-			{"vn_b_m1903",							{ 0, 0, 1, 1}},	//	Bayonet [M1903]
-			{"vn_b_m36",							{ 0, 0, 1, 1}},	//	Bayonet Spike [M36]
-			{"vn_b_camo_m1903",						{ 0, 0, 2, 2}},	//	Camo wrap [M1903]
-			{"vn_b_camo_m36",						{ 0, 0, 2, 2}},	//	Camo wrap [M36]
-			{"vn_bipod_m63a",						{-1, 0, 3,-1}},	//	Bipod [M63A]
- 			{"vn_b_m4956",							{ 0, 0, 0,-1}},	//	Bayonet Model 58 [M49/56]
-			//Suppressor
-			{"vn_s_m14",							{-1, 0, 0,-1}},	//	Suppressor [M14/M40]
-			{"vn_s_m16",							{-1, 0, 0,-1}},	//	Suppressor [M16]
-			{"vn_s_m1895",							{ 0, 0, 0,-1}},	//	Suppressor [M1895]
-			{"vn_s_m1911",							{-1, 0, 0,-1}},	//	Suppressor [M1911]
-			{"vn_s_m3a1",							{-1, 0, 0,-1}},	//	Suppressor [M3]
-			{"vn_s_m45",							{-1, 0, 0,-1}},	//	Suppressor [M/45]
-			{"vn_s_m45_camo",						{-1, 0, 0,-1}},	//	Suppressor [M/45 Camo]
-			{"vn_s_mat49",							{-1, 0, 0,-1}},	//	Suppressor [MAT-49]
-			{"vn_s_mc10",							{-1, 0, 0,-1}},	//	Suppressor [MC-10]
-			{"vn_s_mk22",							{-1, 0, 0,-1}},	//	Suppressor [Mk22]
-			{"vn_s_pm",								{ 0, 0, 0,-1}},	//	Suppressor [PM]
-			{"vn_s_sten",							{-1, 0, 0,-1}},	//	Suppressor [Sten Mk.II]
-			{"vn_s_ppk",							{ 0, 0, 2, 2}},	//	Suppressor 9mm [PPK/ P38]
-			{"vn_s_hp",								{-1, 0, 3,-1}},	//	Suppressor 9mm [HP]
-			{"vn_s_mpu",							{-1, 0, 0,-1}},	//	Suppressor [MPU]
-			//Optics
-			{"vn_o_4x_m16",							{-1, 0, 0,-1}},	//	Optic (M16 4x)
-			{"vn_o_9x_m14",							{-1, 0, 0,-1}},	//	Optic (M14 3-9x)
-			{"vn_o_9x_m16",							{-1, 0, 0,-1}},	//	Optic (M16 3-9x)
-			{"vn_o_9x_m40a1",						{-1, 0, 0,-1}},	//	Optic (M40 3-9x)
-			{"vn_o_9x_m40a1_camo",					{-1, 0, 0,-1}},	//	Optic (M40 3-9x camo)
-			{"vn_o_anpvs2_m14",						{-1, 0, 0,-1}},	//	Scope (AN-PVS2 Starlight) [M14]
-			{"vn_o_anpvs2_m16",						{-1, 0, 0,-1}},	//	Scope (AN-PVS2 Starlight) [XM177/M16]
-			{"vn_o_anpvs2_m40a1",					{-1, 0, 0,-1}},	//	Scope (AN-PVS2 Starlight) [M40]
-			{"vn_o_3x_m84",							{ 0, 0, 0,-1}},	//	Scope (M1/2 Carbine 2.2x)
-			{"vn_o_1x_sp_m16",						{-1, 0, 6,-1}},	//	Optic (M16 SP)
-			{"vn_o_3x_l1a1",						{-1, 0, 2,-1}},	//	Optic (L1A1 3x)
-			{"vn_o_8x_m1903",						{ 0, 0, 1, 1}},	//	Optic [M1903 8x]
-			{"vn_o_m14_front",						{-1, 0, 4,-1}},	//	Optic (M14 Front Sight)
-			{"vn_o_4x_m4956",						{ 0, 0, 0,-1}},	//	Scope (M49/56 3.5x)
-			//OpFor
-			//Bayonet/Camo
-			{"vn_b_sks",							{ 0,-1, 0,-1}},	//	Bayonet Spike [M38]
-			{"vn_b_type56",							{ 0,-1, 0,-1}},	//	Bayonet Spike [Type56]
- 			{"vn_b_camo_vz54",						{ 0,-1,-1,-1}},	//	Camo wrap [VZ54]
-			{"vn_b_camo_svd",						{ 0,-1,-1,-1}},	//	Camo wrap [SVD]
-			{"vn_b_camo_k98k",						{ 0,-1, 2, 2}},	//	Camo wrap [K98K]
-			{"vn_b_k98k",							{ 0,-1, 1, 1}},	//	Bayonet [K98K]
-			{"vn_b_m38",							{ 0,-1, 0,-1}},	//	Bayonet Spike [M38/ M91/30/ M1892]
-			{"vn_b_camo_m9130",						{ 0,-1, 0,-1}},	//	Camo wrap [M9130]
-			//Optic
-			{"vn_o_3x_m9130",						{ 0,-1, 0,-1}},	//	Optic (M91/30 3.5x)
-			{"vn_o_3x_sks",							{ 0,-1, 0,-1}},	//	Optic (SKS 3.5x)
-			{"vn_o_3x_vz54",						{ 0,-1,-1,-1}},	//	Optic (VZ54 2.5x)
-			{"vn_o_4x_svd",							{ 0,-1,-1,-1}},	//	Optic [SVD 4x]
-			{"vn_o_1_5x_k98k",						{ 0,-1, 1, 1}},	//	Optic [K98K 1.5x]
-			//Basics
-			{"vn_b_item_lighter_01",				{-1,-1,-1,-1}},	//
-			{"FirstAidKit",							{-1,-1,-1,-1}},	//
-			{"ItemCompass",							{-1,-1,-1,-1}},	//
-			{"ItemMap",								{-1,-1,-1,-1}},	//
-			{"ItemRadio",							{-1,-1,-1,-1}},	//
-			{"ItemWatch",							{-1,-1,-1,-1}},	//
-			{"Medikit",								{-1,-1,-1,-1}},	//
-			{"Toolkit",								{-1,-1,-1,-1}},	//
-			{"vn_o_item_firstaidkit",				{ 0, 0, 0,-1}},	//
-			{"vn_o_item_map",						{ 0, 0, 0,-1}},	//
-			{"vn_o_item_radio_m252",				{ 0, 0, 0,-1}},	//
-			{"vn_b_item_compass",					{ 0, 0, 0,-1}},	//
-			{"vn_b_item_compass_sog",				{ 0, 0, 0,-1}},	//
-			{"vn_b_item_firstaidkit",				{-1, 0, 0,-1}},	//
-			{"vn_b_item_map",						{-1, 0, 0,-1}},	//
-			{"vn_b_item_medikit_01",				{-1, 0, 0,-1}},	//
-			{"vn_b_item_radio_urc10",				{-1, 0, 0,-1}},	//
-			{"vn_b_item_toolkit",					{ 0, 0, 0,-1}},	//
-			{"vn_b_item_watch",						{ 0, 0, 0,-1}},	//
-			{"vn_b_item_wiretap",					{ 0, 0, 0,-1}},	//
-			{"MineDetector",						{ 0, 0, 0,-1}},	//	ARMA3 Modern
-			{"vn_b_item_trapkit",					{ 0, 0, 0,-1}}, // Trap Kit
-		  //{"ACRE_PRC343",							{-1,-1,-1,-1}},	//	ACRE leftover?
-		  //{"ACRE_PRC77",							{-1,-1,-1,-1}},	//	ACRE leftover?
-		  //{"ItemRadioAcreFlagged",				{-1,-1,-1,-1}},	//	ACRE leftover?
-			{"vn_b_prop_camera_01",					{-1,-1,-1, 0}},	//
-			//OpFor
-			{"vn_o_item_firstaidkit",				{ 0,-1, 0,-1}},	//
-			{"vn_o_item_map",						{ 0,-1, 0,-1}},	//
-			{"vn_o_item_radio_m252",				{ 0,-1, 0,-1}},	//
-			//Facewear
-			{"G_Aviator",							{ 0, 0, 0,-1}},	//	ARMA3 Modern
-			{"G_Bandanna_aviator",					{-1, 0, 0,-1}},	//	ARMA3 Modern
-			{"G_Bandanna_blk",						{-1, 0, 0,-1}},	//	ARMA3 Modern
-			{"G_Bandanna_oli",						{-1, 0, 0,-1}},	//	ARMA3 Modern
-			{"G_Spectacles_Tinted",					{ 0, 0, 0,-1}},	//	ARMA3 Modern
-			{"vn_b_acc_goggles_01",					{-1, 0, 0,-1}},	//	M44 Goggles
-			{"vn_b_acc_m17_01",						{-1, 0, 0,-1}},	//	M17 Respirator
-			{"vn_b_acc_m17_02",						{-1, 0, 0,-1}},	//	M17 Respirator (Hood)
-			{"vn_b_acc_ms22001_01",					{-1, 0, 0,-1}},	//	Mask MS-22001
-			{"vn_b_acc_ms22001_02",					{-1, 0, 0,-1}},	//	Mask MS-22001 (Loose)
-			{"vn_b_aviator",						{ 0, 0, 0,-1}},	//	Unknown
-			{"vn_b_acc_rag_01",						{-1, 0, 0,-1}},	//	Scrim Scarf 01
-			{"vn_b_acc_rag_02",						{-1, 0, 0,-1}},	//	Scrim Scarf 02
-			{"vn_b_acc_towel_01",					{-1, 0, 0,-1}},	//	Towel 01
-			{"vn_b_acc_towel_02",					{-1, 0, 0,-1}},	//	Towel 02
-			{"vn_b_bandana_a",						{-1, 0, 0,-1}},	//	Unknown
-			{"vn_b_scarf_01_01",					{-1, 0, 0,-1}},	//	Scarf (Olive US)
-			{"vn_b_scarf_01_03",					{ 0, 0, 0,-1}},	//	Scarf (Black US)
-			{"vn_b_spectacles",						{ 0, 0, 0,-1}},	//	Unknown
-			{"vn_b_spectacles_tinted",				{ 0, 0, 0,-1}},	//	Unknown
-			{"vn_b_squares",						{ 0, 0, 0,-1}},	//	Unknown
-			{"vn_b_squares_tinted",					{ 0, 0, 0,-1}},	//	Unknown
-			{"vn_g_glasses_01",						{ 0, 0, 0,-1}},	//	Sunglasses
-			{"vn_g_spectacles_01",					{ 0, 0, 0,-1}},	//	Soectacles (Round)
-			{"vn_g_spectacles_02",					{ 0, 0, 0,-1}},	//	Spectacles (GI)
-			{"vn_b_acc_seal_01",					{-1, 0, 0,-1}},	//	SEAL (Diver)
-//OpFor
-			{"vn_o_acc_goggles_01",					{-1, 0, 0,-1}},	//	Crew Goggles
-			{"vn_o_acc_goggles_02",					{-1, 0, 0,-1}},	//	PO-1M Goggles
-			{"vn_o_acc_goggles_03",					{-1, 0, 0,-1}},	//	PO-1M Goggles (KM32 Mask)
-			{"vn_o_acc_km32_01",					{-1, 0, 0,-1}},	//	KM32 Mask
-			{"vn_o_scarf_01_01",					{ 0, 0, 0,-1}},	//	Scarf (Red)
-			{"vn_o_scarf_01_02",					{ 0, 0, 0,-1}},	//	Scarf (Green)
-			{"vn_o_scarf_01_03",					{ 0, 0, 0,-1}},	//	Scarf (Blue)
-			{"vn_o_scarf_01_04",					{ 0, 0, 0,-1}},	//	Scarf (Black)
-			{"vn_o_bandana_b",						{-1, 0, 0,-1}},	//	Unknown
-			{"vn_o_bandana_g",						{-1, 0, 0,-1}},	//	Unknown
-			{"vn_o_poncho_01_01",					{ 0,-1, 0,-1}},	//	Poncho (Camo)
-//Headgear
-			{"vn_b_beret_01_01",					{-1, 0, 0,-1}},	//	Beret (Dark Green)
-			{"vn_b_beret_01_02",					{-1, 0, 0,-1}},	//	Beret (Black)
-			{"vn_b_beret_01_03",					{-1, 0, 0,-1}},	//	Beret (Maroon)
-			{"vn_b_beret_01_04",					{-1, 0, 0,-1}},	//	Beret (Khaki Green)
-			{"vn_b_beret_01_05",					{-1, 0, 0,-1}},	//	Beret (ERDL brown)
-			{"vn_b_beret_01_06",					{-1, 0, 0,-1}},	//	Beret (Tiger)
-			{"vn_b_beret_01_07",					{-1, 0, 0,-1}},	//	Beret (RAC)
-			{"vn_b_beret_01_08",					{-1, 0, 0,-1}},	//	Beret (ERDL) ADDED
-			{"vn_b_beret_01_09",					{-1, 0, 0,-1}},	//	Beret 1 (MEDT)
-			{"vn_b_beret_01_10",					{-1, 0, 0,-1}},	//	Beret 2 (MEDT)
-			{"vn_b_beret_01_11",					{-1, 0, 0,-1}},	//	Beret 3 (MEDT)
-			{"vn_b_beret_03_01",					{-1, 0, 0,-1}},	//	Beret (US TF-116)
-			{"vn_b_beret_04_01",					{-1, 0, 0,-1}},	//	Beret (RAC Headset)
-			{"vn_i_beret_01_01",					{-1, 0, 0,-1}},	//	Beret (ARVN Armor)
-			{"vn_i_beret_03_01",					{-1, 0, 0,-1}},	//	Beret (ARVN Tan)
-			{"vn_i_beret_03_02",					{-1, 0, 0,-1}},	//	Beret (ARVN Black)
-			{"vn_i_beret_03_03",					{-1, 0, 0,-1}},	//	Beret (ARVN Airborne)
-			{"vn_i_beret_03_04",					{-1, 0, 0,-1}},	//	Beret (ARVN Ranger)
-			{"vn_b_bandana_01",						{ 0, 0, 0,-1}},	//	Bandana (Green)
-			{"vn_b_bandana_02",						{-1, 0, 0,-1}},	//	Bandana (Tiger)
-			{"vn_b_bandana_03",						{ 0, 0, 0,-1}},	//	Bandana (Black)
-			{"vn_b_bandana_04",						{-1, 0, 0,-1}},	//	Bandana (Spray)
-			{"vn_b_bandana_05",						{-1, 0, 0,-1}},	//	Bandana (Tiger green)
-			{"vn_b_bandana_06",						{-1, 0, 0,-1}},	//	Bandana (ERDL brown)
-			{"vn_b_bandana_07",						{-1, 0, 0,-1}},	//	Bandana (Leopard)
-			{"vn_b_bandana_08",						{-1, 0, 0,-1}},	//	Bandana (ERDL) ADDED
-			{"vn_b_boonie_01_01",					{-1, 0, 0,-1}},	//	Boonie F/sides (Green)
-			{"vn_b_boonie_01_02",					{-1, 0, 0,-1}},	//	Boonie F/sides (Tiger)
-			{"vn_b_boonie_01_03",					{-1, 0, 0,-1}},	//	Boonie F/sides (Black)
-			{"vn_b_boonie_01_04",					{-1, 0, 0,-1}},	//	Boonie F/sides (Spray)
-			{"vn_b_boonie_01_05",					{-1, 0, 0,-1}},	//	Boonie F/sides (Tiger green)
-			{"vn_b_boonie_01_06",					{-1, 0, 0,-1}},	//	Boonie F/sides (ERDL brown)
-			{"vn_b_boonie_01_07",					{-1, 0, 0,-1}},	//	Boonie F/sides (Leopard)
-			{"vn_b_boonie_01_08",					{-1, 0, 0,-1}},	//	Boonie F/sides (ERDL)
-			{"vn_b_boonie_02_01",					{-1, 0, 0,-1}},	//	Boonie (Green)
-			{"vn_b_boonie_02_02",					{-1, 0, 0,-1}},	//	Boonie (Tiger)
-			{"vn_b_boonie_02_03",					{-1, 0, 0,-1}},	//	Boonie (Black)
-			{"vn_b_boonie_02_04",					{-1, 0, 0,-1}},	//	Boonie (Spray)
-			{"vn_b_boonie_02_05",					{-1, 0, 0,-1}},	//	Boonie (Tiger green)
-			{"vn_b_boonie_02_06",					{-1, 0, 0,-1}},	//	Boonie (ERDL brown)
-			{"vn_b_boonie_02_07",					{-1, 0, 0,-1}},	//	Boonie (Leopard)
-			{"vn_b_boonie_02_08",					{-1, 0, 0,-1}},	//	Boonie (ERDL)
-			{"vn_b_boonie_03_01",					{-1, 0, 0,-1}},	//	Boonie F/front (Green)
-			{"vn_b_boonie_03_02",					{-1, 0, 0,-1}},	//	Boonie F/front (Tiger)
-			{"vn_b_boonie_03_03",					{-1, 0, 0,-1}},	//	Boonie F/front (Black)
-			{"vn_b_boonie_03_04",					{-1, 0, 0,-1}},	//	Boonie F/front (Spray)
-			{"vn_b_boonie_03_05",					{-1, 0, 0,-1}},	//	Boonie F/front (Tiger green)
-			{"vn_b_boonie_03_06",					{-1, 0, 0,-1}},	//	Boonie F/front (ERDL brown)
-			{"vn_b_boonie_03_07",					{-1, 0, 0,-1}},	//	Boonie F/front (Leopard)
-			{"vn_b_boonie_03_08",					{-1, 0, 0,-1}},	//	Boonie F/front (ERDL)
-			{"vn_b_boonie_04_01",					{-1, 0, 0,-1}},	//	Boonie F/left (Green)
-			{"vn_b_boonie_04_02",					{-1, 0, 0,-1}},	//	Boonie F/left (Tiger)
-			{"vn_b_boonie_04_03",					{-1, 0, 0,-1}},	//	Boonie F/left (Black)
-			{"vn_b_boonie_04_04",					{-1, 0, 0,-1}},	//	Boonie F/left (Spray)
-			{"vn_b_boonie_04_05",					{-1, 0, 0,-1}},	//	Boonie F/left (Tiger green)
-			{"vn_b_boonie_04_06",					{-1, 0, 0,-1}},	//	Boonie F/left (ERDL brown)
-			{"vn_b_boonie_04_07",					{-1, 0, 0,-1}},	//	Boonie F/left (Leopard)
-			{"vn_b_boonie_04_08",					{-1, 0, 0,-1}},	//	Boonie F/left (ERDL)
-			{"vn_b_boonie_05_01",					{-1, 0, 0,-1}},	//	Boonie F/right (Green)
-			{"vn_b_boonie_05_02",					{-1, 0, 0,-1}},	//	Boonie F/right (Tiger)
-			{"vn_b_boonie_05_03",					{-1, 0, 0,-1}},	//	Boonie F/right (Black)
-			{"vn_b_boonie_05_04",					{-1, 0, 0,-1}},	//	Boonie F/right (Spray)
-			{"vn_b_boonie_05_05",					{-1, 0, 0,-1}},	//	Boonie F/right (Tiger green)
-			{"vn_b_boonie_05_06",					{-1, 0, 0,-1}},	//	Boonie F/right (ERDL brown)
-			{"vn_b_boonie_05_07",					{-1, 0, 0,-1}},	//	Boonie F/right (Leopard)
-			{"vn_b_boonie_05_08",					{-1, 0, 0,-1}},	//	Boonie F/right (ERDL)
-			{"vn_b_boonie_06_01",					{-1, 0, 0,-1}},	//	Boonie (ANZAC)
-			{"vn_b_boonie_07_01",					{-1, 0, 0,-1}},	//	Boonie (ANZAC Oval)
-			{"vn_b_boonie_08_01",					{-1, 0, 0,-1}},	//	Boonie (ANZAC Folded)
-			{"vn_b_boonie_06_02",					{-1, 0, 0,-1}},	//	Boonie (ANZAC Stripe)
-			{"vn_b_boonie_07_02",					{-1, 0, 0,-1}},	//	Boonie (ANZAC Oval Stripe)
-			{"vn_b_boonie_08_02",					{-1, 0, 0,-1}},	//	Boonie (ANZAC Folded Stripe)
-			{"vn_b_boonie_09_01",					{-1,-1,-1,-1}},	//	Boonie (Rebel/ Green) BLACKLIST
-			{"vn_b_boonie_09_02",					{-1,-1,-1,-1}},	//	Boonie (Rebel/ Tiger) BLACKLIST
-			{"vn_b_boonie_09_03",					{-1,-1,-1,-1}},	//	Boonie (Rebel/ Black) BLACKLIST
-			{"vn_b_boonie_09_04",					{-1,-1,-1,-1}},	//	Boonie (Rebel/ Spray) BLACKLIST
-			{"vn_b_boonie_09_05",					{-1,-1,-1,-1}},	//	Boonie (Rebel/ Tiger green) BLACKLIST
-			{"vn_b_boonie_09_06",					{-1,-1,-1,-1}},	//	Boonie (Rebel/ ERDL brown) BLACKLIST
-			{"vn_b_boonie_09_07",					{-1,-1,-1,-1}},	//	Boonie (Rebel/ Duckhunter) BLACKLIST
-			{"vn_b_boonie_09_08",					{-1,-1,-1,-1}},	//	Boonie (Rebel/ ERDL) BLACKLIST
-			{"vn_b_boonie_09_09",					{-1,-1,-1,-1}},	//	Boonie (Rebel/ Grey)
-			{"vn_b_boonie_01_09",					{-1, 0, 0,-1}},	//	Boonie F/sides (Grey)
-			{"vn_b_boonie_02_09",					{-1, 0, 0,-1}},	//	Boonie (Grey)
-			{"vn_b_boonie_03_09",					{-1, 0, 0,-1}},	//	Boonie F/front (Grey)
-			{"vn_b_boonie_04_09",					{-1, 0, 0,-1}},	//	Boonie F/left (Grey)
-			{"vn_b_boonie_05_09",					{-1, 0, 0,-1}},	//	Boonie F/right (Grey)
-			{"vn_b_headband_01",					{ 0, 0, 0,-1}},	//	Headband (Green)
-			{"vn_b_headband_02",					{-1, 0, 0,-1}},	//	Headband (Tiger)
-			{"vn_b_headband_03",					{ 0, 0, 0,-1}},	//	Headband (Black)
-			{"vn_b_headband_04",					{-1, 0, 0,-1}},	//	Headband (Spray)
-			{"vn_b_headband_05",					{-1, 0, 0,-1}},	//	Headband (ERDL brown)
-			{"vn_b_headband_08",					{-1, 0, 0,-1}},	//	Headband (ERDL) ADDED
-			{"vn_c_headband_01",					{ 0, 0, 0,-1}},	//	Headband (Red)
-			{"vn_c_headband_02",					{ 0, 0, 0,-1}},	//	Headband (Green)
-			{"vn_c_headband_03",					{ 0, 0, 0,-1}},	//	Headband (Blue)
-			{"vn_c_headband_04",					{ 0, 0, 0,-1}},	//	Headband (Black/white)
-			//OpFor
-			{"vn_o_boonie_nva_02_01",				{ 0,-1, 0,-1}},	//	Boonie Hat (NVA/ green)
-			{"vn_o_boonie_nva_02_02",				{ 0,-1, 0,-1}},	//	Boonie Hat (NVA/ black)
-			{"vn_o_boonie_vc_01_01",				{ 0,-1, 0,-1}},	//	Boonie Hat (Green)
-			{"vn_o_boonie_vc_01_02",				{ 0,-1, 0,-1}},	//	Boonie Hat (Black)
-			{"vn_o_boonie_vc_02_01",				{ 0,-1, 0,-1}},	//	Boonie Hat (VC/ green)
-			{"vn_o_boonie_vc_02_02",				{ 0,-1, 0,-1}},	//	Boonie Hat (VC/ black)
-			{"vn_o_cap_navy_01",					{ 0,-1, 0,-1}},	//	Cap (VPN Sailor)
-			{"vn_c_conehat_01",						{ 0,-1, 0,-1}},	//	Non La (Strap)
-			{"vn_c_conehat_02",						{ 0,-1, 0,-1}},	//	Non La
-			{"vn_o_pl_cap_02_01",					{ 0,-1, 0,-1}},	//	Cap (PL)
-			{"vn_o_pl_cap_01_01",					{ 0,-1, 0,-1}},	//	Cap (PL Tan)
-			{"vn_o_pl_cap_02_02",					{ 0,-1, 0,-1}},	//	Cap (PL Grey)
-			{"vn_o_cap_01",							{ 0,-1, 0,-1}},	//	Field cap (NVA)
-			{"vn_o_cap_02",							{ 0,-1, 0,-1}},	//	Field cap (VC)
-			//Helmet
-			{"vn_i_helmet_m1_01_01",				{-1, 0, 0,-1}},	//	Helmet M1 (Biet Dong Quan)
-			{"vn_i_helmet_m1_01_02",				{-1, 0, 0,-1}},	//	Helmet M1 (Quan Canh)
-			{"vn_i_helmet_m1_02_01",				{-1, 0, 0,-1}},	//	Helmet M1 (Net 1)
-			{"vn_i_helmet_m1_03_01",				{-1, 0, 0,-1}},	//	Helmet M1 (Net 2)
-			{"vn_i_helmet_m1_02_02",				{-1, 0, 0,-1}},	//	Helmet M1 (Tiger/ Net 1)
-			{"vn_i_helmet_m1_03_02",				{-1, 0, 0,-1}},	//	Helmet M1 (Tiger/ Net 2)
-			{"vn_b_helmet_svh4_01_01",				{-1, 0, 0,-1}},	//	Helmet SVH4 (Air Cav)
-			{"vn_b_helmet_svh4_01_02",				{-1, 0, 0,-1}},	//	Helmet SVH4 (ARVN custom)
-			{"vn_b_helmet_svh4_01_03",				{-1, 0, 0,-1}},	//	Helmet SVH4 (USAF)
-			{"vn_b_helmet_svh4_01_04",				{-1, 0, 0,-1}},	//	Helmet SVH4 (Army)
-			{"vn_b_helmet_svh4_01_05",				{-1, 0, 0,-1}},	//	Helmet SVH4 (ARVN)
-			{"vn_b_helmet_svh4_01_06",				{-1, 0, 0,-1}},	//	Helmet SVH4 (Scream)
-			{"vn_b_helmet_svh4_02_01",				{-1, 0, 0,-1}},	//	Helmet SVH4 (Air Cav/ Visor)
-			{"vn_b_helmet_svh4_02_02",				{-1, 0, 0,-1}},	//	Helmet SVH4 (ARVN custom/ Visor)
-			{"vn_b_helmet_svh4_02_03",				{-1, 0, 0,-1}},	//	Helmet SVH4 (USAF/ Visor)
-			{"vn_b_helmet_svh4_02_04",				{-1, 0, 0,-1}},	//	Helmet SVH4 (Army/ Visor)
-			{"vn_b_helmet_svh4_02_05",				{-1, 0, 0,-1}},	//	Helmet SVH4 (ARVN/ Visor)
-			{"vn_b_helmet_svh4_02_06",				{-1, 0, 0,-1}},	//	Helmet SVH4 (Scream/ Visor)
-			{"vn_b_helmet_aph6_01_01",				{-1, 0, 0,-1}},	//	Helmet APH6 (White)
-			{"vn_b_helmet_aph6_01_02",				{-1, 0, 0,-1}},	//	Helmet APH6 (USAF Wolfpack)
-			{"vn_b_helmet_aph6_01_03",				{-1, 0, 0,-1}},	//	Helmet APH6 (USN Sundowners)
-			{"vn_b_helmet_aph6_01_04",				{-1, 0, 0,-1}},	//	Helmet APH6 (USN VA196)
-			{"vn_b_helmet_aph6_01_05",				{-1, 0, 0,-1}},	//	Helmet APH6 (USMC VM121)
-			{"vn_b_helmet_aph6_02_01",				{-1, 0, 0,-1}},	//	Helmet APH6 (White/ Visor)
-			{"vn_b_helmet_aph6_02_02",				{-1, 0, 0,-1}},	//	Helmet APH6 (USAF Wolfpack/ Visor)
-			{"vn_b_helmet_aph6_02_03",				{-1, 0, 0,-1}},	//	Helmet APH6 (USN Sundowners/ Visor)
-			{"vn_b_helmet_aph6_02_04",				{-1, 0, 0,-1}},	//	Helmet APH6 (USN VA196/ Visor)
-			{"vn_b_helmet_aph6_02_05",				{-1, 0, 0,-1}},	//	Helmet APH6 (USMC VM121/ Visor)
-			{"vn_b_helmet_t56_01_01",				{-1, 0, 0,-1}},	//	Helmet T56
-			{"vn_b_helmet_t56_01_02",				{-1, 0, 0,-1}},	//	Helmet T56 1
-			{"vn_b_helmet_t56_01_03",				{-1, 0, 0,-1}},	//	Helmet T56 2
-			{"vn_b_helmet_t56_02_01",				{-1, 0, 0,-1}},	//	Helmet T56 (Goggles)
-			{"vn_b_helmet_t56_02_02",				{-1, 0, 0,-1}},	//	Helmet T56 1 (Goggles)
-			{"vn_b_helmet_t56_02_03",				{-1, 0, 0,-1}},	//	Helmet T56 2 (Goggles)
-			{"vn_b_helmet_m1_01_01",				{-1, 0, 0,-1}},	//	Helmet M1 (Steel)
-			{"vn_b_helmet_m1_01_02",				{-1, 0, 0,-1}},	//	Helmet M1 (716 MP)
-			{"vn_b_helmet_m1_02_01",				{-1, 0, 0,-1}},	//	Helmet M1 2 (Camo)
-			{"vn_b_helmet_m1_02_02",				{-1, 0, 0,-1}},	//	Helmet M1 2 (Camo 2)
-			{"vn_b_helmet_m1_03_01",				{-1, 0, 0,-1}},	//	Helmet M1 3 (Camo)
-			{"vn_b_helmet_m1_03_02",				{-1, 0, 0,-1}},	//	Helmet M1 3 (Camo 2)
-			{"vn_b_helmet_m1_04_01",				{-1, 0, 0,-1}},	//	Helmet M1 GL (Camo)
-			{"vn_b_helmet_m1_04_02",				{-1, 0, 0,-1}},	//	Helmet M1 GL (Camo 2)
-			{"vn_b_helmet_m1_05_01",				{-1, 0, 0,-1}},	//	Helmet M1 5 (Camo)
-			{"vn_b_helmet_m1_05_02",				{-1, 0, 0,-1}},	//	Helmet M1 5 (Camo 2)
-			{"vn_b_helmet_m1_06_01",				{-1, 0, 0,-1}},	//	Helmet M1 6 (Camo)
-			{"vn_b_helmet_m1_06_02",				{-1, 0, 0,-1}},	//	Helmet M1 6 (Camo 2)
-			{"vn_b_helmet_m1_07_01",				{-1, 0, 0,-1}},	//	Helmet M1 7 (Camo)
-			{"vn_b_helmet_m1_07_02",				{-1, 0, 0,-1}},	//	Helmet M1 7 (Camo 2)
-			{"vn_b_helmet_m1_08_01",				{-1, 0, 0,-1}},	//	Helmet M1 MG (Camo)
-			{"vn_b_helmet_m1_08_02",				{-1, 0, 0,-1}},	//	Helmet M1 MG (Camo 2)
-			{"vn_b_helmet_m1_09_01",				{-1, 0, 0,-1}},	//	Helmet M1 Crew (Camo)
-			{"vn_b_helmet_m1_09_02",				{-1, 0, 0,-1}},	//	Helmet M1 Crew (Camo 2)
-			{"vn_b_helmet_m1_10_01",				{-1, 0, 0,-1}},	//	Helmet M1 Net 1 (Camo)
-			{"vn_b_helmet_m1_11_01",				{-1, 0, 0,-1}},	//	Helmet M1 Net 2 (Camo)
-			{"vn_b_helmet_m1_12_01",				{-1, 0, 0,-1}},	//	Helmet M1 (ROK/ Jungle)
-			{"vn_b_helmet_m1_12_02",				{-1, 0, 0,-1}},	//	Helmet M1 (ROK/ Sand)
-			{"vn_b_helmet_m1_14_01",				{-1, 0, 0,-1}},	//	Helmet M1 14 (Camo)
-			{"vn_b_helmet_m1_14_02",				{-1, 0, 0,-1}},	//	Helmet M1 14 (Camo 2)
-			{"vn_b_helmet_m1_15_01",				{-1, 0, 0,-1}},	//	Helmet M1 15 (Camo)
-			{"vn_b_helmet_m1_15_02",				{-1, 0, 0,-1}},	//	Helmet M1 15 (Camo 2)
-			{"vn_b_helmet_m1_16_01",				{-1, 0, 0,-1}},	//	Helmet M1 16 (Camo)
-			{"vn_b_helmet_m1_16_02",				{-1, 0, 0,-1}},	//	Helmet M1 16 (Camo 2)
-			{"vn_b_helmet_m1_17_01",				{-1, 0, 0,-1}},	//	Helmet M1 GL 17 (Camo)
-			{"vn_b_helmet_m1_17_02",				{-1, 0, 0,-1}},	//	Helmet M1 GL 17 (Camo 2)
-			{"vn_b_helmet_m1_18_01",				{-1, 0, 0,-1}},	//	Helmet M1 18 (Camo)
-			{"vn_b_helmet_m1_18_02",				{-1, 0, 0,-1}},	//	Helmet M1 18 (Camo 2)
-			{"vn_b_helmet_m1_19_01",				{-1, 0, 0,-1}},	//	Helmet M1 19 (Camo)
-			{"vn_b_helmet_m1_19_02",				{-1, 0, 0,-1}},	//	Helmet M1 19 (Camo 2)
-			{"vn_b_helmet_m1_20_01",				{-1, 0, 0,-1}},	//	Helmet M1 20 (Camo)
-			{"vn_b_helmet_m1_20_02",				{-1, 0, 0,-1}},	//	Helmet M1 20 (Camo 2)
-			//OpFor
-			{"vn_b_helmet_sog_01",					{ 0,-1,-1,-1}},	//	Pith Helmet (SOG) Removed no Monties
-			{"vn_o_helmet_nva_01",					{ 0,-1,-1,-1}},	//	Pith Helmet (NVA)
-			{"vn_o_helmet_nva_02",					{ 0,-1,-1,-1}},	//	Pith Helmet (NVA/ strap)
-			{"vn_o_helmet_nva_03",					{ 0,-1,-1,-1}},	//	Pith Helmet (NVA/ camo)
-			{"vn_o_helmet_nva_04",					{ 0,-1,-1,-1}},	//	Pith Helmet (NVA/ assault)
-			{"vn_o_helmet_nva_05",					{ 0,-1,-1,-1}},	//	Pith Helmet (NVA/ driver)
-			{"vn_o_helmet_nva_06",					{ 0,-1,-1,-1}},	//	Pith Helmet (VPN)
-			{"vn_o_helmet_nva_07",					{ 0,-1,-1,-1}},	//	Pith Helmet (NVA/ net)
-			{"vn_o_helmet_nva_08",					{ 0,-1,-1,-1}},	//	Pith Helmet (VPN/ net)
-			{"vn_o_helmet_nva_09",					{ 0,-1,-1,-1}},	//	Helmet SSh-40
-			{"vn_o_helmet_nva_10",					{ 0,-1,-1,-1}},	//	Helmet M56
-			{"vn_o_helmet_vc_01",					{ 0,-1,-1,-1}},	//	Pith Helmet (VC)
-			{"vn_o_helmet_vc_02",					{ 0,-1,-1,-1}},	//	Pith Helmet (VC/ strap)
-			{"vn_o_helmet_vc_03",					{ 0,-1,-1,-1}},	//	Pith Helmet (VC/ camo)
-			{"vn_o_helmet_vc_04",					{ 0,-1,-1,-1}},	//	Pith Helmet (VC/ assault)
-			{"vn_o_helmet_vc_05",					{ 0,-1,-1,-1}},	//	Pith Helmet (VC/ net)
-			{"vn_o_helmet_shl61_01",				{ 0,-1,-1,-1}},	//	Helmet SHL61 (Goggles)
-			{"vn_o_helmet_shl61_02",				{ 0,-1,-1,-1}},	//	Helmet SHL61
-			{"vn_o_helmet_tsh3_01",					{ 0,-1,-1,-1}},	//	Helmet TSH3 (Goggles)
-			{"vn_o_helmet_tsh3_02",					{ 0,-1,-1,-1}},	//	Helmet TSH3
-			{"vn_o_helmet_zsh3_01",					{ 0,-1,-1,-1}},	//	Helmet ZSH03
-			{"vn_o_helmet_zsh3_02",					{ 0,-1,-1,-1}},	//	Helmet ZSH03 (Visor)
-			//Uniforms
-			//US Air Uniforms
-			{"vn_b_uniform_heli_01_01",				{-1, 0, 0,-1}},	//	BDU US Army Aircrew
-			{"vn_b_uniform_k2b_01_01",				{-1, 0, 0,-1}},	//	K2B USAF Jet Crew
-			{"vn_b_uniform_k2b_01_02",				{-1, 0, 0,-1}},	//	K2B USMC Jet Crew
-			{"vn_b_uniform_k2b_01_04",				{-1, 0, 0,-1}},	//	K2B USMC Jet Crew (Tiger)
-			{"vn_b_uniform_k2b_01_05",				{-1, 0, 0,-1}},	//	K2B USMC Jet Crew (Khaki)
-			{"vn_b_uniform_k2b_02_01",				{-1, 0, 0,-1}},	//	K2B US Army Heli Crew
-			{"vn_b_uniform_k2b_02_02",				{-1, 0, 0,-1}},	//	K2B USMC Heli Crew
-			{"vn_b_uniform_k2b_02_03",				{-1, 0, 0,-1}},	//	K2B USSF Heli Crew
-			{"vn_b_uniform_k2b_02_04",				{-1, 0, 0,-1}},	//	K2B USMC Heli Crew (Tiger)
-			{"vn_b_uniform_k2b_02_05",				{-1, 0, 0,-1}},	//	K2B USMC Heli Crew (Khaki)
-			{"vn_b_uniform_k2b_03_01",				{-1, 0, 0,-1}},	//	K2B RAAF Heli Crew
-			{"vn_b_uniform_k2b_03_02",				{-1, 0, 0,-1}},	//	K2B RAN Heli Crew
-			//US Infantry Uniforms
-			{"vn_b_uniform_macv_01_01",				{-1, 0, 0,-1}},	//	BDU MACV 1 (Olive/ field)
-			{"vn_b_uniform_macv_01_02",				{-1, 0, 0,-1}},	//	BDU MACV 1 (Tiger)
-			{"vn_b_uniform_macv_01_03",				{-1, 0, 0,-1}},	//	BDU MACV 1 (Black)
-			{"vn_b_uniform_macv_01_04",				{-1, 0, 0,-1}},	//	BDU MACV 1 (Spray)
-			{"vn_b_uniform_macv_01_05",				{-1, 0, 0,-1}},	//	BDU MACV 1 (Tiger green)
-			{"vn_b_uniform_macv_01_06",				{-1, 0, 0,-1}},	//	BDU MACV 1 (ERDL/brown)
-			{"vn_b_uniform_macv_01_07",				{-1, 0, 0,-1}},	//	BDU MACV 1 (Olive)
-			{"vn_b_uniform_macv_01_08",				{-1, 0, 0,-1}},	//	BDU MACV 1 (Leopard)
-			{"vn_b_uniform_macv_01_15",				{-1, 0, 0,-1}},	//	BDU MACV 1 (ERDL)
-			{"vn_b_uniform_macv_01_16",				{-1, 0, 0,-1}},	//	BDU RLA 1 (Lizard)
-			{"vn_b_uniform_macv_01_17",				{-1, 0, 0,-1}},	//	BDU ARVN 1 (BDQ)
-			{"vn_b_uniform_macv_01_18",				{-1, 0, 0,-1}},	//	BDU ROK 1 (Frog)
-			{"vn_b_uniform_macv_01_22",				{-1, 0, 0,-1}},	//	BDU MACV 1 (ERDL/ MEDT) ADDED
-			{"vn_b_uniform_macv_01_23",				{-1, 0, 0,-1}},	//	BDU MACV 2 (ERDL/ MEDT) ADDED
-			{"vn_b_uniform_macv_01_24",				{-1, 0, 0,-1}},	//	BDU MACV 3 (ERDL/ MEDT) ADDED
-			{"vn_b_uniform_macv_01_25",				{-1, 0, 0,-1}},	//	BDU MACV 4 (ERDL/ MEDT) ADDED
-			{"vn_b_uniform_macv_01_26",				{-1, 0, 0,-1}},	//	BDU MACV 5 (ERDL/ MEDT) ADDED
-			{"vn_b_uniform_macv_02_01",				{-1, 0, 0,-1}},	//	BDU MACV 2 (Olive/ field)
-			{"vn_b_uniform_macv_02_02",				{-1, 0, 0,-1}},	//	BDU MACV 2 (Tiger)
-			{"vn_b_uniform_macv_02_05",				{-1, 0, 0,-1}},	//	BDU MACV 2 (Tiger green)
-			{"vn_b_uniform_macv_02_06",				{-1, 0, 0,-1}},	//	BDU MACV 2 (ERDL/brown)
-			{"vn_b_uniform_macv_02_07",				{-1, 0, 0,-1}},	//	BDU MACV 2 (Olive)
-			{"vn_b_uniform_macv_02_08",				{-1, 0, 0,-1}},	//	BDU MACV 2 (Leopard)
-			{"vn_b_uniform_macv_02_15",				{-1, 0, 0,-1}},	//	BDU MACV 2 (ERDL) ADDED
-			{"vn_b_uniform_macv_02_16",				{-1, 0, 0,-1}},	//	BDU RLA 2 (Lizard)
-			{"vn_b_uniform_macv_02_17",				{-1, 0, 0,-1}},	//	BDU ARVN 2 (BDQ)
-			{"vn_b_uniform_macv_02_18",				{-1, 0, 0,-1}},	//	BDU ROK 2 (Frog)
-			{"vn_b_uniform_macv_03_01",				{-1, 0, 0,-1}},	//	BDU MACV 3 (Olive/ field)
-			{"vn_b_uniform_macv_03_02",				{-1, 0, 0,-1}},	//	BDU MACV 3 (Tiger)
-			{"vn_b_uniform_macv_03_05",				{-1, 0, 0,-1}},	//	BDU MACV 3 (Tiger green)
-			{"vn_b_uniform_macv_03_06",				{-1, 0, 0,-1}},	//	BDU MACV 3 (ERDL/brown)
-			{"vn_b_uniform_macv_03_07",				{-1, 0, 0,-1}},	//	BDU MACV 3 (Olive)
-			{"vn_b_uniform_macv_03_08",				{-1, 0, 0,-1}},	//	BDU MACV 3 (Leopard)
-			{"vn_b_uniform_macv_03_15",				{-1, 0, 0,-1}},	//	BDU MACV 3 (ERDL) ADDED
-			{"vn_b_uniform_macv_03_16",				{-1, 0, 0,-1}},	//	BDU RLA 3 (Lizard)
-			{"vn_b_uniform_macv_03_17",				{-1, 0, 0,-1}},	//	BDU ARVN 3 (BDQ)
-			{"vn_b_uniform_macv_03_18",				{-1, 0, 0,-1}},	//	BDU ROK 3 (Frog)
-			{"vn_b_uniform_macv_04_01",				{-1, 0, 0,-1}},	//	BDU MACV 4 (Olive/ field)
-			{"vn_b_uniform_macv_04_02",				{-1, 0, 0,-1}},	//	BDU MACV 4 (Tiger)
-			{"vn_b_uniform_macv_04_05",				{-1, 0, 0,-1}},	//	BDU MACV 4 (Tiger green)
-			{"vn_b_uniform_macv_04_06",				{-1, 0, 0,-1}},	//	BDU MACV 4 (ERDL/brown)
-			{"vn_b_uniform_macv_04_07",				{-1, 0, 0,-1}},	//	BDU MACV 4 (Olive)
-			{"vn_b_uniform_macv_04_08",				{-1, 0, 0,-1}},	//	BDU MACV 4 (Leopard)
-			{"vn_b_uniform_macv_04_15",				{-1, 0, 0,-1}},	//	BDU MACV 4 (ERDL)
-			{"vn_b_uniform_macv_04_16",				{-1, 0, 0,-1}},	//	BDU RLA 4 (Lizard)
-			{"vn_b_uniform_macv_04_17",				{-1, 0, 0,-1}},	//	BDU ARVN 4 (BDQ)
-			{"vn_b_uniform_macv_04_18",				{-1, 0, 0,-1}},	//	BDU ROK 4 (Frog)
-			{"vn_b_uniform_macv_04_20",				{-1, 0, 0,-1}},	//	BDU MACV 4 (Tiger/ base)
-			{"vn_b_uniform_macv_04_21",				{-1, 0, 0,-1}},	//	BDU MACV 4 (ERDL/ base)
-			{"vn_b_uniform_macv_05_01",				{-1, 0, 0,-1}},	//	BDU MACV 5 (Olive/ field)
-			{"vn_b_uniform_macv_05_02",				{-1, 0, 0,-1}},	//	BDU MACV 5 (Tiger)
-			{"vn_b_uniform_macv_05_05",				{-1, 0, 0,-1}},	//	BDU MACV 5 (Tiger green)
-			{"vn_b_uniform_macv_05_06",				{-1, 0, 0,-1}},	//	BDU MACV 5 (ERDL/brown)
-			{"vn_b_uniform_macv_05_07",				{-1, 0, 0,-1}},	//	BDU MACV 5 (Olive)
-			{"vn_b_uniform_macv_05_08",				{-1, 0, 0,-1}},	//	BDU MACV 5 (Leopard)
-			{"vn_b_uniform_macv_05_15",				{-1, 0, 0,-1}},	//	BDU MACV 5 (ERDL)
-			{"vn_b_uniform_macv_05_16",				{-1, 0, 0,-1}},	//	BDU RLA 5 (Lizard)
-			{"vn_b_uniform_macv_05_17",				{-1, 0, 0,-1}},	//	BDU ARVN 5 (BDQ)
-			{"vn_b_uniform_macv_05_18",				{-1, 0, 0,-1}},	//	BDU ROK 5 (Frog)
-			{"vn_b_uniform_macv_06_01",				{-1, 0, 0,-1}},	//	BDU MACV 6 (Olive/ field)
-			{"vn_b_uniform_macv_06_02",				{-1, 0, 0,-1}},	//	BDU MACV 6 (Tiger)
-			{"vn_b_uniform_macv_06_05",				{-1, 0, 0,-1}},	//	BDU MACV 6 (Tiger green)
-			{"vn_b_uniform_macv_06_06",				{-1, 0, 0,-1}},	//	BDU MACV 6 (ERDL/brown)
-			{"vn_b_uniform_macv_06_07",				{-1, 0, 0,-1}},	//	BDU MACV 6 (Olive)
-			{"vn_b_uniform_macv_06_08",				{-1, 0, 0,-1}},	//	BDU MACV 6 (Leopard)
-			{"vn_b_uniform_macv_06_15",				{-1, 0, 0,-1}},	//	BDU MACV 6 (ERDL) ADDED
-			{"vn_b_uniform_macv_06_16",				{-1, 0, 0,-1}},	//	BDU RLA 6 (Lizard)
-			{"vn_b_uniform_macv_06_17",				{-1, 0, 0,-1}},	//	BDU ARVN 6 (BDQ)
-			{"vn_b_uniform_macv_06_18",				{-1, 0, 0,-1}},	//	BDU ROK 6 (Frog)
-			{"vn_b_uniform_sog_01_01",				{-1, 0, 0,-1}},	//	BDU SOG 1 (Olive)
-			{"vn_b_uniform_sog_01_02",				{-1, 0, 0,-1}},	//	BDU SOG 1 (Tiger)
-			{"vn_b_uniform_sog_01_03",				{-1, 0, 0,-1}},	//	BDU SOG 1 (Black)
-			{"vn_b_uniform_sog_01_04",				{-1, 0, 0,-1}},	//	BDU SOG 1 (Spray)
-			{"vn_b_uniform_sog_01_05",				{-1, 0, 0,-1}},	//	BDU SOG 1 (Tiger/ black)
-			{"vn_b_uniform_sog_01_06",				{-1, 0, 0,-1}},	//	BDU SOG 1 (Spray/ black)
-			{"vn_b_uniform_sog_02_01",				{-1, 0, 0,-1}},	//	BDU SOG 2 (Olive)
-			{"vn_b_uniform_sog_02_02",				{-1, 0, 0,-1}},	//	BDU SOG 2 (Tiger)
-			{"vn_b_uniform_sog_02_03",				{-1, 0, 0,-1}},	//	BDU SOG 2 (Black)
-			{"vn_b_uniform_sog_02_04",				{-1, 0, 0,-1}},	//	BDU SOG 2 (Spray)
-			{"vn_b_uniform_sog_02_05",				{-1, 0, 0,-1}},	//	BDU SOG 2 (Tiger/ black)
-			{"vn_b_uniform_sog_02_06",				{-1, 0, 0,-1}},	//	BDU SOG 2 (Spray/black)
-			//Seal
-			{"vn_b_uniform_seal_01_06",				{-1, 0, 0,-1}},	//	Uniform SEAL 1 (ERDL)
-			{"vn_b_uniform_seal_01_01",				{-1, 0, 0,-1}},	//	Uniform SEAL 1 (Olive Dirty)
-			{"vn_b_uniform_seal_01_07",				{-1, 0, 0,-1}},	//	Uniform SEAL 1 (Olive)
-			{"vn_b_uniform_seal_01_05",				{-1, 0, 0,-1}},	//	Uniform SEAL 1 (Tiger Green)
-			{"vn_b_uniform_seal_01_02",				{-1, 0, 0,-1}},	//	Uniform SEAL 1 (Tiger)
-			{"vn_b_uniform_seal_02_06",				{-1, 0, 0,-1}},	//	Uniform SEAL 2 (ERDL)
-			{"vn_b_uniform_seal_02_01",				{-1, 0, 0,-1}},	//	Uniform SEAL 2 (Olive Dirty)
-			{"vn_b_uniform_seal_02_07",				{-1, 0, 0,-1}},	//	Uniform SEAL 2 (Olive)
-			{"vn_b_uniform_seal_02_05",				{-1, 0, 0,-1}},	//	Uniform SEAL 2 (Tiger Green)
-			{"vn_b_uniform_seal_02_02",				{-1, 0, 0,-1}},	//	Uniform SEAL 2 (Tiger)
-			{"vn_b_uniform_seal_03_01",				{-1, 0, 0,-1}},	//	Uniform SEAL 3 (Blue)
-			{"vn_b_uniform_seal_04_01",				{-1, 0, 0,-1}},	//	Uniform SEAL 4 (Blue)
-			{"vn_b_uniform_seal_05_06",				{-1, 0, 0,-1}},	//	Uniform SEAL 5 (ERDL)
-			{"vn_b_uniform_seal_05_01",				{-1, 0, 0,-1}},	//	Uniform SEAL 5 (Olive Dirty)
-			{"vn_b_uniform_seal_05_07",				{-1, 0, 0,-1}},	//	Uniform SEAL 5 (Olive)
-			{"vn_b_uniform_seal_05_05",				{-1, 0, 0,-1}},	//	Uniform SEAL 5 (Tiger Green)
-			{"vn_b_uniform_seal_05_02",				{-1, 0, 0,-1}},	//	Uniform SEAL 5 (Tiger)
-			{"vn_b_uniform_seal_06_06",				{-1, 0, 0,-1}},	//	Uniform SEAL 6 (ERDL)
-			{"vn_b_uniform_seal_06_01",				{-1, 0, 0,-1}},	//	Uniform SEAL 6 (Olive Dirty)
-			{"vn_b_uniform_seal_06_07",				{-1, 0, 0,-1}},	//	Uniform SEAL 6 (Olive)
-			{"vn_b_uniform_seal_06_05",				{-1, 0, 0,-1}},	//	Uniform SEAL 6 (Tiger Green)
-			{"vn_b_uniform_seal_06_02",				{-1, 0, 0,-1}},	//	Uniform SEAL 6 (Tiger)
-			{"vn_b_uniform_seal_07_01",				{-1, 0, 0,-1}},	//	Uniform UDT 1 (Blue/ Khaki)
-			{"vn_b_uniform_seal_07_02",				{-1, 0, 0,-1}},	//	Uniform UDT 1 (Blue/ Tiger)
-			{"vn_b_uniform_seal_07_03",				{-1, 0, 0,-1}},	//	Uniform UDT 1 (Yellow/ Khaki)
-			{"vn_b_uniform_seal_07_04",				{-1, 0, 0,-1}},	//	Uniform UDT 1 (Yellow/ Tiger)
-			{"vn_b_uniform_seal_08_01",				{-1, 0, 0,-1}},	//	Uniform UDT 2 (Blue/ Khaki)
-			{"vn_b_uniform_seal_08_02",				{-1, 0, 0,-1}},	//	Uniform UDT 2 (Blue/ Tiger)
-			{"vn_b_uniform_seal_08_03",				{-1, 0, 0,-1}},	//	Uniform UDT 2 ( Yellow/ Khaki)
-			{"vn_b_uniform_seal_08_04",				{-1, 0, 0,-1}},	//	Uniform UDT 2 ( Yellow/ Tiger)
-			{"vn_b_uniform_seal_09_01",				{-1, 0, 0,-1}},	//	Uniform UDT 3 (Beaver Wetsuit)
-			//Anzac
-			{"vn_b_uniform_aus_01_01",				{-1, 0, 0,-1}},	//	BDU AUS 1 (Olive)
-			{"vn_b_uniform_aus_02_01",				{-1, 0, 0,-1}},	//	BDU AUS 2 (Olive)
-			{"vn_b_uniform_aus_03_01",				{-1, 0, 0,-1}},	//	BDU AUS 3 (Olive)
-			{"vn_b_uniform_aus_04_01",				{-1, 0, 0,-1}},	//	BDU AUS 4 (Olive)
-			{"vn_b_uniform_aus_05_01",				{-1, 0, 0,-1}},	//	BDU AUS 5 (Olive)
-			{"vn_b_uniform_aus_06_01",				{-1, 0, 0,-1}},	//	BDU AUS 6 (Olive)
-			{"vn_b_uniform_aus_07_01",				{-1, 0, 0,-1}},	//	BDU AUS 7 (Olive)
-			{"vn_b_uniform_aus_08_01",				{-1, 0, 0,-1}},	//	BDU AUS 8 (Olive)
-			{"vn_b_uniform_aus_09_01",				{-1, 0, 0,-1}},	//	BDU AUS 9 (Olive)
-			{"vn_b_uniform_aus_10_01",				{-1, 0, 0,-1}},	//	BDU AUS 10 (Olive)
-			{"vn_b_uniform_nz_01_01",				{-1, 0, 0,-1}},	//	BDU NZ 1 (Olive)
-			{"vn_b_uniform_nz_02_01",				{-1, 0, 0,-1}},	//	BDU NZ 2 (Olive)
-			{"vn_b_uniform_nz_03_01",				{-1, 0, 0,-1}},	//	BDU NZ 3 (Olive)
-			{"vn_b_uniform_nz_04_01",				{-1, 0, 0,-1}},	//	BDU NZ 4 (Olive)
-			{"vn_b_uniform_nz_05_01",				{-1, 0, 0,-1}},	//	BDU NZ 5 (Olive)
-			{"vn_b_uniform_nz_06_01",				{-1, 0, 0,-1}},	//	BDU NZ 6 (Olive)
-			{"vn_b_uniform_sas_01_06",				{-1, 0, 0,-1}},	//	BDU SAS 1 (ERDL)
-			{"vn_b_uniform_sas_02_06",				{-1, 0, 0,-1}},	//	BDU SAS 2 (ERDL)
-			{"vn_b_uniform_sas_03_06",				{-1, 0, 0,-1}},	//	BDU SAS 3 (ERDL)
-			//NVA Infantry Uniforms
-			{"vn_o_uniform_nva_air_01",				{ 0,-1,-1,-1}},	//	PAVN Pilot Uniform
-			{"vn_o_uniform_nva_army_01_01",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 1
-			{"vn_o_uniform_nva_army_01_02",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 1 (Field)
-			{"vn_o_uniform_nva_army_01_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 1
-			{"vn_o_uniform_nva_army_01_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 1 (Field)
-			{"vn_o_uniform_nva_army_02_01",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 2
-			{"vn_o_uniform_nva_army_02_02",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 2 (Field)
-			{"vn_o_uniform_nva_army_02_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 2
-			{"vn_o_uniform_nva_army_02_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 2 (Field)
-			{"vn_o_uniform_nva_army_03_01",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 3
-			{"vn_o_uniform_nva_army_03_02",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 3 (Field)
-			{"vn_o_uniform_nva_army_03_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 3
-			{"vn_o_uniform_nva_army_03_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 3 (Field)
-			{"vn_o_uniform_nva_army_04_01",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 4
-			{"vn_o_uniform_nva_army_04_02",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 4 (Field)
-			{"vn_o_uniform_nva_army_04_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 4
-			{"vn_o_uniform_nva_army_04_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 4 (Field)
-			{"vn_o_uniform_nva_army_05_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 5
-			{"vn_o_uniform_nva_army_05_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 5 (Field)
-			{"vn_o_uniform_nva_army_06_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 6
-			{"vn_o_uniform_nva_army_06_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 6 (Field)
-			{"vn_o_uniform_nva_army_07_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 7
-			{"vn_o_uniform_nva_army_07_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 7 (Field)
-			{"vn_o_uniform_nva_army_08_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 8
-			{"vn_o_uniform_nva_army_08_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 8 (Field)
-			{"vn_o_uniform_nva_army_09_01",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 9
-			{"vn_o_uniform_nva_army_09_02",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 9 (Field)
-			{"vn_o_uniform_nva_army_09_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 9
-			{"vn_o_uniform_nva_army_09_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 9 (Field)
-			{"vn_o_uniform_nva_army_10_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 10
-			{"vn_o_uniform_nva_army_10_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 10 (Field)
-			{"vn_o_uniform_nva_army_11_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 11
-			{"vn_o_uniform_nva_army_11_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 11 (Field)
-			{"vn_o_uniform_nva_army_12_01",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 12
-			{"vn_o_uniform_nva_army_12_02",			{ 0,-1,-1,-1}},	//	NVA 65 Uniform 12 (Field)
-			{"vn_o_uniform_nva_army_12_03",			{ 0,-1,-1,-1}},	//	NVA Uniform 12
-			{"vn_o_uniform_nva_army_12_04",			{ 0,-1,-1,-1}},	//	NVA Uniform 12 (Field)
-			{"vn_o_uniform_nva_dc_13_02",			{ 0,-1,-1,-1}},	//	NVA Dac Cong Uniform 1 (Tan)
-			{"vn_o_uniform_nva_dc_13_04",			{ 0,-1,-1,-1}},	//	NVA Dac Cong Uniform 1 (Green)
-			{"vn_o_uniform_nva_dc_13_07",			{ 0,-1,-1,-1}},	//	NVA Dac Cong Uniform 1 (Black)
-			{"vn_o_uniform_nva_dc_13_08",			{ 0,-1,-1,-1}},	//	NVA Dac Cong Uniform 1 (Blue)
-			{"vn_o_uniform_nva_dc_14_01",			{ 0,-1,-1,-1}},	//	NVA Dac Cong Uniform 2 (Black)
-			{"vn_o_uniform_nva_dc_14_04",			{ 0,-1,-1,-1}},	//	NVA Dac Cong Uniform 2 (Blue)
-			{"vn_o_uniform_nva_navy_01",			{ 0,-1,-1,-1}},	//	VPN Marines Uniform 1
-			{"vn_o_uniform_nva_navy_02",			{ 0,-1,-1,-1}},	//	VPN Marines Uniform 2
-			{"vn_o_uniform_nva_navy_03",			{ 0,-1,-1,-1}},	//	VPN Navy Uniform 1
-			{"vn_o_uniform_nva_navy_04",			{ 0,-1,-1,-1}},	//	VPN Navy Uniform 2
-			//VC Uniforms
-			{"vn_o_uniform_vc_01_01",				{ 0,-1,-1,-1}},	//	VC Uniform 1 (Black)
-			{"vn_o_uniform_vc_01_02",				{ 0,-1,-1,-1}},	//	VC Uniform 1 (Black/ white)
-			{"vn_o_uniform_vc_01_03",				{ 0,-1,-1,-1}},	//	VC Uniform 1 (Grey/ tan)
-			{"vn_o_uniform_vc_01_04",				{ 0,-1,-1,-1}},	//	VC Uniform 1 (Blue)
-			{"vn_o_uniform_vc_01_05",				{ 0,-1,-1,-1}},	//	VC Uniform 1 (White/ black)
-			{"vn_o_uniform_vc_01_06",				{ 0,-1,-1,-1}},	//	VC Uniform 1 (Blue/ white)
-			{"vn_o_uniform_vc_01_07",				{ 0,-1,-1,-1}},	//	VC Uniform 1 (Blue/ grey)
-			{"vn_o_uniform_vc_02_01",				{ 0,-1,-1,-1}},	//	VC Uniform 2 (Black)
-			{"vn_o_uniform_vc_02_02",				{ 0,-1,-1,-1}},	//	VC Uniform 2 (Black/ white)
-			{"vn_o_uniform_vc_02_03",				{ 0,-1,-1,-1}},	//	VC Uniform 2 (Grey/ tan)
-			{"vn_o_uniform_vc_02_04",				{ 0,-1,-1,-1}},	//	VC Uniform 2 (Blue)
-			{"vn_o_uniform_vc_02_05",				{ 0,-1,-1,-1}},	//	VC Uniform 2 (White/ black)
-			{"vn_o_uniform_vc_02_06",				{ 0,-1,-1,-1}},	//	VC Uniform 2 (Blue/ white)
-			{"vn_o_uniform_vc_02_07",				{ 0,-1,-1,-1}},	//	VC Uniform 2 (Blue/ grey)
-			{"vn_o_uniform_vc_03_01",				{ 0,-1,-1,-1}},	//	VC Uniform 3 (Black)
-			{"vn_o_uniform_vc_03_02",				{ 0,-1,-1,-1}},	//	VC Uniform 3 (Black/ white)
-			{"vn_o_uniform_vc_03_03",				{ 0,-1,-1,-1}},	//	VC Uniform 3 (Grey/ tan)
-			{"vn_o_uniform_vc_03_04",				{ 0,-1,-1,-1}},	//	VC Uniform 3 (Blue)
-			{"vn_o_uniform_vc_03_05",				{ 0,-1,-1,-1}},	//	VC Uniform 3 (White/ black)
-			{"vn_o_uniform_vc_03_06",				{ 0,-1,-1,-1}},	//	VC Uniform 3 (Blue/ white)
-			{"vn_o_uniform_vc_03_07",				{ 0,-1,-1,-1}},	//	VC Uniform 3 (Blue/ grey)
-			{"vn_o_uniform_vc_04_01",				{ 0,-1,-1,-1}},	//	VC Uniform 4 (Black)
-			{"vn_o_uniform_vc_04_02",				{ 0,-1,-1,-1}},	//	VC Uniform 4 (Black/ white)
-			{"vn_o_uniform_vc_04_03",				{ 0,-1,-1,-1}},	//	VC Uniform 4 (Grey/tan)
-			{"vn_o_uniform_vc_04_04",				{ 0,-1,-1,-1}},	//	VC Uniform 4 (Blue)
-			{"vn_o_uniform_vc_04_05",				{ 0,-1,-1,-1}},	//	VC Uniform 4 (White/black)
-			{"vn_o_uniform_vc_04_06",				{ 0,-1,-1,-1}},	//	VC Uniform 4 (Blue/ white)
-			{"vn_o_uniform_vc_04_07",				{ 0,-1,-1,-1}},	//	VC Uniform 4 (Blue/ grey)
-			{"vn_o_uniform_vc_05_01",				{ 0,-1,-1,-1}},	//	VC Uniform 5 (Black)
-			{"vn_o_uniform_vc_05_02",				{ 0,-1,-1,-1}},	//	VC Uniform 5 (White)
-			{"vn_o_uniform_vc_05_03",				{ 0,-1,-1,-1}},	//	VC Uniform 5 (Grey)
-			{"vn_o_uniform_vc_05_04",				{ 0,-1,-1,-1}},	//	VC Uniform 5 (Blue)
-			{"vn_o_uniform_vc_mf_01_07",			{ 0,-1,-1,-1}},	//	VC Uniform 1
-			{"vn_o_uniform_vc_mf_02_07",			{ 0,-1,-1,-1}},	//	VC Uniform 2
-			{"vn_o_uniform_vc_mf_03_07",			{ 0,-1,-1,-1}},	//	VC Uniform 3
-			{"vn_o_uniform_vc_mf_04_07",			{ 0,-1,-1,-1}},	//	VC Uniform 4
-			{"vn_o_uniform_vc_mf_09_07",			{ 0,-1,-1,-1}},	//	VC Uniform 9
-			{"vn_o_uniform_vc_mf_10_07",			{ 0,-1,-1,-1}},	//	VC Uniform 10
-			{"vn_o_uniform_vc_mf_11_07",			{ 0,-1,-1,-1}},	//	VC Uniform 11
-			{"vn_o_uniform_vc_mf_12_07",			{ 0,-1,-1,-1}},	//	VC Uniform 12
-			{"vn_o_uniform_vc_reg_11_08",			{ 0,-1,-1,-1}},	//	VC Uniform 11 (Blue)
-			{"vn_o_uniform_vc_reg_11_09",			{ 0,-1,-1,-1}},	//	VC Uniform 11 (Blue/ tan)
-			{"vn_o_uniform_vc_reg_11_10",			{ 0,-1,-1,-1}},	//	VC Uniform 11 (Tan/ black)
-			{"vn_o_uniform_vc_reg_12_08",			{ 0,-1,-1,-1}},	//	VC Uniform 12 (Blue)
-			{"vn_o_uniform_vc_reg_12_09",			{ 0,-1,-1,-1}},	//	VC Uniform 12 (Blue/ tan)
-			{"vn_o_uniform_vc_reg_12_10",			{ 0,-1,-1,-1}},	//	VC Uniform 12 (Tan/ black)
-			{"vn_o_uniform_pl_army_01_11",			{ 0,-1,-1,-1}},	//	PL Uniform 1 (Dark)
-			{"vn_o_uniform_pl_army_01_12",			{ 0,-1,-1,-1}},	//	PL Uniform 1 (Dark/ Field)
-			{"vn_o_uniform_pl_army_01_13",			{ 0,-1,-1,-1}},	//	PL Uniform 1 (Light)
-			{"vn_o_uniform_pl_army_01_14",			{ 0,-1,-1,-1}},	//	PL Uniform 1 (Light/ Field)
-			{"vn_o_uniform_pl_army_02_11",			{ 0,-1,-1,-1}},	//	PL Uniform 2 (Dark)
-			{"vn_o_uniform_pl_army_02_12",			{ 0,-1,-1,-1}},	//	PL Uniform 2 (Dark/ Field)
-			{"vn_o_uniform_pl_army_02_13",			{ 0,-1,-1,-1}},	//	PL Uniform 2 (Light)
-			{"vn_o_uniform_pl_army_02_14",			{ 0,-1,-1,-1}},	//	PL Uniform 2 (Light/ Field)
-			{"vn_o_uniform_pl_army_03_11",			{ 0,-1,-1,-1}},	//	PL Uniform 3 (Dark)
-			{"vn_o_uniform_pl_army_03_12",			{ 0,-1,-1,-1}},	//	PL Uniform 3 (Dark/ Field)
-			{"vn_o_uniform_pl_army_03_13",			{ 0,-1,-1,-1}},	//	PL Uniform 3 (Light)
-			{"vn_o_uniform_pl_army_03_14",			{ 0,-1,-1,-1}},	//	PL Uniform 3 (Light/ Field)
-			{"vn_o_uniform_pl_army_04_11",			{ 0,-1,-1,-1}},	//	PL Uniform 4 (Dark)
-			{"vn_o_uniform_pl_army_04_12",			{ 0,-1,-1,-1}},	//	PL Uniform 4 (Dark/ Field)
-			{"vn_o_uniform_pl_army_04_13",			{ 0,-1,-1,-1}},	//	PL Uniform 4 (Light)
-			{"vn_o_uniform_pl_army_04_14",			{ 0,-1,-1,-1}},	//	PL Uniform 4 (Light/ Field)
-			//Vests
-			//US Vests
-			{"vn_b_vest_aircrew_01",				{-1, 0, 0,-1}},	//	Vest - Aircrew
-			{"vn_b_vest_aircrew_02",				{-1, 0, 0,-1}},	//	Vest - USAF (Pilot)
-			{"vn_b_vest_aircrew_03",				{-1, 0, 0,-1}},	//	Vest - Army (Pilot)
-			{"vn_b_vest_aircrew_04",				{-1, 0, 0,-1}},	//	Vest - USAF (Pilot/ holster)
-			{"vn_b_vest_aircrew_05",				{-1, 0, 0,-1}},	//	Vest - Army (Pilot/ holster)
-			{"vn_b_vest_aircrew_06",				{-1, 0, 0,-1}},	//	Vest - USAF (Pilot/ camo)
-			{"vn_b_vest_aircrew_07",				{-1, 0, 0,-1}},	//	Vest - USSF (Pilot/ camo/ holster)
-			{"vn_b_vest_sog_01",					{-1, 0, 0,-1}},	//	Vest - SOG (One-Zero TL)
-			{"vn_b_vest_sog_02",					{-1, 0, 0,-1}},	//	Vest - SOG (One-Two Medic)
-			{"vn_b_vest_sog_03",					{-1, 0, 0,-1}},	//	Vest - SOG (Demolitions)
-			{"vn_b_vest_sog_04",					{-1, 0, 0,-1}},	//	Vest - SOG (Scout)
-			{"vn_b_vest_sog_05",					{-1, 0, 0,-1}},	//	Vest - SOG (MG)
-			{"vn_b_vest_sog_06",					{-1, 0, 0,-1}},	//	Vest - SOG (One-One RTO)
-			{"vn_b_vest_usarmy_01",					{-1, 0, 0,-1}},	//	Vest - Army (Sentry)
-			{"vn_b_vest_usarmy_02",					{-1, 0, 0,-1}},	//	Vest - Army (Rifleman 01)
-			{"vn_b_vest_usarmy_03",					{-1, 0, 0,-1}},	//	Vest - Army (Rifleman 02)
-			{"vn_b_vest_usarmy_04",					{-1, 0, 0,-1}},	//	Vest - Army (Scout)
-			{"vn_b_vest_usarmy_05",					{-1, 0, 0,-1}},	//	Vest - Army (Grenadier)
-			{"vn_b_vest_usarmy_06",					{-1, 0, 0,-1}},	//	Vest - Army (MG)
-			{"vn_b_vest_usarmy_07",					{-1, 0, 0,-1}},	//	Vest - Army (Medic)
-			{"vn_b_vest_usarmy_08",					{-1, 0, 0,-1}},	//	Vest - Army (Marksman)
-			{"vn_b_vest_usarmy_09",					{-1, 0, 0,-1}},	//	Vest - Army (Officer)
-			{"vn_b_vest_usarmy_10",					{-1, 0, 0,-1}},	//	Vest - Army (Crewman)
-			{"vn_b_vest_usarmy_11",					{-1, 0, 0,-1}},	//	Vest - Army (Crewman M1952A holster)
-			{"vn_b_vest_usarmy_12",					{-1, 0, 0,-1}},	//	Vest - Army (Crewman M1952A)
-			{"vn_b_vest_usarmy_13",					{-1, 0, 0,-1}},	//	Vest - Army (Crewman M69 holster)
-			{"vn_b_vest_usarmy_14",					{-1, 0, 0,-1}},	//	Vest - Army (Crewman M69)
-			{"vn_b_vest_seal_01",					{-1, 0, 0,-1}},	//	Vest - SEAL (diver)
-			{"vn_b_vest_seal_02",					{-1, 0, 0,-1}},	//	Vest - SEAL (TL)
-			{"vn_b_vest_seal_03",					{-1, 0, 0,-1}},	//	Vest - SEAL (MG)
-			{"vn_b_vest_seal_04",					{-1, 0, 0,-1}},	//	Vest - SEAL (Rifleman)
-			{"vn_b_vest_seal_05",					{-1, 0, 0,-1}},	//	Vest - SEAL (Scout)
-			{"vn_b_vest_seal_06",					{-1, 0, 0,-1}},	//	Vest - SEAL (Medic)
-			{"vn_b_vest_seal_07",					{-1, 0, 0,-1}},	//	Vest - SEAL (Grenadier)
-			{"vn_b_vest_usmc_01",					{-1, 0, 0,-1}},	//	Vest - USMC (Rifleman 01)
-			{"vn_b_vest_usmc_02",					{-1, 0, 0,-1}},	//	Vest - USMC (Rifleman 02)
-			{"vn_b_vest_usmc_03",					{-1, 0, 0,-1}},	//	Vest - USMC (MG)
-			{"vn_b_vest_usmc_04",					{-1, 0, 0,-1}},	//	Vest - USMC (Grenadier)
-			{"vn_b_vest_usmc_05",					{-1, 0, 0,-1}},	//	Vest - USMC (Corpsman)
-			{"vn_b_vest_usmc_06",					{-1, 0, 0,-1}},	//	Vest - USMC (Officer)
-			{"vn_b_vest_usmc_07",					{-1, 0, 0,-1}},	//	Vest - USMC (Rifleman/ recon)
-			{"vn_b_vest_usmc_08",					{-1, 0, 0,-1}},	//	Vest - USMC (MG/ recon)
-			{"vn_b_vest_usmc_09",					{-1, 0, 0,-1}},	//	Vest - USMC (Grenadier/ recon)
-			//Anzac
-			{"vn_b_vest_anzac_01",					{-1, 0, 0,-1}}, 	// 	Vest - ANZAC (Rifleman 01)
-			{"vn_b_vest_anzac_02",					{-1, 0, 0,-1}},	//	Vest - ANZAC (Rifleman 02)
-			{"vn_b_vest_anzac_03",					{-1, 0, 0,-1}},	//	Vest - ANZAC (Scout)
-			{"vn_b_vest_anzac_04",					{-1, 0, 0,-1}},	//	Vest - ANZAC (Grenadier)
-			{"vn_b_vest_anzac_05",					{-1, 0, 0,-1}},	//	Vest - ANZAC (MG)
-			{"vn_b_vest_anzac_06",					{-1, 0, 0,-1}},	//	Vest - ANZAC (Medic)
-			{"vn_b_vest_anzac_07",					{-1, 0, 0,-1}},	//	Vest - ANZAC (Officer)
-			{"vn_b_vest_anzac_08",					{-1, 0, 0,-1}},	//	Vest - ANZAC (Pilot M1952A)
-			{"vn_b_vest_anzac_09",					{-1, 0, 0,-1}},	//	Vest - ANZAC (Crewman M1952A)
-			{"vn_b_vest_anzac_10",					{-1, 0, 0,-1}},	//	Vest - ANZAC (Crewman)
-			{"vn_b_vest_sas_01",					{-1, 0, 0,-1}},	//	Vest - SAS (Scout)
-			{"vn_b_vest_sas_02",					{-1, 0, 0,-1}},	//	Vest - SAS (Grenadier)
-			{"vn_b_vest_sas_03",					{-1, 0, 0,-1}},	//	Vest - SAS (MG)
-			{"vn_b_vest_sas_04",					{-1, 0, 0,-1}},	//	Vest - SAS (Patrol Commander)
-			//NVA Vests
-			{"vn_o_vest_01",						{ 0,-1, 0,-1}},	//	Vest - NVA (Assault)
-			{"vn_o_vest_02",						{ 0,-1, 0,-1}},	//	Vest - NVA (Rifle)
-			{"vn_o_vest_03",						{ 0,-1, 0,-1}},	//	Vest - NVA (MG)
-			{"vn_o_vest_04",						{ 0,-1, 0,-1}},	//	Vest - VPN
-			{"vn_o_vest_05",						{ 0,-1, 0,-1}},	//	Vest - VPN (Holster)
-			{"vn_o_vest_06",						{ 0,-1, 0,-1}},	//	Vest - NVA (Medic)
-			{"vn_o_vest_07",						{ 0,-1, 0,-1}},	//	Vest - NVA (Officer)
-			{"vn_o_vest_08",						{ 0,-1, 0,-1}},	//	Vest - NVA (Sapper)
-			//VC Vests
-			{"vn_o_vest_vc_01",						{ 0,-1, 0,-1}},	//	Vest - VC (Assault)
-			{"vn_o_vest_vc_02",						{ 0,-1, 0,-1}},	//	Vest - VC (Rifle)
-			{"vn_o_vest_vc_03",						{ 0,-1, 0,-1}},	//	Vest - VC (MG)
-			{"vn_o_vest_vc_04",						{ 0,-1, 0,-1}},	//	Vest - VC (Medic)
-			{"vn_o_vest_vc_05",						{ 0,-1, 0,-1}},	//	Vest - VC (Leader)
-		};
-		backpacks[] =
-		{
-			//Blufor
-			{"B_Parachute",							{ 0, 0, 0,-1}},	//	ARMA3 Steerable
-			{"vn_b_pack_01",						{-1, 0, 0,-1}},	//	SOG (CISO)
-			{"vn_b_pack_01_02",						{-1, 0, 0,-1}},	//	CIDG (CISO)
-			{"vn_b_pack_02",						{-1, 0, 0,-1}},	//	SOG (CISO MG)
-			{"vn_b_pack_02_02",						{-1, 0, 0,-1}},	//	CIDG (CISO MG)
-			{"vn_b_pack_03",						{-1, 0, 0,-1}},	//	SOG (CISO RTO)
-			{"vn_b_pack_03_02",						{-1, 0, 0,-1}},	//	CIDG (CISO RTO)
-			{"vn_b_pack_04",						{-1, 0, 0,-1}},	//	SOG (CISO Scout)
-			{"vn_b_pack_04_02",						{-1, 0, 0,-1}},	//	CIDG (CISO Scout)
-			{"vn_b_pack_05",						{-1, 0, 0,-1}},	//	SOG (CISO Demo)
-			{"vn_b_pack_05_02",						{-1, 0, 0,-1}},	//	CIDG (CISO Demo)
-			{"vn_b_pack_lw_01",						{-1, 0, 0,-1}},	//	Army (Rifleman)
-			{"vn_b_pack_lw_02",						{-1, 0, 0,-1}},	//	Army (MG)
-			{"vn_b_pack_lw_03",						{-1, 0, 0,-1}},	//	Army (Scout)
-			{"vn_b_pack_lw_04",						{-1, 0, 0,-1}},	//	Army (Engineer)
-			{"vn_b_pack_lw_05",						{-1, 0, 0,-1}},	//	Army (MG Ammo)
-			{"vn_b_pack_lw_06",						{-1, 0, 0,-1}},	//	Army (RTO 2)
-			{"vn_b_pack_lw_07",						{-1, 0, 0,-1}},	//	Army (Medic)
-			{"vn_b_pack_m5_01",						{-1, 0, 0,-1}},	//	Army (Medic M5)
-			{"vn_b_pack_prc77_01",					{-1, 0, 0,-1}},	//	Army (RTO)
-			{"vn_b_pack_trp_01",					{-1, 0, 0,-1}},	//	SOG (Tropical MG)
-			{"vn_b_pack_trp_01_02",					{-1, 0, 0,-1}},	//	Army (Tropical MG)
-			{"vn_b_pack_trp_02",					{-1, 0, 0,-1}},	//	SOG (Tropical)
-			{"vn_b_pack_trp_02_02",					{-1, 0, 0,-1}},	//	Army (Tropical)
-			{"vn_b_pack_trp_03",					{-1, 0, 0,-1}},	//	SOG (Tropical Demo)
-			{"vn_b_pack_trp_03_02",					{-1, 0, 0,-1}},	//	Army (Tropical Demo)
-			{"vn_b_pack_trp_04",					{-1, 0, 0,-1}},	//	SOG (Tropical RTO)
-			{"vn_b_pack_trp_04_02",					{-1, 0, 0,-1}},	//	Army (Tropical RTO)
-			{"vn_b_pack_seal_01",					{-1,-1,-1,-1}},	//	SEAL (Diver) removed due to non protection under water
-			{"vn_b_pack_p08_01",					{-1, 0, 0,-1}},	//	ANZAC (P08 1)
-			{"vn_b_pack_p08_02",					{-1, 0, 0,-1}},	//	ANZAC (P08 2)
-			{"vn_b_pack_p08_03",					{-1, 0, 0,-1}},	//	ANZAC (P08 3)
-			{"vn_b_pack_p44_01",					{-1, 0, 0,-1}},	//	ANZAC (P44 1)
-			{"vn_b_pack_p44_02",					{-1, 0, 0,-1}},	//	ANZAC (P44 2)
-			{"vn_b_pack_p44_03",					{-1, 0, 0,-1}},	//	ANZAC (P44 3)
-			{"vn_b_pack_pfield_01",					{-1, 0, 0,-1}},	//	ANZAC (Field 1)
-			{"vn_b_pack_pfield_02",					{-1, 0, 0,-1}},	//	ANZAC (Field 2)
-			{"vn_b_pack_ba18_01",					{-1, 0, 0,-1}},	//	Parachute (BA18)
-			{"vn_b_pack_ba22_01",					{-1, 0, 0,-1}},	//	Parachute (BA22)
-			{"vn_b_pack_t10_01",					{ 0, 0, 0, 0}},	//	Parachute (T10) OPEN TO ALL
-			{"vn_b_pack_m41_01",					{-1, 0, 0,-1}},	//	USMC (M41 1)
-			{"vn_b_pack_m41_02",					{-1, 0, 0,-1}},	//	USMC (M41 2)
-			{"vn_b_pack_m41_03",					{-1, 0, 0,-1}},	//	USMC (M41 3)
-			{"vn_b_pack_m41_04",					{-1, 0, 0,-1}},	//	USMC (M41 4)
-			{"vn_b_pack_m41_05",					{-1, 0, 0,-1}},	//	USMC (M41 RTO)
-			{"vn_b_pack_arvn_01",					{-1, 0, 0,-1}},	//	ARVN 1
-			{"vn_b_pack_arvn_02",					{-1, 0, 0,-1}},	//	ARVN 2
-			{"vn_b_pack_arvn_03",					{-1, 0, 0,-1}},	//	ARVN 3
-			{"vn_b_pack_arvn_04",					{-1, 0, 0,-1}},	//	ARVN 4
-			//Blufor Static Backpacks
-			{"vn_b_pack_static_ammo_01",			{-1, 0, 0,-1}},	//	ARMY (Ammo Resupply)
-			{"vn_b_pack_static_base_01",			{-1, 0, 0,-1}},	//	ARMY (Weapon Base)
-			{"vn_b_pack_static_tow",				{-1, 0, 0,-1}},	//	ARMY (BGM-71 TOW) ADDED
-			{"vn_b_pack_static_m1919a4_high_01",	{-1, 0, 0,-1}},	//	ARMY (M1919A4 high)
-			{"vn_b_pack_static_m1919a4_low_01",		{-1, 0, 0,-1}},	//	ARMY (M1919A4 low)
-			{"vn_b_pack_static_m1919a6_01",			{-1, 0, 0,-1}},	//	ARMY (M1919A6)
-			{"vn_b_pack_static_m29_01",				{-1,-1,-1,-1}},	//	ARMY (M29 Mortar 81mm) BLACKLIST
-			{"vn_b_pack_static_m2_01",				{-1,-1,-1,-1}},	//	ARMY (M2 Mortar 60mm) BLACKLIST
-			{"vn_b_pack_static_m2_high_01",			{-1, 0, 0,-1}},	//	ARMY(M2 high)
-			{"vn_b_pack_static_m2_low_01",			{-1, 0, 0,-1}},	//	ARMY(M2 low)
-			{"vn_b_pack_static_m60_high_01",		{-1, 0, 0,-1}},	//	ARMY (M60 high)
-			{"vn_b_pack_static_m60_low_01",			{-1, 0, 0,-1}},	//	ARMY (M60 low)
-			{"vn_b_pack_static_mk18",				{-1, 0, 0,-1}},	//	ARMY (MK18)
-			{"vn_b_pack_static_m2_scoped_high_01",	{-1, 0, 0,-1}},	//	ARMY(M2 Scoped high)
-			{"vn_b_pack_static_m2_scoped_low_01",	{-1, 0, 0,-1}},	//	ARMY(M2 Scoped low)
-			//OpFor
-			{"vn_c_pack_01",						{ 0,-1, 0,-1}},	//	Pack (Basket)
-			{"vn_c_pack_02",						{ 0,-1, 0,-1}},	//	Pack (Ganh Hang Rong)
-			{"vn_o_pack_01",						{ 0,-1, 0,-1}},	//	NVA 1
-			{"vn_o_pack_02",						{ 0,-1, 0,-1}},	//	NVA 2
-			{"vn_o_pack_03",						{ 0,-1, 0,-1}},	//	NVA (RPG)
-			{"vn_o_pack_04",						{ 0,-1, 0,-1}},	//	NVA (Assault)
-			{"vn_o_pack_05",						{ 0,-1, 0,-1}},	//	NVA (Sapper)
-			{"vn_o_pack_06",						{ 0,-1, 0,-1}},	//	NVA (Recon)
-			{"vn_o_pack_07",						{ 0,-1, 0,-1}},	//	NVA (Recon/RPG)
-			{"vn_o_pack_08",						{ 0,-1, 0,-1}},	//	NVA (Mortar Ammo)
-			{"vn_o_pack_t884_01",					{ 0,-1, 0,-1}},	//	NVA T884 Radio
-			{"vn_i_pack_parachute_01",				{-1,-1,-1,-1}},	//	Parachute (Independant) BLACKLIST
-			{"vn_o_pack_parachute_01",				{ 0,-1, 0,-1}},	//	Parachute (Opfor)
-			//Opfor Static Backpacks
-			{"vn_o_pack_static_ammo_01",			{ 0,-1, 0,-1}},	//	NVA (Ammo Resupply) ??
-			{"vn_o_pack_static_base_01",			{ 0,-1, 0,-1}},	//	NVA (Weapon Base)
-			{"vn_o_pack_static_dp28_01",			{ 0,-1, 0,-1}},	//	NVA (DP27)
-			{"vn_o_pack_static_dshkm_high_01",		{ 0,-1, 0,-1}},	//	NVA (DShKM high)
-			{"vn_o_pack_static_dshkm_high_02",		{ 0,-1, 0,-1}},	//	NVA (DShKM AA)
-			{"vn_o_pack_static_dshkm_low_01",		{ 0,-1, 0,-1}},	//	NVA (DShKM Armour)
-			{"vn_o_pack_static_dshkm_low_02",		{ 0,-1, 0,-1}},	//	NVA (DShKM low)
-			{"vn_o_pack_static_rpd_01",				{ 0,-1, 0,-1}},	//	NVA (RPD)
-			{"vn_o_pack_static_type53_01",			{ 0,-1, 0,-1}},	//	NVA (Type 53 Mortar)
-			{"vn_o_pack_static_type63_01",			{ 0,-1, 0,-1}},	//	NVA (Type 63 Mortar)
-			{"vn_o_pack_static_at3_01",				{ 0,-1, 0,-1}},	//	NVA (AT-3) ADDED
-			{"vn_o_pack_static_pk_high_01",			{ 0,-1, 0,-1}},	//	NVA (PK high) ADDED
-			{"vn_o_pack_static_pk_low_01",			{ 0,-1, 0,-1}},	//	NVA (PK low) ADDED
-			{"vn_o_pack_static_sgm_low_01",			{ 0,-1, 0,-1}},	//	NVA (SGM low,shield)
-			{"vn_o_pack_static_sgm_low_02",			{ 0,-1, 0,-1}},	//	NVA (SGM low)
-			{"vn_o_pack_static_sgm_high_01",		{ 0,-1, 0,-1}},	//	NVA (SGM high)
-			{"vn_o_pack_static_mg42_low",			{ 0,-1, 0,-1}},	//	NVA (MG42 high)
-			{"vn_o_pack_static_mg42_high",			{ 0,-1, 0,-1}},	//	NVA (MG42 low)
-			{"vn_o_pack_static_m1910_low_01",		{ 0,-1, 0,-1}},	//	NVA (M1910 low,shield)
-			{"vn_o_pack_static_m1910_low_02",		{ 0,-1, 0,-1}},	//	NVA (M1910 low)
-			{"vn_o_pack_static_m1910_high_01",		{ 0,-1, 0,-1}},	//	NVA (M1910 high)
-			{"vn_o_pack_static_type56rr_01",		{ 0,-1, 0,-1}},	//	NVA (Type 56 Recoilless)
-		};
-		vehicles[] =
-		{
+weapons[] = {
+/*
+    // Nickel Steel
+    // Weapons
+    {"vnx_m77e",                {-1, 0, 0, 0}},     // Model 77E 12 gauge Shotgun, 5-round mag
+    {"vnx_m77e_shorty",         {-1, 0, 0, 0}},     // Model 77E Sawn-off 12 gauge Shotgun, 5-round mag
+    {"vnx_fm2429",              {0, 0, 0, 0}},      // FM24/29 7.5x54mm selective-fire LMG
+    {"vnx_fm2429_aa",           {0, 0, 0, 0}},      // FM24/29 7.5x54mm selective-fire LMG, AA sight
+    {"vnx_gjet",                {-1, 0, 0, 0}},     // G-Jet rocket pistol, 6-round mag
+    {"vnx_hd_02",               {0, 0, 0, 0}},      // HD pistol, .22LR caliber, 10-round mag
+    {"vnx_l1a1_04",             {-1, 0, 0, 0}},     // L1A1 (shorty) 7.62mm Rifle
+    {"vnx_l1a1_04_camo",        {-1, 0, 0, 0}},     // L1A1 shorty 7.62mm Rifle, with camo paint
+    {"vnx_l1a1_05",             {-1, 0, 0, 0}},     // SAS L1A1 (shorty) 7.62mm Rifle, fitted with foregrip
+    {"vnx_l1a1_05_camo",        {-1, 0, 0, 0}},     // SAS L1A1 shorty 7.62mm Rifle, fitted with foregrip and camo paint
+    {"vnx_m12_smg",             {-1, 0, 0, 0}},     // M12 9mm Submachinegun. Italian SMG with folding stock
+    {"vnx_m12_smg_fold",        {-1, 0, 0, 0}},     // M12 9mm Submachinegun. Italian SMG with folded stock
+    {"vnx_m45_sf",              {-1, 0, 0, 0}},     // M/45 9mm Submachinegun. Swedish SMG with folding stock, fitted with a fore-grip
+    {"vnx_m45_sf_sd",           {-1, 0, 0, 0}},     // M/45 9mm Submachinegun. Swedish SMG with suppressed barrel and folding stock
+    {"vnx_m50_smg",             {-1, 0, 0, 0}},     // M50 9mm Submachinegun. Danish SMG with folding stock
+    {"vnx_m50_smg_fold",        {-1, 0, 0, 0}},     // M50 9mm Submachinegun. Danish SMG with folded stock
+    {"vnx_type56_xm148",        {0, -1, 0, 0}},     // Type 56 7.62mm Assault Rifle with XM148 single-shot 40mm grenade-launcher attached under the barrel
+    {"vnx_c96",                 {0, 0, 0, 0}},      // C96 is a German semi-automatic pistol chambered in 7.62x25
+    {"vnx_no4",                 {-1, 0, 0, 0}},     // The No.4 Mark I Rifle is a United Kingdom service rifle
+    {"vnx_no4_bayo",            {-1, 0, 0, 0}},     // No.4 Mk I Rifle + No.4 Bayonet
+    {"vnx_no4_sniper",          {-1, 0, 0, 0}},     // No.4 Mk I Rifle + 3.5x No.32 Telescope
+    {"vnx_m201z",               {-1, 0, 0, 0}},     // M201-Z Gas Gun made in the US fires a variety of 37mm rounds
+    {"vnx_stg44",               {0, -1, 0, 0}},     // Sturmgewehr 44 is a German automatic rifle
+    // Nickel Steel
+    // Melee Weapons
+    {"vnx_m_ladle",             {0, 0, 0, 0}},      // Ladle
+    {"vnx_m_spoon_01",          {0, 0, 0, 0}},      // Spoon 01
+    {"vnx_m_spoon_02",          {0, 0, 0, 0}},      // Spoon 02
+    // Nickel Steel
+    // Bayonet/Camo
+    {"vnx_b_no4",               {-1, 0, 0, 0}},     // Bayonet Spike [No.4]
+    {"vnx_o_aa_fm2429",         {0, 0, 0, 0}},      // Optic (FM24/29 AA)
+    {"vnx_xm148_muzzle",        {0, 0, 0, 0}},      // XM148 40mm Under-barrel Grenade Launcher. Fires 40mm HE grenades, smoke and flares
+*/
+    // Rifles
+    // BluFor
+    {"vn_m40a1",                {-1, 0, 0, -1}},    // M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
+    {"vn_m40a1_sniper",         {-1, 0, 0, -1}},    // M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
+    {"vn_m40a1_sniper_sd",      {-1, 0, 0, -1}},    // M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
+    {"vn_m40a1_nvg",            {-1, 0, 0, -1}},    // M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
+    {"vn_m40a1_nvg_sd",         {-1, 0, 0, -1}},    // M40 Sniper Rifle firing 7.62x51mm match-grade ammunition
+    {"vn_m40a1_camo",           {-1, 0, 0, -1}},    // M40 Sniper Rifle, camo polymer body, firing 7.62x51mm match-grade ammunition
+    {"vn_m14",                  {-1, 0, 0, -1}},    // M14 selective-fire rifle firing 7.62mm ammunition in 20-round mags
+    {"vn_m14_sd",               {-1, 0, 0, -1}},    // M14 selective-fire rifle firing 7.62mm ammunition in 20-round mags
+    {"vn_m14_bayo",             {-1, 0, 0, -1}},    // M14 selective-fire rifle firing 7.62mm ammunition in 20-round mags
+    {"vn_m14_camo",             {-1, 0, 0, -1}},    // M14 selective-fire rifle firing 7.62mm ammunition in 20-round mags, with camo tape
+    {"vn_m21",                  {-1, 0, 0, -1}},    // XM21 sniper rifle firing 7.62mm ammunition in 20-round mags. Fitted with a 3x to 9x Adjustable Ranging Telescope
+    {"vn_m21_sd",               {-1, 0, 0, -1}},    // XM21 sniper rifle firing 7.62mm ammunition in 20-round mags. Fitted with a 3x to 9x Adjustable Ranging Telescope
+    {"vn_m21_nvg",              {-1, 0, 0, -1}},    // XM21 sniper rifle firing 7.62mm ammunition in 20-round mags. Fitted with a 3x to 9x Adjustable Ranging Telescope
+    {"vn_m21_nvg_sd",           {-1, 0, 0, -1}},    // XM21 sniper rifle firing 7.62mm ammunition in 20-round mags. Fitted with a 3x to 9x Adjustable Ranging Telescope
+    {"vn_m1_garand",            {-1, 0, 0, -1}},    // M1 Garand 7.62x63mm Rifle
+    {"vn_m1_garand_sniper",     {-1, 0, 0, -1}},    // M1 Garand 7.62x63mm Rifle
+    {"vn_m1_garand_bayo",       {-1, 0, 0, -1}},    // M1 Garand 7.62x63mm Rifle
+    {"vn_m1_garand_gl",         {-1, 0, 1, -1}},    // M1 Garand 7.62x63mm Rifle, fitted with an M8 22mm rifle grenade
+    {"vn_m14a1",                {-1, 0, -1, -1}},   // M14A1 7.62mm automatic rifle
+    {"vn_m14a1_bipod",          {-1, 0, -1, -1}},   // M14A1 7.62mm automatic rifle
+    {"vn_m14a1_sniper",         {-1, 0, -1, -1}},   // M14A1 7.62mm automatic rifle
+    {"vn_m14a1_nvg",            {-1, 0, -1, -1}},   // M14A1 7.62mm automatic rifle
+    {"vn_m14a1_camo",           {-1, 0, -1, -1}},   // M14A1 7.62mm automatic rifle, fitted with a bipod and camo paint
+    {"vn_m14a1_shorty",         {-1, 0, 4, -1}},    // M14A1 cut short for use by SOG recon
+    {"vn_m14a1_shorty_fs",      {-1, 0, 5, -1}},    // M14A1 cut short for use by SOG recon, with added front sight
+    {"vn_m1903",                {0, 0, 0, 0}},      // M1903 5-shot, clip-fed, 7.62x65 rifle
+    {"vn_m1903_sniper",         {0, 0, 0, 0}},      // M1903 5-shot, clip-fed, 7.62x65 rifle
+    {"vn_m1903_bayo",           {0, 0, 0, 0}},      // M1903 5-shot, clip-fed, 7.62x65 rifle
+    {"vn_m1903_gl",             {0, 0, 2, 2}},      // M1903 5-shot, clip-fed, 7.62x65 rifle fitted with an M8 22mm rifle grenade
+    {"vn_m36",                  {0, 0, 0, 0}},      // M36 5-shot, clip-fed, 7.5x54mm rifle
+    {"vn_m36_bayo",             {0, 0, 0, 0}},      // M36 5-shot, clip-fed, 7.5x54mm rifle
+    {"vn_m36_camo",             {0, 0, 0, 0}},      // M36 5-shot, clip-fed, 7.5x54mm rifle
+    {"vn_l1a1_01",              {-1, 0, 1, -1}},    // Australian L1A1 7.62mm Rifle
+    {"vn_l1a1_01_mrk",          {-1, 0, 1, -1}},    // Australian L1A1 7.62mm Rifle
+    {"vn_l1a1_01_bayo",         {-1, 0, 1, -1}},    // Australian L1A1 7.62mm Rifle
+    {"vn_l1a1_01_camo",         {-1, 0, 1, -1}},    // Australian L1A1 7.62mm Rifle, fitted with camo tape
+    {"vn_l1a1_01_gl",           {-1, 0, 2, -1}},    // Australian L1A1 7.62mm Rifle, fitted with a 22mm rifle grenade adapter
+    {"vn_l1a1_02",              {-1, 0, 1, -1}},    // New Zealand L1A1 7.62mm Rifle
+    {"vn_l1a1_02_mrk",          {-1, 0, 1, -1}},    // New Zealand L1A1 7.62mm Rifle
+    {"vn_l1a1_02_bayo",         {-1, 0, 1, -1}},    // New Zealand L1A1 7.62mm Rifle
+    {"vn_l1a1_02_camo",         {-1, 0, 2, -1}},    // New Zealand L1A1 7.62mm Rifle, fitted with camo tape
+    {"vn_l1a1_02_gl",           {-1, 0, 3, -1}},    // New Zealand L1A1 7.62mm Rifle, fitted with a 22mm rifle grenade adapter
+    {"vn_l1a1_03",              {-1, 0, 4, -1}},    // SAS L1A1 7.62mm Rifle, fitted with foregrip
+    {"vn_l1a1_03_camo",         {-1, 0, 5, -1}},    // SAS L1A1 7.62mm Rifle, fitted with foregrip and camo paint
+    {"vn_l1a1_xm148",           {-1, 0, 4, -1}},    // L1A1 7.62mm Rifle, fitted with an XM148 40mm grenade launcher
+    {"vn_l1a1_xm148_camo",      {-1, 0, 5, -1}},    // L1A1 7.62mm Rifle, fitted with an XM148 40mm grenade launcher and camo paint
+    // OpFor
+    {"vn_sks",                  {0, -1, 0, -1}},    // SKS semi-automatic rifle with folding bayonet. Chambered in 10-round clips of 7.62x39mm
+    {"vn_sks_sniper",           {0, -1, 0, -1}},    // SKS semi-automatic rifle with folding bayonet. Chambered in 10-round clips of 7.62x39mm
+    {"vn_sks_bayo",             {0, -1, 0, -1}},    // SKS semi-automatic rifle with folding bayonet. Chambered in 10-round clips of 7.62x39mm
+    {"vn_sks_gl",               {0, -1, 0, -1}},    // SKS semi-automatic rifle with folding bayonet. Chambered in 10-round clips of 7.62x39mm. Fitted with 22mm rifle grenade
+    {"vn_m1891",                {0, -1, 0, -1}},    // M1891 5-shot, clip-fed, 7.62x54mmR rifle
+    {"vn_m1891_bayo",           {0, -1, 0, -1}},    // M1891 5-shot, clip-fed, 7.62x54mmR rifle
+    {"vn_m38",                  {0, -1, 0, -1}},    // M38 5-shot, clip-fed, 7.62x54mmR rifle
+    {"vn_m38_bayo",             {0, -1, 0, -1}},    // M38 5-shot, clip-fed, 7.62x54mmR rifle
+    {"vn_m9130",                {0, -1, 0, -1}},    // M91/30 5-shot, clip-fed, 7.62x54mmR rifle
+    {"vn_m9130_sniper",         {0, -1, 0, -1}},    // M91/30 5-shot, clip-fed, 7.62x54mmR rifle
+    {"vn_m9130_bayo",           {0, -1, 0, -1}},    // M91/30 5-shot, clip-fed, 7.62x54mmR rifle
+    {"vn_vz54",                 {0, -1, -1, -1}},   // VZ54 7.62mm Rifle
+    {"vn_vz54_sniper",          {0, -1, -1, -1}},   // VZ54 7.62mm Rifle
+    {"vn_vz54_sniper_camo",     {0, -1, -1, -1}},   // VZ54 7.62mm Rifle
+    {"vn_svd",                  {0, -1, -1, -1}},   // SVD 7.62x54mm semi-automatic marksman rifle
+    {"vn_svd_sniper",           {0, -1, -1, -1}},   // SVD 7.62x54mm semi-automatic marksman rifle
+    {"vn_svd_sniper_camo",      {0, -1, -1, -1}},   // SVD 7.62x54mm semi-automatic marksman rifle
+    {"vn_k98k",                 {0, -1, 0, 0}},     // K98K 5-shot, clip-fed, 7.92x57mm rifle
+    {"vn_k98k_bayo",            {0, -1, 0, 0}},     // K98K 5-shot, clip-fed, 7.92x57mm rifle
+    {"vn_k98k_mrk",             {0, -1, 0, 0}},     // K98K 5-shot, clip-fed, 7.92x57mm rifle
+    {"vn_k98k_mrk_camo",        {0, -1, 0, 0}},     // K98K 5-shot, clip-fed, 7.92x57mm rifle
+    // Assault Rifles
+    // BluFor
+    {"vn_m16",                  {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle. 20-round mag
+    {"vn_m16_muzzle",           {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle. 20-round mag
+    {"vn_m16_camo",             {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG camo version
+    {"vn_m16_bayo",             {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG camo version
+    {"vn_m16_sd",               {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG camo version
+    {"vn_m16_mrk",              {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG camo version
+    {"vn_m16_mrk_sd",           {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG camo version
+    {"vn_m16_sniper",           {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG camo version
+    {"vn_m16_sniper_sd",        {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG camo version
+    {"vn_m16_nvg",              {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG camo version
+    {"vn_m16_nvg_sd",           {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG camo version
+    {"vn_m16_xm148",            {-1, 0, 0, -1}},    // M16A1 5.56mm Assault Rifle with XM148 single-shot 40mm grenade-launcher attached under the barrel, and camo tape
+    {"vn_m16_m203",             {-1, 0, 4, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG version fitted with M203 40mm Grenade Launcher
+    {"vn_m16_m203_camo",        {-1, 0, 6, -1}},    // M16A1 5.56mm Assault Rifle, SF/SOG version fitted with M203 40mm Grenade Launcher and camo
+    {"vn_m16_usaf",             {-1, 0, 0, -1}},    // M16 5.56mm Assault Rifle. USAF version. 20-round mag
+    {"vn_m16_usaf_bayo",        {-1, 0, 0, -1}},    // M16 5.56mm Assault Rifle. USAF version. 20-round mag
+    {"vn_m16_usaf_mrk",         {-1, 0, 0, -1}},    // M16 5.56mm Assault Rifle. USAF version. 20-round mag
+    {"vn_m16_usaf_sniper",      {-1, 0, 0, -1}},    // M16 5.56mm Assault Rifle. USAF version. 20-round mag
+    {"vn_m16_usaf_nvg",         {-1, 0, 0, -1}},    // M16 5.56mm Assault Rifle. USAF version. 20-round mag
+    {"vn_gau5a",                {-1, 0, 2, -1}},    // GAU-5A/A 5.56mm USAF carbine
+    {"vn_gau5a_mrk",            {-1, 0, 2, -1}},    // GAU-5A/A 5.56mm USAF carbine
+    {"vn_m63a",                 {-1, 0, 0, -1}},    // M63A 5.56mm Automatic Rifle. 30-round mag
+    {"vn_xm16e1",               {-1, 0, 0, -1}},    // XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
+    {"vn_xm16e1_bayo",          {-1, 0, 0, -1}},    // XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
+    {"vn_xm16e1_mrk",           {-1, 0, 0, -1}},    // XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
+    {"vn_xm16e1_sniper",        {-1, 0, 0, -1}},    // XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
+    {"vn_xm16e1_xm148",         {-1, 0, 5, -1}},    // XM16E1 5.56mm Assault Rifle, fitted with XM148 40mm grenade launcher
+    {"vn_xm16e1_nvg",           {-1, 0, 0, -1}},    // XM16E1 5.56mm Assault Rifle. Early version. 20-round mag
+    {"vn_xm177_stock",          {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG version fitted with an M16 stock
+    {"vn_xm177_stock_camo",     {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG version fitted with an M16 stock and camo paint
+    {"vn_xm177_short",          {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, short SF/SOG version with 10 inch barrel
+    {"vn_xm177",                {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG light version
+    {"vn_xm177_muzzle",         {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG light version
+    {"vn_xm177_mrk",            {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG light version
+    {"vn_xm177_sniper",         {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG light version
+    {"vn_xm177_nvg",            {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG light version
+    {"vn_xm177_camo",           {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG version with camo tape
+    {"vn_xm177_fg",             {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG version fitted with a fore-grip
+    {"vn_xm177_xm148",          {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG version fitted with XM148 40mm grenade launcher
+    {"vn_xm177_xm148_camo",     {-1, 0, 0, -1}},    // XM177E2 5.56mm carbine, SF/SOG version fitted with XM148 40mm grenade launcher and camo paint
+    {"vn_xm177e1",              {-1, 0, 1, -1}},    // XM177E1 5.56mm carbine, early SF/SOG light version
+    {"vn_xm177e1_mrk",          {-1, 0, 1, -1}},    // XM177E1 5.56mm carbine, early SF/SOG light version
+    {"vn_xm177e1_sniper",       {-1, 0, 1, -1}},    // XM177E1 5.56mm carbine, early SF/SOG light version
+    {"vn_xm177e1_nvg",          {-1, 0, 1, -1}},    // XM177E1 5.56mm carbine, early SF/SOG light version
+    {"vn_xm177e1_camo",         {-1, 0, 2, -1}},    // XM177E1 5.56mm carbine, early SF/SOG light version with camo tape
+    {"vn_xm177_m203",           {-1, 0, 5, -1}},    // XM177E2 5.56mm Assault Rifle, SF/SOG version fitted with M203 40mm Grenade Launcher
+    {"vn_xm177_m203_camo",      {-1, 0, 6, -1}},    // XM177E2 5.56mm Assault Rifle, SF/SOG camo version fitted with M203 40mm Grenade Launcher
+    // OpFor
+    {"vn_type56",               {0, -1, 0, -1}},    // Type 56 7.62mm Assault Rifle. Chinese copy of AK-47 with folding cruciform bayonet
+    {"vn_type56_bayo",          {0, -1, 0, -1}},    // Type 56 7.62mm Assault Rifle. Chinese copy of AK-47 with folding cruciform bayonet
+    {"vn_kbkg",                 {0, -1, -1, 4}},    // KBKG 7.62x39mm Assault Rifle
+    {"vn_kbkg_gl",              {0, -1, -1, 6}},    // KBKG 7.62x39mm, lightweight, easy-to-use selective-fire rifle, fitted with a 22mm rifle grenade
+    {"vn_ak_01",                {0, -1, 4, 2}},     // AK 7.62x39mm Assault Rifle
+    // Carbine
+    // BluFor
+    {"vn_m2carbine",            {-1, 0, 0, -1}},    // M2 Carbine, 7.62x33mm, lightweight, easy-to-use selective-fire rifle
+    {"vn_m2carbine_bayo",       {-1, 0, 0, -1}},    // M2 Carbine, 7.62x33mm, lightweight, easy-to-use selective-fire rifle
+    {"vn_m2carbine_sniper",     {-1, 0, 0, -1}},    // M2 Carbine, 7.62x33mm, lightweight, easy-to-use selective-fire rifle
+    {"vn_m2carbine_gl",         {-1, 0, 0, -1}},    // M2 Carbine, 7.62x33mm, lightweight, easy-to-use selective-fire rifle, fitted with an M8 22mm rifle grenade
+    {"vn_m3carbine",            {-1, 0, 0, -1}},    // M3 carbine 7.62x33mm rifle, fitted with a heavy infra-red night-vision scope
+    {"vn_m1carbine_shorty",     {-1, 0, 6, -1}},    // M1 Carbine cut short with added scope and rechambered in 9x19mm to take HP magazines, for use by SOG recon
+    {"vn_m1carbine",            {0, 0, 0, -1}},     // M1 Carbine, 7.62x33mm, lightweight, easy-to-use semi-automatic rifle
+    {"vn_m1carbine_bayo",       {0, 0, 0, -1}},     // M1 Carbine, 7.62x33mm, lightweight, easy-to-use semi-automatic rifle
+    {"vn_m1carbine_sniper",     {0, 0, 0, -1}},     // M1 Carbine, 7.62x33mm, lightweight, easy-to-use semi-automatic rifle
+    {"vn_m1carbine_gl",         {0, 0, 0, -1}},     // M1 Carbine, 7.62x33mm, lightweight, easy-to-use semi-automatic rifle, fitted with an M8 22mm rifle grenade
+    {"vn_m4956",                {0, 0, 0, -1}},     // M49/56 French semi-automatic 7.5x54mm rifle
+    {"vn_m4956_sniper",         {0, 0, 0, -1}},     // M49/56 French semi-automatic 7.5x54mm rifle
+    {"vn_m4956_bayo",           {0, 0, 0, -1}},     // M49/56 French semi-automatic 7.5x54mm rifle
+    {"vn_m4956_gl",             {0, 0, 0, -1}},     // M49/56 French semi-automatic 7.5x54mm rifle fitted with a 22mm rifle grenade
+    // Machine Guns
+    // BluFor
+    {"vn_m60_shorty",           {-1, 0, 0, -1}},    // M60 7.62mm Light Machine Gun with 100-round box and short barrel
+    {"vn_m60_shorty_camo",      {-1, 0, 0, -1}},    // M60 7.62mm Light Machine Gun with 100-round box, short barrel and camo spray
+    {"vn_m60",                  {-1, 0, 0, -1}},    // M60 7.62mm Light Machine Gun with 100-round box and bipod
+    {"vn_m63a_cdo",             {-1, 0, 0, -1}},    // M63A 5.56mm Commando. 150-round drum
+    {"vn_m63a_cdo_bipod",       {-1, 0, 0, -1}},    // M63A 5.56mm Commando. 150-round drum
+    {"vn_m63a_lmg",             {-1, 0, 0, -1}},    // M63A 5.56mm LMG. 100-round box
+    {"vn_m63a_lmg_bipod",       {-1, 0, 0, -1}},    // M63A 5.56mm LMG. 100-round box
+    {"vn_m1918",                {-1, 0, 2, -1}},    // M1918A2 7.62x63mm Light Machine Gun fed by 20 round magazines
+    {"vn_m1918_bipod",          {-1, 0, 2, -1}},    // M1918A2 7.62x63mm Light Machine Gun fed by 20 round magazines
+    {"vn_l2a1_01",              {-1, 0, 3, -1}},    // L2A1 7.62mm LMG, fitted with a bipod
+    {"vn_l4",                   {-1, 0, -1, -1}},   // L4 7.62x51mm selective-fire LMG
+    // OpFor
+    {"vn_rpd_shorty",           {0, -1, 0, -1}},    // RPD 7.62mm LMG, with sawn-off barrel, sight, and bipod, carried by El Cid of MACV SOG
+    {"vn_rpd_shorty_01",        {0, -1, 0, -1}},    // RPD 7.62mm LMG, with sawn-off barrel and bipod
+    {"vn_rpd",                  {0, -1, 0, -1}},    // RPD 7.62x39mm Light Machine Gun fed by drums containing 100-round belts
+    {"vn_dp28",                 {0, -1, 0, -1}},    // DP-27 7.62mm Light Machine Gun with 47 round mag and bipod
+    {"vn_pk",                   {0, -1, 0, -1}},    // PK 7.62mm Light Machine Gun with 100-round box and bipod
+    {"vn_mg42",                 {0, -1, -1, 4}},    // MG42 7.92x57mm Light Machine Gun fed by 50-round drums or boxes containing 250-round belts
+    // Submachine Guns
+    // BluFor
+    {"vn_m3a1",                 {-1, 0, 0, -1}},    // M3A1 Grease Gun
+    {"vn_m3sd",                 {-1, 0, 0, -1}},    // M3A1 Grease Gun
+    {"vn_m45",                  {-1, 0, 0, -1}},    // M/45 9mm Submachinegun. Swedish SMG with folding stock
+    {"vn_m45_sd",               {-1, 0, 0, -1}},    // M/45 9mm Submachinegun. Swedish SMG with folding stock
+    {"vn_m45_camo",             {-1, 0, 0, -1}},    // M/45 9mm Submachinegun. Swedish SMG with camo paint and folding stock
+    {"vn_m45_fold",             {-1, 0, 0, -1}},    // M/45 9mm Submachinegun. Swedish SMG with folded stock
+    {"vn_mat49",                {-1, 0, 0, -1}},    // MAT-49
+    {"vn_mat49_sd",             {-1, 0, 0, -1}},    // MAT-49
+    {"vn_mc10",                 {-1, 0, 0, -1}},    // The MC-10 is a compact, blowback operated machine pistol developed in 1964 chambered in 9mm (or .45ACP)
+    {"vn_mc10_sd",              {-1, 0, 0, -1}},    // The MC-10 is a compact, blowback operated machine pistol developed in 1964 chambered in 9mm (or .45ACP)
+    {"vn_sten",                 {-1, 0, 0, 0}},     // Sten Mk.II
+    {"vn_sten_sd",              {-1, 0, 0, 0}},     // Sten Mk.II
+    {"vn_m1928_tommy",          {-1, 0, 0, -1}},    // The M1928 Tommy Gun is a blowback operated, selective fire U.S. submachinegun chambered in .45 ACP, capable of using a 50 round drum
+    {"vn_m1928a1_tommy",        {-1, 0, 0, -1}},    // The M1928A1 Tommy Gun is a blowback operated, selective fire U.S. submachinegun chambered in .45 ACP, capable of using a 50 round drum
+    {"vn_m1a1_tommy",           {-1, 0, 0, -1}},    // The M1A1 Tommy Gun is a blowback operated, selective fire U.S. submachinegun chambered in .45 ACP
+    {"vn_m1a1_tommy_so",        {-1, 0, 0, -1}},    // The M1A1 Tommy Gun (shorty) is a blowback operated, selective fire U.S. submachinegun chambered in .45 ACP with the butt removed
+    {"vn_mpu",                  {-1, 0, 0, -1}},    // The MPU is a compact, open bolt, blowback operated submachinegun developed in 1954 chambered in 9mm
+    {"vn_mpu_sd",               {-1, 0, 0, -1}},    // The MPU is a compact, open bolt, blowback operated submachinegun developed in 1954 chambered in 9mm
+    {"vn_f1_smg",               {-1, 0, 2, -1}},    // F1 9mm SMG
+    {"vn_f1_smg_bayo",          {-1, 0, 2, -1}},    // F1 9mm SMG
+    {"vn_l2a3",                 {-1, 0, 2, -1}},    // L2A3 9mm Submachinegun
+    {"vn_l2a3_f",               {-1, 0, 3, -1}},    // L2A3 9mm Submachinegun. SMG with folded stock
+    {"vn_l34a1",                {-1, 0, 4, -1}},    // L34A1 9mm Submachinegun with folding stock and integral suppressor
+    {"vn_l34a1_f",              {-1, 0, 5, -1}},    // L34A1 9mm Submachinegun with folded stock and integral suppressor
+    {"vn_l34a1_xm148",          {-1, 0, 6, -1}},    // L34A1 9mm Submachinegun with folding stock and integral suppressor, with XM148 single-shot 40mm grenade-launcher attached under the barrel
+    // OpFor
+    {"vn_k50m",                 {0, -1, 0, -1}},    // Vietnamese K-50M 7.62mm submachinegun with 35 or 71-round magazine
+    {"vn_mat49_f",              {0, -1, 0, -1}},    // MAT-49 SMG with folded stock
+    {"vn_mat49_vc",             {0, -1, 0, -1}},    // MAT-49 SMG, Viet Cong conversion
+    {"vn_mp40",                 {0, -1, 0, -1}},    // The MP40 is a submachinegun chambered for 9x19mm Parabellum cartridge
+    {"vn_pps43",                {0, -1, 0, -1}},    // Polish PPS-43 7.62mm automatic submachinegun with 35-round magazine
+    {"vn_pps52",                {0, -1, 0, -1}},    // Polish PPS-52 7.62mm automatic submachinegun with 35-round magazine
+    {"vn_ppsh41",               {0, -1, 0, -1}},    // Soviet PPSh-41 7.62mm submachinegun with 35 or 71-round magazine
+    {"vn_vz61",                 {0, -1, 0, -1}},    // The VZ.61 Skorpion is a select-fire blowback operated Czech machine pistol chambered in .32 ACP
+    {"vn_type64_smg",           {0, -1, -1, -1}},   // Type 64 7.65mm Submachinegun. Chinese SMG with folding stock and integral suppressor
+    {"vn_type64_f_smg",         {0, -1, -1, -1}},   // Type 64 7.65mm Submachinegun. Chinese SMG with folded stock and integral suppressor
+    // Shotguns
+    // BluFor
+    {"vn_m1897",                {-1, 0, 0, -1}},    // Model 1897 12 gauge Trench gun, 6-round mag, capable of slam-firing
+    {"vn_m1897_bayo",           {-1, 0, 0, -1}},    // Model 1897 12 gauge Trench gun, 6-round mag, capable of slam-firing
+    // OpFor
+    {"vn_izh54",                {0, -1, 0, -1}},    // ISh-54 double-barrelled Shotgun
+    {"vn_izh54_shorty",         {0, -1, 0, -1}},    // ISh-54 double-barrelled Shotgun (Sawn-off)
+    // Sidearm
+    // BluFor
+    {"vn_welrod",               {-1, 0, 0, -1}},    // Welrod single-shot, suppressed pistol, caliber 7.65x17mm, 8-round mag
+    {"vn_vz61_p",               {-1, 0, 0, -1}},    // The VZ.61 Skorpion is a select-fire blowback operated Czech machine pistol chambered in .32 ACP, and worn as a sidearm
+    {"vn_fkb1_pm",              {0, 0, 0, -1}},     // PM semi-automatic pistol, 9mm caliber, 8-round mag with FKB-1 Flashlight
+    {"vn_fkb1_pm_sd",           {0, 0, 0, -1}},     // PM semi-automatic pistol, 9mm caliber, 8-round mag with FKB-1 Flashlight
+    {"vn_mx991_m1911",          {0, 0, 0, -1}},     // M1911 .45 caliber semi-automatic pistol, 7-round magazine, with angle-head MX-991 Flashlight
+    {"vn_mx991_m1911_sd",       {0, 0, 0, -1}},     // M1911 .45 caliber semi-automatic pistol, 7-round magazine, with angle-head MX-991 Flashlight
+    {"vn_pm",                   {0, 0, 0, -1}},     // PM semi-automatic pistol, 9mm caliber, 8-round mag
+    {"vn_pm_sd",                {0, 0, 0, -1}},     // PM semi-automatic pistol, 9mm caliber, 8-round mag
+    {"vn_tt33",                 {0, 0, 0, -1}},     // TT-33 semi-automatic pistol, chambered in 7.62x25mm. 8-round magazine
+    {"vn_hd",                   {0, 0, 0, -1}},     // HD suppressed pistol, .22LR caliber, 10-round mag
+    {"vn_hp",                   {0, 0, 0, -1}},     // HP 9mm semi-automatic pistol, 13 round mag
+    {"vn_hp_sd",                {0, 0, 0, -1}},     // HP 9mm semi-automatic pistol, 13 round mag
+    {"vn_m1911",                {0, 0, 0, -1}},     // M1911 .45 caliber semi-automatic pistol, 7-round magazine
+    {"vn_m1911_sd",             {0, 0, 0, -1}},     // M1911 .45 caliber semi-automatic pistol, 7-round magazine
+    {"vn_mk22",                 {0, 0, 0, -1}},     // Mk22 Mod 0
+    {"vn_mk22_sd",              {0, 0, 0, -1}},     // Mk22 Mod 0
+    {"vn_m10",                  {0, 0, 0, -1}},     // Model 10 .38 revolver, 6-round reload
+    {"vn_m10_sd",               {0, 0, 0, -1}},     // Model 10 .38 revolver, 6-round reload
+    {"vn_m1895",                {0, 0, 0, -1}},     // M1895 seven-shot, gas-seal revolver chambered for 7.62x38mmR. The unique gas seal enables use with a suppressor
+    {"vn_m1895_sd",             {0, 0, 0, -1}},     // M1895 seven-shot, gas-seal revolver chambered for 7.62x38mmR. The unique gas seal enables use with a suppressor
+    {"vn_p38s",                 {0, 0, 0, -1}},     // .38 Revolver revolver, 6-round reload
+    {"vn_ppk",                  {0, 0, 2, 0}},      // PPK 9mm semi-automatic pistol
+    {"vn_ppk_sd",               {0, 0, 2, 0}},      // PPK 9mm semi-automatic pistol
+    {"vn_p38",                  {0, 0, 1, 1}},      // P38 9mm semi-automatic pistol
+    {"vn_p38_sd",               {0, 0, 1, 1}},      // P38 9mm semi-automatic pistol
+    {"vn_mk1_udg",              {-1, 0, 0, -1}},    // The Mk1 Underwater Defence Gun (UDG) is a compact, double action only pepper-box weapon developed in the 1960s with a removable cylinder of six 4.25in darts
+    // OpFor
+    {"vn_m712",                 {0, -1, 0, -1}},    // M712 selective-fire pistol, chambered in 7.62x25mm. 20-round magazine
+    {"vn_izh54_p",              {0, -1, 0, -1}},    // ISh-54 double-barrelled Shotgun (Sidearm)
+    {"vn_type64",               {0, -1, -1, 6}},    // Suppressed Type 64 7.65x17mm semi-automatic pistol
+    // Launchers
+    // BluFor
+    {"vn_m72",                  {-1, 0, 0, -1}},    // M72 LAW single-use HEAT rocket
+    {"vn_m79",                  {0, 0, 0, -1}},     // M79 Grenade Launcher. Fires 40mm HE grenades, smoke and flares
+    {"vn_m79_p",                {-1, 0, 0, -1}},    // M79 Grenade Launcher. Sawn-off for close quarters by SOG as a sidearm. Fires 40mm HE grenades, smoke and flares
+    {"vn_m20a1b1_01",           {-1, 0, 3, -1}},    // M20A1B1 Bazooka
+    {"vn_rocket_m128_launcher", {-1, 0, 0, -1}},    // Flare Launcher
+    // OpFor
+    {"vn_rpg2",                 {0, -1, 0, -1}},    // B40 HEAT rocket
+    {"vn_rpg7",                 {0, -1, 0, -1}},    // B41 HEAT rocket
+    {"vn_sa7",                  {0, -1, 0, -1}},    // 9K32 Strela-2 Anti-Aircraft Missile
+    {"vn_sa7b",                 {0, -1, 0, -1}},    // 9K32 Strela-2M Anti-Aircraft Missile
+    // Other
+    // BluFor
+    {"vn_mx991",                {0, 0, 0, -1}},     // US Angle-head MX-991 Flashlight, powered by BA-30 1.5v batteries
+    {"vn_mx991_red",            {0, 0, 0, -1}},     // Angle-head MX-991 Flashlight with red lens, powered by BA-30 1.5v batteries
+    {"vn_m127",                 {0, 0, 0, -1}},     // M127 single-use flare, white
+    {"vn_camera_01",            {-1, 0, 1, -1}},    // SOG 35mm camera carried on clandestine missions by MACV SOG
+    {"vn_fkb1",                 {0, 0, 0, -1}},     // Soviet FKB-1 Flashlight, powered by 2xR20 batteries
+    {"vn_fkb1_red",             {0, 0, 0, -1}},     // Soviet FKB-1 Flashlight with red lens, powered by 2xR20 batteries
+    // Melee Weapons
+    // BluFor
+    {"vn_m_axe_01",             {0, 0, 0, -1}},     // Axe
+    {"vn_m_axe_fire",           {0, 0, 0, -1}},     // Fire Axe
+    {"vn_m_bayo_carbine",       {0, 0, 0, -1}},     // Carbine Bayonet
+    {"vn_m_bayo_m14",           {-1, 0, 0, -1}},    // M14 Bayonet
+    {"vn_m_bayo_m16",           {-1, 0, 0, -1}},    // M16 Bayonet
+    {"vn_m_bayo_m1897",         {0, 0, 0, -1}},     // M1897 Bayonet
+    {"vn_m_bayo_m4956",         {0, 0, 0, -1}},     // M49/56 Bayonet
+    {"vn_m_bolo_01",            {0, 0, 0, -1}},     // Bolo Knife
+    {"vn_m_fighting_knife_01",  {0, 0, 0, -1}},     // Fighting Knife
+    {"vn_m_hammer",             {0, 0, 0, -1}},     // Hammer
+    {"vn_m_m51_etool_01",       {-1, 0, 0, -1}},    // M51 Entrenching Tool
+    {"vn_m_machete_01",         {0, 0, 0, -1}},     // Machete
+    {"vn_m_machete_02",         {0, 0, 0, -1}},     // Machete
+    {"vn_m_mk2_knife_01",       {-1, 0, 0, -1}},    // MK2 Knife
+    {"vn_m_shovel_01",          {0, 0, 0, -1}},     // Shovel
+    {"vn_m_typeivaxe_01",       {0, 0, 0, -1}},     // Type IV Axe
+    {"vn_m_wrench_01",          {0, 0, 0, -1}},     // Wrench
+    {"vn_b_melee_m43_etool_01", {-1, 0, 0, -1}},    // M43 Entrenching Tool
+    {"vn_b_melee_m1903",        {0, 0, 0, 0}},      // M1903 Bayonet
+    {"vn_b_melee_m36",          {0, 0, 0, 0}},      // M36 Bayonet
+    // OpFor
+    {"vn_b_melee_k98k",         {0, -1, -1, 0}},    // K98K Bayonet
+    {"vn_m_vc_knife_01",        {0, -1, 0, -1}},    // VC Knife
+    // Binoculars
+    // BluFor
+    {"vn_m19_binocs_grey",      {0, 0, 0, 0}},      // Binocular M19 Grey (7x50)
+    {"vn_m19_binocs_grn",       {0, 0, 0, 0}},      // Binocular M19 Green (7x50)
+    {"vn_mk21_binocs",          {0, 0, 0, 0}},      // Binocular Mk21 (7x50)
+    {"vn_anpvs2_binoc",         {-1, 0, 0, 0}},     // Starlight ANPVS2 (NV)
+    // BluFor
+    // Bayonet/Camo
+    {"vn_b_camo_m14",           {-1, 0, 0, -1}},    // Camo wrap [M14]
+    {"vn_b_camo_m14a1",         {-1, 0, 0, -1}},    // Camo wrap [M14A1]
+    {"vn_b_camo_m40a1",         {-1, 0, 0, -1}},    // Camo wrap [M40]
+    {"vn_b_carbine",            {0, 0, 0, -1}},     // Bayonet M4 [M1/M2]
+    {"vn_b_m14",                {-1, 0, 0, -1}},    // Bayonet M6 [M14]
+    {"vn_b_m16",                {-1, 0, 0, -1}},    // Bayonet M7 [M16]
+    {"vn_b_m1897",              {-1, 0, 0, -1}},    // Bayonet M1917 [M1897]
+    {"vn_b_m1_garand",          {-1, 0, 1, -1}},    // Bayonet M5 [M1 Garand]
+    {"vn_b_camo_m1_garand",     {-1, 0, 2, -1}},    // Camo wrap [M1 Garand]
+    {"vn_bipod_m1918",          {-1, 0, 4, -1}},    // Bipod [M1918]
+    {"vn_bipod_m16",            {-1, 0, 1, -1}},    // Bipod [M16]
+    {"vn_bipod_m14",            {-1, 0, 1, -1}},    // Bipod [M14]
+    {"vn_b_l1a1",               {-1, 0, 1, -1}},    // Bayonet L1A1 [L1A1/F1]
+    {"vn_b_m1903",              {0, 0, 1, 1}},      // Bayonet [M1903]
+    {"vn_b_m36",                {0, 0, 1, 1}},      // Bayonet Spike [M36]
+    {"vn_b_camo_m1903",         {0, 0, 2, 2}},      // Camo wrap [M1903]
+    {"vn_b_camo_m36",           {0, 0, 2, 2}},      // Camo wrap [M36]
+    {"vn_bipod_m63a",           {-1, 0, 3, -1}},    // Bipod [M63A]
+    {"vn_b_m4956",              {0, 0, 0, -1}},     // Bayonet Model 58 [M49/56]
+    // Suppressor
+    {"vn_s_m14",                {-1, 0, 0, -1}},    // Suppressor [M14/M40]
+    {"vn_s_m16",                {-1, 0, 0, -1}},    // Suppressor [M16]
+    {"vn_s_m1895",              {0, 0, 0, -1}},     // Suppressor [M1895]
+    {"vn_s_m1911",              {-1, 0, 0, -1}},    // Suppressor [M1911]
+    {"vn_s_m3a1",               {-1, 0, 0, -1}},    // Suppressor [M3]
+    {"vn_s_m45",                {-1, 0, 0, -1}},    // Suppressor [M/45]
+    {"vn_s_m45_camo",           {-1, 0, 0, -1}},    // Suppressor [M/45 Camo]
+    {"vn_s_mat49",              {-1, 0, 0, -1}},    // Suppressor [MAT-49]
+    {"vn_s_mc10",               {-1, 0, 0, -1}},    // Suppressor [MC-10]
+    {"vn_s_mk22",               {-1, 0, 0, -1}},    // Suppressor [Mk22]
+    {"vn_s_pm",                 {0, 0, 0, -1}},     // Suppressor [PM]
+    {"vn_s_sten",               {-1, 0, 0, -1}},    // Suppressor [Sten Mk.II]
+    {"vn_s_ppk",                {0, 0, 2, 2}},      // Suppressor 9mm [PPK/P38]
+    {"vn_s_hp",                 {-1, 0, 3, -1}},    // Suppressor 9mm [HP]
+    {"vn_s_mpu",                {-1, 0, 0, -1}},    // Suppressor [MPU]
+    // Optics
+    {"vn_o_4x_m16",             {-1, 0, 0, -1}},    // Optic (M16 4x)
+    {"vn_o_9x_m14",             {-1, 0, 0, -1}},    // Optic (M14 3-9x)
+    {"vn_o_9x_m16",             {-1, 0, 0, -1}},    // Optic (M16 3-9x)
+    {"vn_o_9x_m40a1",           {-1, 0, 0, -1}},    // Optic (M40 3-9x)
+    {"vn_o_9x_m40a1_camo",      {-1, 0, 0, -1}},    // Optic (M40 3-9x camo)
+    {"vn_o_anpvs2_m14",         {-1, 0, 0, -1}},    // Scope (AN-PVS2 Starlight) [M14]
+    {"vn_o_anpvs2_m16",         {-1, 0, 0, -1}},    // Scope (AN-PVS2 Starlight) [XM177/M16]
+    {"vn_o_anpvs2_m40a1",       {-1, 0, 0, -1}},    // Scope (AN-PVS2 Starlight) [M40]
+    {"vn_o_3x_m84",             {0, 0, 0, -1}},     // Scope (M1/2 Carbine 2.2x)
+    {"vn_o_1x_sp_m16",          {-1, 0, 6, -1}},    // Optic (M16 SP)
+    {"vn_o_3x_l1a1",            {-1, 0, 2, -1}},    // Optic (L1A1 3x)
+    {"vn_o_8x_m1903",           {0, 0, 1, 1}},      // Optic [M1903 8x]
+    {"vn_o_m14_front",          {-1, 0, 4, -1}},    // Optic (M14 Front Sight)
+    {"vn_o_4x_m4956",           {0, 0, 0, -1}},     // Scope (M49/56 3.5x)
+    // OpFor
+    // Bayonet/Camo
+    {"vn_b_sks",                {0, -1, 0, -1}},    // Bayonet Spike [M38]
+    {"vn_b_type56",             {0, -1, 0, -1}},    // Bayonet Spike [Type56]
+    {"vn_b_camo_vz54",          {0, -1, -1, -1}},   // Camo wrap [VZ54]
+    {"vn_b_camo_svd",           {0, -1, -1, -1}},   // Camo wrap [SVD]
+    {"vn_b_camo_k98k",          {0, -1, 2, 2}},     // Camo wrap [K98K]
+    {"vn_b_k98k",               {0, -1, 1, 1}},     // Bayonet [K98K]
+    {"vn_b_m38",                {0, -1, 0, -1}},    // Bayonet Spike [M38/M91/30/M1892]
+    {"vn_b_camo_m9130",         {0, -1, 0, -1}},    // Camo wrap [M9130]
+    // Optic
+    {"vn_o_3x_m9130",           {0, -1, 0, -1}},    // Optic (M91/30 3.5x)
+    {"vn_o_3x_sks",             {0, -1, 0, -1}},    // Optic (SKS 3.5x)
+    {"vn_o_3x_vz54",            {0, -1, -1, -1}},   // Optic (VZ54 2.5x)
+    {"vn_o_4x_svd",             {0, -1, -1, -1}},   // Optic [SVD 4x]
+    {"vn_o_1_5x_k98k",          {0, -1, 1, 1}},     // Optic [K98K 1.5x]
+};
+
+magazines[] = {
+/*
+    // Nickel Steel
+    // Mags
+    {"vnx_m77e_fl_mag",         {-1, 0, 0, 0}},     // 5Rnd. M77E Reload. Caliber: 12 gauge flechette. Used in Model 77E shotgun
+    {"vnx_m77e_buck_mag",       {-1, 0, 0, 0}},     // 5Rnd. M77E Reload. Caliber: 12 gauge buckshot. Used in Model 77E shotgun
+    {"vnx_m77e_so_mag",         {-1, 0, 0, 0}},     // 5Rnd. M77E Sawn-off. Caliber: 12 gauge buckshot. Used in M77E Sawn-off shotgun
+    {"vnx_fm2429_mag",          {0, 0, 0, 0}},      // 25Rnd. FM24/29 Mag. Calibre: 7.5x54mm. Used in FM24/29
+    {"vnx_fm2429_t_mag",        {0, 0, 0, 0}},      // 25Rnd. FM24/29 Tracer Mag. Calibre: 7.5x54mm. Used in FM24/29
+    {"vnx_gjet_mag",            {-1, 0, 0, 0}},     // 6Rnd. G-jet magazine. Caliber: .51in. Used in G-jet pistol
+    {"vnx_hd_02_mag",           {0, 0, 0, 0}},      // 10Rnd. HD magazine. Caliber .22 LR. Used in HD pistol
+    {"vnx_m12_smg_32_mag",      {-1, 0, 0, 0}},     // 20Rnd. M12 Magazine. Caliber: 9x19mm. Used in M12 Submachinegun
+    {"vnx_m12_smg_32_t_mag",    {-1, 0, 0, 0}},     // 20Rnd. M12 Tracer Magazine. Caliber: 9x19mm. Used in M12 Submachinegun
+    {"vnx_m12_smg_20_mag",      {-1, 0, 0, 0}},     // 32Rnd. M12 Magazine. Caliber: 9x19mm. Used in M12 Submachinegun
+    {"vnx_m12_smg_20_t_mag",    {-1, 0, 0, 0}},     // 32Rnd. M12 Tracer Magazine. Caliber: 9x19mm. Used in M12 Submachinegun
+    {"vnx_m50_smg_mag",         {-1, 0, 0, 0}},     // 32Rnd. M50 Magazine. Caliber: 9x19mm. Used in M50 Submachinegun
+    {"vnx_m50_smg_t_mag",       {-1, 0, 0, 0}},     // 32Rnd. M50 Tracer Magazine. Caliber: 9x19mm. Used in M50 Submachinegun
+    {"vnx_c96_mag",             {0, 0, 0, 0}},      // C96 Magazine Caliber 7.63x25mm used in C96
+    {"vnx_c96_t_mag",           {0, 0, 0, 0}},      // C96 Magazine with tracers Caliber 7.63x25mm used in C96
+    {"vnx_37mm_baton_mag",      {-1, 0, 0, 0}},     // No.264 Multiple Baton round used for riot control
+    {"vnx_37mm_cs_fin_mag",     {-1, 0, 0, 0}},     // No.230 high velocity projectile designed to breech doors, windows and partions
+    {"vnx_37mm_cs_mag",         {-1, 0, 0, 0}},     // No.203 low velocity riot control CS Gas canister
+    {"vnx_37mm_cs_skat_mag",    {-1, 0, 0, 0}},     // No.265 Multiple CS canister rounds used for riot control
+    {"vnx_37mm_cs_spray_mag",   {-1, 0, 0, 0}},     // No.208 short range spray, will spray CS gas to 40ft in 1 second
+    {"vnx_37mm_flare_mag",      {-1, 0, 0, 0}},     // No.213 37mm Flare
+    {"vnx_no4_mag",             {-1, 0, 0, 0}},     // No.4 Magazine Caliber .303
+    {"vnx_no4_t_mag",           {-1, 0, 0, 0}},     // No.4 Magzine with tracer, Caliber .303
+    {"vnx_mk3a2_grenade_mag",   {-1, 0, 0, 0}},     // US MK3A2 grenade - 227g TNT, concussion, 5s fuze, effective radius 5m
+    {"vnx_stg44_mag",           {0, -1, 0, 0}},     // 30Rnds StG44 Magazine Caliber 7.92x33mm used in StG44
+    {"vnx_stg44_t_mag",         {0, -1, 0, 0}},     // 30Rnds StG44 Tracer Magazine Caliber 7.92x33mm used in StG44
+*/
+    // Rifle Grenades
+    {"vn_22mm_cs_mag",          {0, 0, 0, -1}},     // 22mm CS Riot gas rifle grenade used in SKS, M1 Carbine and M49/56
+    {"vn_22mm_he_mag",          {0, 0, 0, -1}},     // 22mm FRAG rifle grenade used in M49/56 rifle
+    {"vn_22mm_lume_mag",        {0, 0, 0, -1}},     // 22mm Illumination rifle grenade used in SKS, M1 Carbine and M49/56
+    {"vn_22mm_m17_frag_mag",    {0, 0, 0, -1}},     // M17 22mm FRAG rifle grenade used in M1 Carbine
+    {"vn_22mm_m19_wp_mag",      {0, 0, 0, -1}},     // M19 22mm White Phosphorus rifle grenade used in SKS, M1 Carbine and M49/56
+    {"vn_22mm_m1a2_frag_mag",   {0, 0, 0, -1}},     // M1A2 22mm FRAG rifle grenade used in M1 Carbine
+    {"vn_22mm_m22_smoke_mag",   {0, 0, 0, -1}},     // M22 22mm Smoke rifle grenade used in SKS, M1 Carbine and M49/56
+    {"vn_22mm_m60_frag_mag",    {0, 0, 0, -1}},     // M60 22mm FRAG rifle grenade used in SKS rifle
+    {"vn_22mm_m60_heat_mag",    {0, 0, 0, -1}},     // M60 22mm HEAT rifle grenade used in SKS rifle
+    {"vn_22mm_m9_heat_mag",     {0, 0, 0, -1}},     // M9 22mm HEAT rifle grenade used in M1 Carbine and M49/56
+    {"vn_22mm_m61_frag_mag",    {-1, 0, 0, -1}},    // M61 22mm FRAG rifle grenade used in L1A1
+    {"vn_22mm_n94_heat_mag",    {-1, 0, 0, -1}},    // N94 22mm HEAT rifle grenade used in L1A1
+    // OpFor
+    {"vn_20mm_f1n60_frag_mag",  {0, -1, 0, -1}},    // F1N60 20mm FRAG rifle grenade used in KBKG rifle
+    {"vn_20mm_kgn_frag_mag",    {0, -1, 0, -1}},    // KGN 20mm FRAG rifle grenade used in KBKG rifle
+    {"vn_20mm_pgn60_heat_mag",  {0, -1, 0, -1}},    // PGN60 20mm HEAT rifle grenade used in KBKG rifle
+    {"vn_20mm_dgn_wp_mag",      {0, -1, 0, -1}},    // DGN 20mm White Phosphorus rifle grenade used in KBKG, M1 Carbine and M49/56
+    // 40mm Ammo
+    {"vn_40mm_m381_he_mag",     {-1, 0, 0, -1}},    // M381 40mm HE Grenade used in M79, XM148 and M203 Grenade Launchers. 3m arming distance
+    {"vn_40mm_m397_ab_mag",     {-1, 0, 0, -1}},    // M397 40mm Airburst Grenade used in M79, XM148 and M203 Grenade Launchers
+    {"vn_40mm_m406_he_mag",     {-1, 0, 0, -1}},    // M406 40mm HE Grenade used in M79, XM148 and M203 Grenade Launchers. 14m arming distance
+    {"vn_40mm_m433_hedp_mag",   {-1, 0, 0, -1}},    // M433 40mm HEDP Grenade used in M79, XM148 and M203 Grenade Launchers. Range 15m, penetrates 2in RHA steel armour
+    {"vn_40mm_m576_buck_mag",   {-1, 0, 0, -1}},    // M576 40mm Buckshot round used in M79, XM148 and M203 Grenade Launchers
+    {"vn_40mm_m583_flare_w_mag", {-1, 0, 0, -1}},   // M583 40mm Flare (White) used in M79, XM148 and M203 Grenade Launchers
+    {"vn_40mm_m651_cs_mag",     {-1, 0, 0, -1}},    // M651 40mm CS Gas grenade used in M203, XM148 and M79 grenade launchers
+    {"vn_40mm_m661_flare_g_mag", {-1, 0, 0, -1}},   // M661 40mm Flare (Green) used in M79, XM148 and M203 Grenade Launchers
+    {"vn_40mm_m662_flare_r_mag", {-1, 0, 0, -1}},   // M662 40mm Flare (Red) used in M79, XM148 and M203 Grenade Launchers
+    {"vn_40mm_m680_smoke_w_mag", {-1, 0, 0, -1}},   // M680 40mm Smoke grenade (White) used in M203, XM148 and M79 grenade launchers
+    {"vn_40mm_m682_smoke_r_mag", {-1, 0, 0, -1}},   // M682 40mm Smoke grenade (Red) used in M203, XM148 and M79 grenade launchers
+    {"vn_40mm_m695_flare_y_mag", {-1, 0, 0, -1}},   // M695 40mm Flare (Yellow) used in M79, XM148 and M203 Grenade Launchers
+    {"vn_40mm_m715_smoke_g_mag", {-1, 0, 0, -1}},   // M715 40mm Smoke grenade (Green) used in M203, XM148 and M79 grenade launchers
+    {"vn_40mm_m716_smoke_y_mag", {-1, 0, 0, -1}},   // M716 40mm Smoke grenade (Yellow) used in M203, XM148 and M79 grenade launchers
+    {"vn_40mm_m717_smoke_p_mag", {-1, 0, 0, -1}},   // M717 40mm Smoke grenade (Purple) used in M203, XM148 and M79 grenade launchers
+    // Rifle Cartridge
+    // Clips
+    {"vn_m40a1_mag",            {-1, 0, 0, -1}},    // 5Rnd. M40 Reload. Caliber: 7.62x51mm. Used in M40 Rifle
+    {"vn_m40a1_t_mag",          {-1, 0, 0, -1}},    // 5Rnd. M40 Reload (Tracer). Caliber: 7.62x51mm. Used in M40 Rifle
+    {"vn_sks_mag",              {0, 0, 0, -1}},     // 10Rnd. SKS Clip. Caliber: 7.62x39mm. Used in SKS rifle
+    {"vn_sks_t_mag",            {0, 0, 0, -1}},     // 10Rnd. SKS Tracer Clip. Caliber: 7.62x39mm. Used in SKS rifle
+    {"vn_m1_garand_mag",        {-1, 0, 0, -1}},    // 8Rnd. M1 Garand Clip. Caliber: 7.62x63mm. Used in M1 Garand
+    {"vn_m1_garand_t_mag",      {-1, 0, 0, -1}},    // 8Rnd. M1 Garand Clip Caliber: 7.62x63mm. Used in M1 Garand(Tracer)
+    {"vn_m1903_mag",            {0, 0, 0, -1}},     // 5Rnd. M1903 Clip. Caliber: 7.62x65mm. Used in M1903 rifle
+    {"vn_m1903_t_mag",          {0, 0, 0, -1}},     // 5Rnd. M1903 Tracer Clip. Caliber: 7.62x65mm Used in M1903 rifle
+    {"vn_m36_mag",              {0, 0, 0, -1}},     // 5Rnd. M36 Clip. Caliber: 7.5x54mm. Used in M36 rifle
+    {"vn_m36_t_mag",            {0, 0, 0, -1}},     // 5Rnd. M36 Tracer Clip. Caliber: 7.5x54mm Used in M36 rifle
+    // OpFor
+    {"vn_m38_mag",              {0, -1, 0, 3}},     // 5Rnd. M38 Clip. Caliber: 7.62x54mmR. Used in M38, VZ54, M1891 and M91/30 rifles
+    {"vn_m38_t_mag",            {0, -1, 0, 3}},     // 5Rnd. M38 Tracer Clip. Caliber: 7.62x54mmR. Used in M38, VZ54, M1891 and M91/30 rifles
+    {"vn_k98k_mag",             {0, -1, 0, -1}},    // 5Rnd. K98K Clip. Caliber: 7.92x57mm. Used in K98K
+    {"vn_k98k_t_mag",           {0, -1, 0, -1}},    // 5Rnd. K98K Tracer Clip. Caliber: 7.92x57mm Used in K98K
+    // Mags
+    {"vn_m14_10_mag",           {-1, 0, 0, -1}},    // 10Rnd. M14 Magazine. Caliber: 7.62x51mm. Used in M14 and XM21 Rifles
+    {"vn_m14_10_t_mag",         {-1, 0, 0, -1}},    // 10Rnd. M14 Tracer Magazine. Caliber: 7.62x51mm. Used in M14 and XM21 Rifles
+    {"vn_m14_mag",              {-1, 0, 0, -1}},    // 20Rnd. M14 Magazine. Caliber: 7.62x51mm. Used in M14 and XM21 Rifles
+    {"vn_m14_t_mag",            {-1, 0, 0, -1}},    // 20Rnd. M14 Tracer Magazine. Caliber: 7.62x51mm. Used in M14 and XM21 Rifles
+    {"vn_m16_20_mag",           {-1, 0, 0, -1}},    // 20Rnd. M16 Magazine. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
+    {"vn_m16_20_t_mag",         {-1, 0, 0, -1}},    // 20Rnd. M16 Tracer Magazine. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
+    {"vn_m16_30_mag",           {-1, 0, 0, -1}},    // 30Rnd. M16 Magazine. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
+    {"vn_m16_30_t_mag",         {-1, 0, 0, -1}},    // 30Rnd. M16 Tracer Magazine. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
+    {"vn_m16_40_mag",           {-1, 0, 0, -1}},    // Dual 20Rnd. M16 Magazines. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed to protect the spring
+    {"vn_m16_40_t_mag",         {-1, 0, 0, -1}},    // Dual 20Rnd. M16 Tracer Magazines. Caliber: 5.56x45mm. Used in M16 and XM177, 2 rounds removed
+    {"vn_m4956_10_mag",         {0, 0, 0, -1}},     // 10Rnd. M49/56 Carbine Magazine. Caliber: 7.5x54mm. Used in M49/56
+    {"vn_m4956_10_t_mag",       {0, 0, 0, -1}},     // 10Rnd. M49/56 Carbine Magazine. Caliber: 7.5x54mm. Used in M49/56. (Tracer)
+    {"vn_hp_sd_mag",            {0, 0, 0, -1}},     // 13Rnd. HP magazine. Caliber: 9mm Used in M1 Carbine (Shorty)
+    {"vn_carbine_15_mag",       {0, 0, 0, -1}},     // 15Rnd. M1/M2 Carbine. Caliber: 7.62x33mm. Used in M1 and M2 Carbines
+    {"vn_carbine_30_mag",       {0, 0, 0, -1}},     // 30Rnd. M1/M2 Carbine Magazine. Caliber: 7.62x33mm. Used in M1 and M2 Carbines
+    {"vn_carbine_15_t_mag",     {0, 0, 0, -1}},     // 15Rnd. M1/M2 Carbine Tracer Magazine. Caliber: 7.62x33mm. Used in M1 and M2 Carbines
+    {"vn_carbine_30_t_mag",     {0, 0, 0, -1}},     // 30Rnd. M1/M2 Carbine Tracer Magazine. Caliber: 7.62x33mm. Used in M1 and M2 Carbines
+    {"vn_l1a1_10_mag",          {-1, 0, 0, -1}},    // 10Rnd. L1A1/L2A1/L4 Mag. Calibre: 5.56x45mm. Used in L1A1/L2A1/L4
+    {"vn_l1a1_10_t_mag",        {-1, 0, 0, -1}},    // 10Rnd. L1A1/L2A1/L4 Mag. Calibre: 5.56x45mm. Used in L1A1/L2A1/L4 (Tracer)
+    {"vn_l1a1_20_mag",          {-1, 0, 0, -1}},    // 20Rnd. L1A1/L2A1/L4 Mag. Calibre: 7.62x51mm. Used in L1A1/L2A1/L4
+    {"vn_l1a1_20_t_mag",        {-1, 0, 0, -1}},    // 20Rnd. L1A1/L2A1/L4 Mag (Tracer). Calibre: 7.62x51mm. Used in L1A1/L2A1/L4
+    {"vn_l1a1_30_mag",          {-1, 0, 0, -1}},    // 30Rnd. L2A1/L1A1/L4 Mag. Calibre: 7.62x51mm. Used in L2A1/L1A1/L4
+    {"vn_l1a1_30_t_mag",        {-1, 0, 0, -1}},    // 30Rnd. L2A1/L1A1/L4 Tracer Mag. Calibre: 7.62x51mm. Used in L2A1/L1A1/L4
+    {"vn_l1a1_30_02_mag",       {-1, 0, 0, -1}},    // 30Rnd. L2A1/L1A1/L4 Mag Straight. Calibre: 7.62x51mm. Used in L2A1/L1A1/L4
+    {"vn_l1a1_30_02_t_mag",     {-1, 0, 0, -1}},    // 30Rnd. L2A1/L1A1/L4 Straight Tracer Mag. Calibre: 7.62x51mm. Used in L2A1/L1A1/L4
+    {"vn_m1a1_20_mag",          {-1, 0, 0, -1}},    // 20Rnd. M1A1 magazine. Caliber: 11.43x23mm. Used in M1A1 and M1928 Tommy gun
+    {"vn_m1a1_20_t_mag",        {-1, 0, 0, -1}},    // 20Rnd. M1A1 magazine. Caliber: 11.43x23mm. Used in M1A1 and M1928 Tommy gun (Tracer)
+    {"vn_m1a1_30_mag",          {-1, 0, 0, -1}},    // 30Rnd. M1A1 magazine. Caliber: 11.43x23mm. Used in M1A1 and M1928 Tommy gun
+    {"vn_m1a1_30_t_mag",        {-1, 0, 0, -1}},    // 30Rnd. M1A1 magazine. Caliber: 11.43x23mm. Used in M1A1 and M1928 Tommy gun (Tracer)
+    // OpFor
+    {"vn_type56_mag",           {0, -1, 0, -1}},    // 30Rnd. Type 56/AK Magazine. Caliber: 7.62x39mm. Used in Type 56/AK, AK and KBKG assault rifle
+    {"vn_type56_t_mag",         {0, -1, 0, -1}},    // 30Rnd. Type 56/AK Tracer Magazine. Caliber: 7.62x39mm. Used in Type 56/AK, AK and KBKG assault rifle
+    {"vn_svd_mag",              {0, -1, 0, -1}},    // 10Rnd. SVD Mag. Caliber: 7.62x54mm. Used in SVD sniper rifle
+    {"vn_svd_t_mag",            {0, -1, 0, -1}},    // 10Rnd. SVD Tracer Magazine. Caliber: 7.62x54mm Used in SVD sniper rifle
+    {"vn_kbkg_mag",             {0, -1, 0, -1}},    // 10Rnd. KBKG Mag. Caliber: 7.62x39mm. Used in KBKG, Type 56 and AK rifles
+    {"vn_kbkg_t_mag",           {0, -1, 0, -1}},    // 10Rnd. KBKG Tracer Magazine. Caliber: 7.62x39mm Used in KBKG, Type 56 and AK rifles
+    // MG Belts/Mags
+    {"vn_m1918_mag",            {-1, 0, 0, -1}},    // 20Rnd. M1918 Magazine. Calibre: 7.62x63mm. Used in M1918 automatic rifle
+    {"vn_m1918_t_mag",          {-1, 0, 0, -1}},    // 20Rnd. M1918 Tracer Magazine. Calibre: 7.62x63mm. Used in M1918 automatic rifle
+    {"vn_m60_100_mag",          {-1, 0, 0, -1}},    // 100Rnd. M60 Belt. Caliber: 7.62x51mm. Used in M60/ Shorty Machine Guns
+    {"vn_m63a_30_mag",          {-1, 0, 0, -1}},    // 30Rnd. STANAG Magazine. Caliber: 5.56x45mm. Used in M63A assault rifle
+    {"vn_m63a_30_t_mag",        {-1, 0, 0, -1}},    // 30Rnd. STANAG Tracer Magazine. Caliber: 5.56x45mm. Used in M63A assault rifle
+    {"vn_m63a_150_mag",         {-1, 0, 0, -1}},    // 150Rnd. M63A Drum. Caliber: 5.56x45mm. Used in M63A Commando
+    {"vn_m63a_150_t_mag",       {-1, 0, 0, -1}},    // 150Rnd. M63A Drum. Caliber: 5.56x45mm. Used in M63A Commando (Tracer)
+    {"vn_m63a_100_mag",         {-1, 0, 0, -1}},    // 100Rnd. M63A Box. Caliber: 5.56x45mm. Used in M63A LMG
+    {"vn_m63a_100_t_mag",       {-1, 0, 0, -1}},    // 100Rnd. M63A Box. Caliber: 5.56x45mm. Used in M63A LMG (Tracer)
+    // OpFor
+    {"vn_rpd_100_mag",          {0, -1, 0, -1}},    // 100Rnd. RPD Belt. Caliber: 7.62x39mm. Used in RPD Light machine gun
+    {"vn_rpd_125_mag",          {0, -1, 0, -1}},    // 125Rnd. RPD Belt. Caliber: 7.62x39mm. 1:1 tracer, used by US Special Forces in captured RPD machine guns
+    {"vn_pk_100_mag",           {0, -1, 0, -1}},    // 100Rnd. PK Belt. Caliber: 7.62x54mmR. Used in PK machine gun
+    {"vn_dp28_mag",             {0, -1, 0, -1}},    // 47Rnd. DP-27 Mag. Caliber: 7.62x54mmR. Used in DP-27 machine gun
+    {"vn_mg42_50_mag",          {0, -1, 0, -1}},    // 50Rnd. MG42 Drum. Calibre: 7.92x57mm. Used in MG42 machine gun
+    {"vn_mg42_50_t_mag",        {0, -1, 0, -1}},    // 50Rnd. MG42 Tracer Drum. Calibre: 7.92x57mm. Used in MG42 machine gun
+    // Pistol Mags
+    {"vn_hd_mag",               {0, 0, 0, -1}},     // 10Rnd. HD magazine. Caliber .22 LR. Used in HD pistol
+    {"vn_hp_mag",               {0, 0, 0, -1}},     // 13Rnd. HP magazine. Caliber: 9mm Used in HP pistol
+    {"vn_m1911_mag",            {0, 0, 0, -1}},     // 7Rnd. M1911 magazine. Caliber: .45in. Used in M1911 pistol
+    {"vn_m712_mag",             {0, 0, 0, 4}},      // 20Rnd. M712 Magazine. Caliber: 7.62x25mm. Used in M712 pistol
+    {"vn_mk22_mag",             {0, 0, 0, -1}},     // 14Rnd. Mk22 Magazine. Caliber: 9x19mm. Used in Mk22 Mod 0 pistol
+    {"vn_pm_mag",               {0, 0, 0, -1}},     // 8Rnd. PM magazine. Caliber: 9x18mm. Used in PM pistol
+    {"vn_tt33_mag",             {0, 0, 0, -1}},     // 8Rnd. TT-33 Magazine. Caliber: 7.62x25mm. Used in TT-33 pistol
+    {"vn_welrod_mag",           {0, 0, 0, -1}},     // 8Rnd. Welrod magazine. Caliber 7.65x17mm. Used in Welrod pistol
+    {"vn_vz61_mag",             {0, 0, 0, -1}},     // 20Rnd. VZ.61 SMG magazine. Caliber: 7.65x17mm. Used in VZ.61 Skorpion SMG
+    {"vn_vz61_t_mag",           {0, 0, 0, -1}},     // 20Rnd. VZ.61 SMG magazine. Caliber: 7.65x17mm. Used in VZ.61 Skorpion SMG (Tracer)
+    {"vn_ppk_mag",              {0, 0, 0, -1}},     // 7Rnd. PPK Mag. Caliber: 9x17mm. Used in PPK pistol
+    {"vn_p38_mag",              {0, 0, 0, -1}},     // 8Rnd. P38 Mag. Caliber: 9x19mm. Used in P38 pistol
+    // OpFor
+    {"vn_type64_mag",           {0, -1, 0, -1}},    // 9Rnd. Type 64 Mag. Caliber: 7.65x17mm. Used in Type 64 pistol
+    // SMG Mags
+    {"vn_m3a1_mag",             {-1, 0, 0, -1}},    // 30Rnd. M3A1 Magazine. Caliber: 11.43x23mm .45 cal. Used in M3A1 Submachinegun
+    {"vn_m3a1_t_mag",           {-1, 0, 0, -1}},    // 30Rnd. M3A1 Tracer Magazine. Caliber: 11.43x23mm .45 cal. Used in M3A1 Submachinegun
+    {"vn_m45_mag",              {-1, 0, 0, -1}},    // 36Rnd. M/45 Magazine. Caliber: 9x19mm. Used in M/45 Submachinegun
+    {"vn_m45_t_mag",            {-1, 0, 0, -1}},    // 36Rnd. M/45 Tracer Magazine. Caliber: 9x19mm. Used in M/45 Submachinegun
+    {"vn_mat49_mag",            {0, 0, 0, -1}},     // 32Rnd. MAT-49 Magazine. Caliber: 9x19mm Used in MAT-49 Submachinegun
+    {"vn_mat49_t_mag",          {0, 0, 0, -1}},     // 32Rnd. MAT-49 Tracer Magazine. Caliber: 9x19mm Used in MAT-49 Submachinegun
+    {"vn_mc10_mag",             {-1, 0, 0, -1}},    // 32Rnd. MC-10 SMG Magazine. Caliber: 9x19mm. Used in MC-10 SMG
+    {"vn_mc10_t_mag",           {-1, 0, 0, -1}},    // 32Rnd. MC-10 SMG Magazine. Caliber: 9x19mm. Used in MC-10 SMG. (Tracer)
+    {"vn_sten_mag",             {-1, 0, 0, -1}},    // 32Rnd. Sten Mk.II Magazine. Caliber: 9x19mm Used in Sten Mk.II Submachinegun
+    {"vn_sten_t_mag",           {-1, 0, 0, -1}},    // 32Rnd. Sten Mk.II Tracer Magazine. Caliber: 9x19mm Used in Sten Mk.II Submachinegun
+    {"vn_f1_smg_mag",           {-1, 0, 0, -1}},    // 34Rnd. F1/L2A3/L34A1 Mag. Calibre: 9x19mm. Used in F1, L2A3, L34A1 SMG
+    {"vn_f1_smg_t_mag",         {-1, 0, 0, -1}},    // 34Rnd. F1/L2A3/L34A1 Tracer Mag. Calibre: 9x19mm. Used in F1, L2A3, L34A1 SMG
+    {"vn_m1928_mag",            {-1, 0, 0, -1}},    // 50Rnd. M1928 magazine. Caliber: 11.43x23mm. Used in M1928 Tommy gun
+    {"vn_m1928_t_mag",          {-1, 0, 0, -1}},    // 50Rnd. M1928 magazine. Caliber: 11.43x23mm. Used in M1928 Tommy gun (Tracer)
+    {"vn_mpu_mag",              {-1, 0, 0, -1}},    // 32Rnd. MPU SMG magazine. Caliber: 9x19mm. Used in MPU SMG
+    {"vn_mpu_t_mag",            {-1, 0, 0, -1}},    // 32Rnd. MPU SMG Magazine. Caliber: 9x19mm. Used in MPU SMG (Tracer)
+    {"vn_l34a1_smg_mag",        {-1, 0, 6, -1}},    // 34Rnd. L34A1 Mag. Calibre: 9x19mm Subsonic. Used in L34A1 SMG
+    {"vn_l34a1_smg_t_mag",      {-1, 0, 6, -1}},    // 34Rnd. L34A1 Tracer Mag. Calibre: 9x19mm Subsonic. Used in L34A1 SMG
+    // OpFor
+    {"vn_mat49_vc_mag",         {0, -1, 0, -1}},    // 32Rnd. MAT-49 Magazine (VC). Caliber: 7.62x25mm Used in VC converted MAT-49 Submachinegun
+    {"vn_mat49_vc_t_mag",       {0, -1, 0, -1}},    // 32Rnd. MAT-49 Tracer Magazine (VC). Caliber: 7.62x25mm Used in VC converted MAT-49 Submachinegun
+    {"vn_type64_smg_mag",       {0, -1, 0, -1}},    // 30Rnd. Type 64 SMG Magazine. Caliber: 7.65x25mm Used in Type 64 SMG
+    {"vn_type64_smg_t_mag",     {0, -1, 0, -1}},    // 30Rnd. Type 64 SMG Tracer Magazine. Caliber: 7.65x25mm Used in Type 64 SMG
+    {"vn_mp40_mag",             {0, -1, 0, -1}},    // 32Rnd. MP40 Mag
+    {"vn_mp40_t_mag",           {0, -1, 0, -1}},    // 32Rnd. MP40 Mag (Tracer)
+    {"vn_pps_mag",              {0, -1, 0, -1}},    // 35Rnd. PPS Magazine. Caliber: 7.62x25mm. Used in PPS-43 and PPS-52 SMGs
+    {"vn_pps_t_mag",            {0, -1, 0, -1}},    // 35Rnd. PPS Tracer Magazine. Caliber: 7.62x25mm. Used in PPS-43 and PPS-52 SMGs
+    {"vn_ppsh41_35_mag",        {0, -1, 0, -1}},    // 35Rnd. PPSh-41 Magazine. Caliber: 7.62x25mm Used in PPSh-41 and K-50M Submachineguns
+    {"vn_ppsh41_35_t_mag",      {0, -1, 0, -1}},    // 35Rnd. PPSh-41 Tracer Magazine. Caliber: 7.62x25mm Used in PPSh-41 and K-50M Submachineguns
+    {"vn_ppsh41_71_mag",        {0, -1, 0, -1}},    // 71Rnd. PPSh-41 Magazine. Caliber: 7.62x25mm Used in PPSh-41 and K-50M Submachineguns
+    {"vn_ppsh41_71_t_mag",      {0, -1, 0, -1}},    // 71Rnd. PPSh-41 Tracer Magazine. Caliber: 7.62x25mm Used in PPSh-41 and K-50M Submachineguns
+    // Revolver Ammo
+    {"vn_m10_mag",              {0, 0, 0, -1}},     // 6Rnd. .38 revolver. Caliber: .38 revolver. Used in M10 and .38 revolvers
+    {"vn_m1895_mag",            {0, 0, 0, -1}},     // 7Rnd. M1895 reload. Caliber 7.62x38mm. Used in Model 1895 revolver
+    {"vn_mk1_udg_mag",          {-1, 0, 0, -1}},    // 6Rnd. Mk1 UDG magazine. Caliber: 4.25in Mk59 dart. Used in Mk1 Underwater Defence Gun
+    // Shotgun Ammo
+    {"vn_m1897_buck_mag",       {-1, 0, 0, -1}},    // 6Rnd. M1897 Reload. Caliber: 12 gauge buckshot. Used in Model 1897 shotgun
+    {"vn_m1897_fl_mag",         {-1, 0, 0, -1}},    // 6Rnd. M1897 Reload. Caliber: 12 gauge flechette. Used in Model 1897 shotgun
+    // OpFor
+    {"vn_izh54_mag",            {0, -1, 0, -1}},    // 2Rnd. ISh-54 Reload. Caliber: 12 gauge buckshot. Used in ISh-54 shotgun
+    {"vn_izh54_so_mag",         {0, -1, 0, -1}},    // 2Rnd. ISh-54 Sawn-off. Caliber: 12 gauge buckshot. Used in ISh-54 shotgun
+    // Grenades
+    {"vn_v40_grenade_mag",      {-1, 0, 0, -1}},    // Grenade V40 (Frag)
+    {"vn_m61_grenade_mag",      {-1, 0, 0, -1}},    // Grenade M61 (Frag)
+    {"vn_m67_grenade_mag",      {-1, 0, 0, -1}},    // Grenade M67 (Frag)
+    {"vn_m14_grenade_mag",      {-1, 0, 0, -1}},    // Grenade M14 (Incendiary)
+    {"vn_m14_early_grenade_mag", {-1, -1, -1, -1}}, // Grenade M14-A (Incendiary)
+    {"vn_m34_grenade_mag",      {-1, 0, 0, -1}},    // Grenade M34 (WP)
+    {"vn_m7_grenade_mag",       {-1, 0, 0, -1}},    // Grenade M7A3 (CS Gas)
+    {"vn_m18_green_mag",        {-1, 0, 0, -1}},    // Grenade Smoke (Green)
+    {"vn_m18_purple_mag",       {-1, 0, 0, -1}},    // Grenade Smoke (Purple)
+    {"vn_m18_red_mag",          {-1, 0, 0, -1}},    // Grenade Smoke (Red)
+    {"vn_m18_white_mag",        {-1, 0, 0, -1}},    // Grenade Smoke (White)
+    {"vn_m18_yellow_mag",       {-1, 0, 0, -1}},    // Grenade Smoke (Yellow)
+    {"Chemlight_blue",          {-1, 0, 0, -1}},    //
+    {"Chemlight_green",         {-1, 0, 0, -1}},    //
+    {"Chemlight_yellow",        {-1, 0, 0, -1}},    //
+    // OpFor
+    {"vn_t67_grenade_mag",      {0, -1, 0, -1}},    // Grenade Type67 (Frag)
+    {"vn_chicom_grenade_mag",   {0, -1, 0, -1}},    // Grenade Chicom (Frag)
+    {"vn_rg42_grenade_mag",     {0, -1, 0, -1}},    // Grenade RG-42 (Frag)
+    {"vn_rgd33_grenade_mag",    {0, -1, 0, -1}},    // Grenade RGD-33 (Frag)
+    {"vn_rgd5_grenade_mag",     {0, -1, 0, -1}},    // Grenade RGD-5 (Frag)
+    {"vn_rkg3_grenade_mag",     {0, -1, 0, -1}},    // Grenade RKG-3 (HEAT)
+    {"vn_molotov_grenade_mag",  {0, -1, 0, 0}},     // Grenade (Molotov Cocktail)
+    {"vn_rdg2_mag",             {0, -1, 0, -1}},    // Grenade RDG-2 Smoke (White)
+    {"vn_f1_grenade_mag",       {0, -1, 0, -1}},    // Grenade F-1 (Frag)
+    {"Chemlight_red",           {0, -1, 0, -1}},    //
+    // Rockets/Missiles
+    {"vn_m72_mag",              {-1, 0, 0, -1}},    // M72 66mm HEAT Rocket. Used in M72 single-shot, disposable rocket launcher
+    {"vn_m20a1b1_heat_mag",     {-1, 0, 0, -1}},    // M28A2 HEAT Rocket. Used in M20A1B1 Super Bazooka
+    {"vn_m20a1b1_wp_mag",       {-1, 0, 0, -1}},    // M30 WP Rocket. Used in M20A1B1 Super Bazooka
+    // OpFor
+    {"vn_rpg2_mag",             {0, -1, 0, -1}},    // PG-2 82mm HEAT Rocket. Used in B40 hand-held, anti-tank grenade-launcher
+    {"vn_rpg7_mag",             {0, -1, 0, -1}},    // PG-7V 85mm HEAT Rocket. Used in B41 hand-held, anti-tank grenade-launcher
+    {"vn_sa7_mag",              {0, -1, 0, -1}},    // Strela-2 72mm Anti-Aircraft Missile. Used in 9K32 hand-held, anti-aircraft missile system
+    {"vn_sa7b_mag",             {0, -1, 0, -1}},    // Strela-2M 72mm Anti-Aircraft Missile. Used in 9K32 hand-held, anti-aircraft missile system
+    {"vn_rpg2_fuze_mag",        {0, -1, 0, -1}},    // PG-2 82mm Fuze Rocket. Used in B40 hand-held, anti-tank grenade-launcher
+    // Explosives
+    {"vn_mine_m112_remote_mag", {-1, 0, 0, -1}},    // M112 Breaching charge
+    {"vn_mine_m14_mag",         {-1, 0, 0, -1}},    // Mine M14 Toe-popper
+    {"vn_mine_m15_mag",         {-1, 0, 0, -1}},    // Mine M15 Anti-Tank
+    {"vn_mine_m16_mag",         {-1, 0, 0, -1}},    // Mine M16 Bounding
+    {"vn_mine_m18_mag",         {-1, 0, 0, -1}},    // Mine M18 Claymore (Remote)
+    {"vn_mine_m18_range_mag",   {-1, 0, 0, -1}},    // Mine M18 Claymore (Proximity)
+    {"vn_mine_m18_x3_mag",      {-1, 0, 0, -1}},    // Mine M18 Claymore x3 (Remote)
+    {"vn_mine_m18_x3_range_mag", {-1, 0, 0, -1}},   // Mine M18 Claymore x3 (Proximity)
+    {"vn_mine_satchel_remote_02_mag", {0, 0, 0, -1}}, // Satchel charge
+    {"vn_mine_tripwire_m16_02_mag", {-1, 0, 0, -1}}, // Mine M16 2m tripwire
+    {"vn_mine_tripwire_m16_04_mag", {-1, 0, 0, -1}}, // Mine M16 4m tripwire
+    {"vn_mine_tripwire_m49_02_mag", {-1, 0, 0, -1}}, // Mine M49A1 2m tripwire (Flare)
+    {"vn_mine_tripwire_m49_04_mag", {-1, 0, 0, -1}}, // Mine M49A1 4m tripwire (Flare)
+    {"vn_mine_bangalore_mag",   {-1, 0, 0, -1}},    // Mine Bangalore (Remote)
+    {"vn_mine_limpet_01_mag",   {-1, 0, 0, -1}},    // Mine Limpet US (Remote)
+    {"vn_mine_tripwire_m16_02_mag", {-1, 0, 0, -1}}, //
+    {"vn_mine_tripwire_m16_04_mag", {-1, 0, 0, -1}}, //
+    {"vn_mine_m18_fuze10_mag",  {-1, 0, 0, -1}},    // Mine M18 Claymore (10s Fuze)
+    {"vn_mine_m18_wp_mag",      {-1, 0, 0, -1}},    // Mine M18/WP Claymore (Remote)
+    {"vn_mine_m18_wp_range_mag", {-1, 0, 0, -1}},   // Mine M18/WP Claymore (Proximity)
+    {"vn_mine_m18_wp_fuze10_mag", {-1, 0, 0, -1}},  // Mine M18/WP Claymore (10s Fuze)
+    // OpFor
+    {"vn_mine_ammobox_range_mag", {0, -1, 0, -1}},  // Mine Ammobox (booby-trapped)
+    {"vn_mine_punji_01_mag",    {0, -1, 0, -1}},    // Trap punji (Large)
+    {"vn_mine_punji_02_mag",    {0, -1, 0, -1}},    // Trap punji (Small)
+    {"vn_mine_punji_03_mag",    {0, -1, 0, -1}},    // Trap punji (Whip)
+    {"vn_mine_tm57_mag",        {0, -1, 0, -1}},    // Mine TM-57 Anti-Tank
+    {"vn_mine_tripwire_arty_mag", {0, -1, 0, -1}},  // Trap IED 4m tripwire
+    {"vn_mine_tripwire_f1_02_mag", {0, -1, 0, -1}}, // Trap F-1 2m tripwire
+    {"vn_mine_tripwire_f1_04_mag", {0, -1, 0, -1}}, // Trap F-1 4m tripwire
+    {"vn_mine_bike_mag",        {0, -1, 0, -1}},    // Mine Bicycle (Remote)
+    {"vn_mine_bike_range_mag",  {0, -1, 0, -1}},    // Mine Bicycle (Proximity)
+    {"vn_mine_cartridge_mag",   {0, -1, 0, -1}},    // Mine Cartridge (Proximity)
+    {"vn_mine_dh10_mag",        {0, -1, 0, -1}},    // Mine DH10 (Remote)
+    {"vn_mine_dh10_range_mag",  {0, -1, 0, -1}},    // Mine DH10 (Proximity)
+    {"vn_mine_jerrycan_mag",    {0, -1, 0, -1}},    // Mine Jerry Can (Remote)
+    {"vn_mine_jerrycan_range_mag", {0, -1, 0, -1}}, // Mine Jerry Can (Proximity)
+    {"vn_mine_lighter_mag",     {0, -1, 0, -1}},    // Mine Lighter (Proximity)
+    {"vn_mine_mortar_range_mag", {0, -1, 0, -1}},   // Mine Mortar (Proximity)
+    {"vn_mine_chicom_no8_mag",  {0, -1, 0, -1}},    // Mine No 8 (Proximity)
+    {"vn_mine_pot_mag",         {0, -1, 0, -1}},    // Mine Pot (Remote)
+    {"vn_mine_pot_range_mag",   {0, -1, 0, -1}},    // Mine Pot (Proximity)
+    {"vn_mine_gboard_range_mag", {0, -1, 0, -1}},   // Trap RGD5 4m (AP)
+    {"vn_mine_punji_04_mag",    {0, -1, 0, -1}},    // Trap punji (Doorway)
+    {"vn_mine_punji_05_mag",    {0, -1, 0, -1}},    // Trap punji (Side Whip Tripwire)
+    {"vn_satchelcharge_02_throw_mag", {0, -1, 0, -1}}, // Satchel charge (Thrown)
+    {"vn_mine_limpet_02_mag",   {0, -1, 0, -1}},    // Mine Limpet Russian (Remote)
+    // Other
+    {"vn_m127_mag",             {-1, 0, 0,-1}},     // M127 Flare Launcher
+    {"vn_m128_mag",             {-1, 0, 0,-1}},     // M128 Flare Launcher (Green)
+    {"vn_m129_mag",             {-1, 0, 0,-1}},     // M129 Flare Launcher (Red)
+    {"vn_prop_fort_mag",        {0, 0, 0, 0}},      // Sandbag
+    {"MineDetector",            {0, 0, 0,-1}},      // Mine Detector ARMA 3 Modern
+    {"vn_b_item_trapkit",       {0, 0, 0,-1}},      // Trapkit
+    {"vn_b_item_lighter_01",    {0, 0, 0,-1}},      // Lighter
+    {"vn_b_item_cigs_01",       {0, 0, 0,-1}},      // Cigs
+    // Vehicle Ammo
+    {"vn_v_m18r_mag",           {-1,-1, 0,-1}}, //
+    {"vn_v_m61_mag",            {-1,-1, 0,-1}}, //
+    {"vn_v_m7_mag",             {-1,-1, 0,-1}}, //
+    {"vn_v_rdg2_mag",           {-1,-1, 0,-1}}, //
+    {"vn_v_rgd5_mag",           {-1,-1, 0,-1}}, //
+    {"vn_type56_v_12_he_mag",   {-1,-1, 0,-1}}, //
+    {"vn_type56_v_12_heat_mag", {-1,-1, 0,-1}}, //
+    // Food and Drink
+    {"vn_prop_drink_01",        {0, 0, 0, 0}},
+    {"vn_prop_drink_02",        {0, 0, 0, 0}},
+    {"vn_prop_drink_03",        {0, 0, 0, 0}},
+    {"vn_prop_drink_04",        {0, 0, 0, 0}},
+    {"vn_prop_drink_05",        {0, 0, 0, 0}},
+    {"vn_prop_drink_06",        {0, 0, 0, 0}},
+    {"vn_prop_drink_07_01",     {0,-1, 0, 0}},
+    {"vn_prop_drink_07_02",     {0,-1, 0, 0}},
+    {"vn_prop_drink_07_03",     {0,-1, 0, 0}},
+    {"vn_prop_drink_08_01",     {0,-1, 0, 0}},
+    {"vn_prop_drink_09_01",     {0, 0, 0, 0}},
+    {"vn_prop_food_box_01_01",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_01_02",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_01_03",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_02_01",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_02_02",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_02_03",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_02_04",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_02_05",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_02_06",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_02_07",  {0, 0, 0, 0}},
+    {"vn_prop_food_box_02_08",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_01",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_02",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_03",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_04",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_05",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_06",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_07",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_08",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_09",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_10",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_11",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_12",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_13",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_14",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_15",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_01_16",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_02_01",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_02_02",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_02_03",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_02_04",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_02_05",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_02_06",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_02_07",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_02_08",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_03_01",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_03_02",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_03_03",  {0, 0, 0, 0}},
+    {"vn_prop_food_can_03_04",  {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_01",   {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_02",   {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_03",   {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_04",   {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_05",   {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_06",   {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_07",   {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_08",   {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_09",   {0, 0, 0, 0}},
+    {"vn_prop_food_fresh_10",   {0, 0, 0, 0}},
+    {"vn_prop_food_lrrp_01_01", {0, 0, 0, 0}},
+    {"vn_prop_food_lrrp_01_02", {0, 0, 0, 0}},
+    {"vn_prop_food_lrrp_01_03", {0, 0, 0, 0}},
+    {"vn_prop_food_lrrp_01_04", {0, 0, 0, 0}},
+    {"vn_prop_food_lrrp_01_05", {0, 0, 0, 0}},
+    {"vn_prop_food_lrrp_01_06", {0, 0, 0, 0}},
+    {"vn_prop_food_lrrp_01_07", {0, 0, 0, 0}},
+    {"vn_prop_food_lrrp_01_08", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01",    {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_01", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_02", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_03", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_04", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_05", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_06", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_07", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_08", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_09", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_10", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_11", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_12", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_13", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_14", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_15", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_16", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_17", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_01_18", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_02_01", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_02_02", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_02_03", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_02_04", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_02_05", {0, 0, 0, 0}},
+    {"vn_prop_food_meal_02_06", {0, 0, 0, 0}},
+    {"vn_prop_food_pir_01_01",  {0, 0, 0, 0}},
+    {"vn_prop_food_pir_01_02",  {0, 0, 0, 0}},
+    {"vn_prop_food_pir_01_03",  {0, 0, 0, 0}},
+    {"vn_prop_food_pir_01_04",  {0, 0, 0, 0}},
+    {"vn_prop_food_pir_01_05",  {0, 0, 0, 0}},
+    {"vn_prop_food_sack_01",    {0, 0, 0, 0}},
+    {"vn_prop_food_sack_02",    {0, 0, 0, 0}},
+    // Medication
+    {"vn_prop_med_antibiotics", {0, 0, 0, 0}},
+    {"vn_prop_med_antimalaria", {0, 0, 0, 0}},
+    {"vn_prop_med_antivenom",   {-1,-1,-1,-1}},
+    {"vn_prop_med_dysentery",   {0, 0, 0, 0}},
+    {"vn_prop_med_painkillers", {0, 0, 0, 0}},
+    {"vn_prop_med_wormpowder",  {0, 0, 0, 0}},
+};
+
+items[] =   {
+/*
+    // Nickel Steel
+    // Uniforms
+    {"vnx_b_helmet_aph6_01_06", {-1, 0, 0, 0}}, // Helmet APH-6 Olive Green
+    {"vnx_b_helmet_aph6_02_06", {-1, 0, 0, 0}}, // Helmet APH-6 Olive Green (visor down)
+    {"vnx_b_helmet_hgu7_01_01", {-1, 0, 0, 0}}, // Helmet HGU-7-P (White)
+    {"vnx_b_helmet_hgu7_01_02", {-1, 0, 0, 0}}, // Helmet HGU-7-P (Tape)
+    {"vnx_b_helmet_hgu7_01_03", {-1, 0, 0, 0}}, // Helmet HGU-7-P (Camo)
+    {"vnx_b_helmet_hgu7_01_04", {-1, 0, 0, 0}}, // Helmet HGU-7-P (Black)
+    {"vnx_b_helmet_hgu7_02_01", {-1, 0, 0, 0}}, // Helmet HGU-7-P (Visor/White)
+    {"vnx_b_helmet_hgu7_02_02", {-1, 0, 0, 0}}, // Helmet HGU-7-P (Visor/Tape)
+    {"vnx_b_helmet_hgu7_02_03", {-1, 0, 0, 0}}, // Helmet HGU-7-P (Visor/Camo)
+    {"vnx_b_uniform_cwu_01",    {-1, 0, 0, 0}}, // CWU-28/P Jet Summer suit
+    {"vnx_b_uniform_cwu_02",    {-1, 0, 0, 0}}, // CWU-28/P Summer suit
+    {"vnx_b_uniform_cwu_03",    {-1, 0, 0, 0}}, // CWU-28/P Jet Summer MA-1 Jacket
+    {"vnx_b_uniform_cwu_04",    {-1, 0, 0, 0}}, // CWU-28/P Summer MA-1 Jacket
+    {"vnx_b_uniform_heli_01_19", {-1, 0, 0, 0}}, // BDU US Army Aircrew (Thai Tiger)
+    {"vnx_b_uniform_k2b_01_19", {-1, 0, 0, 0}}, // K2B USAF Jet Crew (Thai Tiger)
+    {"vnx_b_uniform_k2b_02_19", {-1, 0, 0, 0}}, // K2B USAF Heli Crew (Thai Tiger)
+    {"vnx_b_uniform_macv_01_19", {-1, 0, 0, 0}}, // BDU MACV 1 (Thai Tiger)
+    {"vnx_b_uniform_macv_02_19", {-1, 0, 0, 0}}, // BDU MACV 2 (Thai Tiger)
+    {"vnx_b_uniform_macv_03_19", {-1, 0, 0, 0}}, // BDU MACV 3 (Thai Tiger)
+    {"vnx_b_uniform_macv_04_19", {-1, 0, 0, 0}}, // BDU MACV 4 (Thai Tiger)
+    {"vnx_b_uniform_macv_05_19", {-1, 0, 0, 0}}, // BDU MACV 5 (Thai Tiger)
+    {"vnx_b_uniform_macv_06_19", {-1, 0, 0, 0}}, // BDU MACV 6 (Thai Tiger)
+    {"vnx_b_uniform_sog_01_19", {-1, 0, 0, 0}}, // BDU SOG 1 (Thai Tiger)
+    {"vnx_b_uniform_sog_02_19", {-1, 0, 0, 0}}, // BDU SOG 2 (Thai Tiger)
+    {"vnx_b_vest_usaf_01",      {-1, 0, 0, 0}}, // Vest - USAF (Aircrew 1), C-1 Survival vest
+    {"vnx_b_vest_usaf_02",      {-1, 0, 0, 0}}, // Vest - USAF (Aircrew 2), C-1 Survival vest
+    {"vnx_b_vest_usaf_03",      {-1, 0, 0, 0}}, // Vest - USAF (Aircrew 3), C-1 Survival vest
+    {"vnx_b_vest_usaf_04",      {-1, 0, 0, 0}}, // Vest - USAF (Security 1), CSPS Patrol
+    {"vnx_b_vest_usaf_05",      {-1, 0, 0, 0}}, // Vest - USAF (Security 2), CSPS Patrol
+    {"vnx_b_vest_usaf_06",      {-1, 0, 0, 0}}, // Vest - USAF (Security 3), CSPS Lead patrol
+    {"vnx_b_vest_usaf_07",      {-1, 0, 0, 0}}, // Vest - USAF (Security 4), CSPS lead patrol
+*/
+    // Basics
+    {"vn_b_item_lighter_01",    {-1, -1, -1, -1}},
+    {"FirstAidKit",             {-1, -1, -1, -1}},
+    {"ItemCompass",             {-1, -1, -1, -1}},
+    {"ItemMap",                 {-1, -1, -1, -1}},
+    {"ItemRadio",               {-1, -1, -1, -1}},
+    {"ItemWatch",               {-1, -1, -1, -1}},
+    {"Medikit",                 {-1, -1, -1, -1}},
+    {"Toolkit",                 {-1, -1, -1, -1}},
+    {"vn_o_item_firstaidkit",   {0, -1, 0, -1}},
+    {"vn_o_item_map",           {0, -1, 0, -1}},
+    {"vn_o_item_radio_m252",    {0, -1, 0, -1}},
+    {"vn_b_item_compass",       {0, 0, 0, -1}},
+    {"vn_b_item_compass_sog",   {0, 0, 0, -1}},
+    {"vn_b_item_firstaidkit",   {-1, 0, 0, -1}},
+    {"vn_b_item_map",           {-1, 0, 0, -1}},
+    {"vn_b_item_medikit_01",    {-1, 0, 0, -1}},
+    {"vn_b_item_radio_urc10",   {-1, 0, 0, -1}},
+    {"vn_b_item_toolkit",       {0, 0, 0, -1}},
+    {"vn_b_item_watch",         {0, 0, 0, -1}},
+    {"vn_b_item_wiretap",       {0, 0, 0, -1}},
+    {"MineDetector",            {0, 0, 0, -1}},
+    {"vn_b_prop_camera_01",     {-1, -1, -1, 0}},
+    // OpFor
+    {"vn_o_item_firstaidkit",   {0, -1, 0, -1}},
+    {"vn_o_item_map",           {0, -1, 0, -1}},
+    {"vn_o_item_radio_m252",    {0, -1, 0, -1}},
+    // Facewear
+    {"G_Aviator",               {0, 0, 0, -1}},
+    {"G_Bandanna_aviator",      {-1, 0, 0, -1}},
+    {"G_Bandanna_blk",          {-1, 0, 0, -1}},
+    {"G_Bandanna_oli",          {-1, 0, 0, -1}},
+    {"G_Spectacles_Tinted",     {0, 0, 0, -1}},
+    {"vn_b_acc_goggles_01",     {-1, 0, 0, -1}},
+    {"vn_b_acc_m17_01",         {-1, 0, 0, -1}},
+    {"vn_b_acc_m17_02",         {-1, 0, 0, -1}},
+    {"vn_b_acc_ms22001_01",     {-1, 0, 0, -1}},
+    {"vn_b_acc_ms22001_02",     {-1, 0, 0, -1}},
+    {"vn_b_aviator",            {0, 0, 0, -1}},
+    {"vn_b_acc_rag_01",         {-1, 0, 0, -1}},
+    {"vn_b_acc_rag_02",         {-1, 0, 0, -1}},
+    {"vn_b_acc_towel_01",       {-1, 0, 0, -1}},
+    {"vn_b_acc_towel_02",       {-1, 0, 0, -1}},
+    {"vn_b_bandana_a",          {-1, 0, 0, -1}},
+    {"vn_b_scarf_01_01",        {-1, 0, 0, -1}},
+    {"vn_b_scarf_01_03",        {0, 0, 0, -1}},
+    {"vn_b_spectacles",         {0, 0, 0, -1}},
+    {"vn_b_spectacles_tinted",  {0, 0, 0, -1}},
+    {"vn_b_squares",            {0, 0, 0, -1}},
+    {"vn_b_squares_tinted",     {0, 0, 0, -1}},
+    {"vn_g_glasses_01",         {0, 0, 0, -1}},
+    {"vn_g_spectacles_01",      {0, 0, 0, -1}},
+    {"vn_g_spectacles_02",      {0, 0, 0, -1}},
+    {"vn_b_acc_seal_01",        {-1, 0, 0, -1}},
+    // OpFor
+    {"vn_o_acc_goggles_01",     {-1, 0, 0, -1}},
+    {"vn_o_acc_goggles_02",     {-1, 0, 0, -1}},
+    {"vn_o_acc_goggles_03",     {-1, 0, 0, -1}},
+    {"vn_o_acc_km32_01",        {-1, 0, 0, -1}},
+    {"vn_o_scarf_01_01",        {0, 0, 0, -1}},
+    {"vn_o_scarf_01_02",        {0, 0, 0, -1}},
+    {"vn_o_scarf_01_03",        {0, 0, 0, -1}},
+    {"vn_o_scarf_01_04",        {0, 0, 0, -1}},
+    {"vn_o_bandana_b",          {-1, 0, 0, -1}},
+    {"vn_o_bandana_g",          {-1, 0, 0, -1}},
+    {"vn_o_poncho_01_01",       {0, -1, 0, -1}},
+    // Headgear
+    {"vn_b_beret_01_01",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_02",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_03",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_04",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_05",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_06",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_07",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_08",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_09",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_10",        {-1, 0, 0, -1}},
+    {"vn_b_beret_01_11",        {-1, 0, 0, -1}},
+    {"vn_b_beret_03_01",        {-1, 0, 0, -1}},
+    {"vn_b_beret_04_01",        {-1, 0, 0, -1}},
+    {"vn_i_beret_01_01",        {-1, 0, 0, -1}},
+    {"vn_i_beret_03_01",        {-1, 0, 0, -1}},
+    {"vn_i_beret_03_02",        {-1, 0, 0, -1}},
+    {"vn_i_beret_03_03",        {-1, 0, 0, -1}},
+    {"vn_i_beret_03_04",        {-1, 0, 0, -1}},
+    {"vn_b_bandana_01",         {0, 0, 0, -1}},
+    {"vn_b_bandana_02",         {-1, 0, 0, -1}},
+    {"vn_b_bandana_03",         {0, 0, 0, -1}},
+    {"vn_b_bandana_04",         {-1, 0, 0, -1}},
+    {"vn_b_bandana_05",         {-1, 0, 0, -1}},
+    {"vn_b_bandana_06",         {-1, 0, 0, -1}},
+    {"vn_b_bandana_07",         {-1, 0, 0, -1}},
+    {"vn_b_bandana_08",         {-1, 0, 0, -1}},
+    {"vn_b_boonie_01_01",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_01_02",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_01_03",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_01_04",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_01_05",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_01_06",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_01_07",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_01_08",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_02_01",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_02_02",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_02_03",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_02_04",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_02_05",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_02_06",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_02_07",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_02_08",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_03_01",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_03_02",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_03_03",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_03_04",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_03_05",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_03_06",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_03_07",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_03_08",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_04_01",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_04_02",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_04_03",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_04_04",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_04_05",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_04_06",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_04_07",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_04_08",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_05_01",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_05_02",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_05_03",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_05_04",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_05_05",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_05_06",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_05_07",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_05_08",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_06_01",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_07_01",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_08_01",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_06_02",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_07_02",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_08_02",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_09_01",       {-1, -1, -1, -1}},
+    {"vn_b_boonie_09_02",       {-1, -1, -1, -1}},
+    {"vn_b_boonie_09_03",       {-1, -1, -1, -1}},
+    {"vn_b_boonie_09_04",       {-1, -1, -1, -1}},
+    {"vn_b_boonie_09_05",       {-1, -1, -1, -1}},
+    {"vn_b_boonie_09_06",       {-1, -1, -1, -1}},
+    {"vn_b_boonie_09_07",       {-1, -1, -1, -1}},
+    {"vn_b_boonie_09_08",       {-1, -1, -1, -1}},
+    {"vn_b_boonie_09_09",       {-1, -1, -1, -1}},
+    {"vn_b_boonie_01_09",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_02_09",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_03_09",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_04_09",       {-1, 0, 0, -1}},
+    {"vn_b_boonie_05_09",       {-1, 0, 0, -1}},
+    {"vn_b_headband_01",        {0, 0, 0, -1}},
+    {"vn_b_headband_02",        {-1, 0, 0, -1}},
+    {"vn_b_headband_03",        {0, 0, 0, -1}},
+    {"vn_b_headband_04",        {-1, 0, 0, -1}},
+    {"vn_b_headband_05",        {-1, 0, 0, -1}},
+    {"vn_b_headband_08",        {-1, 0, 0, -1}},
+    {"vn_c_headband_01",        {0, 0, 0, -1}},
+    {"vn_c_headband_02",        {0, 0, 0, -1}},
+    {"vn_c_headband_03",        {0, 0, 0, -1}},
+    {"vn_c_headband_04",        {0, 0, 0, -1}},
+    // OpFor
+    {"vn_o_boonie_nva_02_01", {0, -1, 0, -1}},
+    {"vn_o_boonie_nva_02_02", {0, -1, 0, -1}},
+    {"vn_o_boonie_vc_01_01", {0, -1, 0, -1}},
+    {"vn_o_boonie_vc_01_02", {0, -1, 0, -1}},
+    {"vn_o_boonie_vc_02_01", {0, -1, 0, -1}},
+    {"vn_o_boonie_vc_02_02", {0, -1, 0, -1}},
+    {"vn_o_cap_navy_01", {0, -1, 0, -1}},
+    {"vn_c_conehat_01", {0, -1, 0, -1}},
+    {"vn_c_conehat_02", {0, -1, 0, -1}},
+    {"vn_o_pl_cap_02_01", {0, -1, 0, -1}},
+    {"vn_o_pl_cap_01_01", {0, -1, 0, -1}},
+    {"vn_o_pl_cap_02_02", {0, -1, 0, -1}},
+    {"vn_o_cap_01", {0, -1, 0, -1}},
+    {"vn_o_cap_02", {0, -1, 0, -1}},
+    // Helmet
+    {"vn_i_helmet_m1_01_01", {-1, 0, 0, -1}},
+    {"vn_i_helmet_m1_01_02", {-1, 0, 0, -1}},
+    {"vn_i_helmet_m1_02_01", {-1, 0, 0, -1}},
+    {"vn_i_helmet_m1_03_01", {-1, 0, 0, -1}},
+    {"vn_i_helmet_m1_02_02", {-1, 0, 0, -1}},
+    {"vn_i_helmet_m1_03_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_01_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_01_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_01_03", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_01_04", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_01_05", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_01_06", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_02_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_02_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_02_03", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_02_04", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_02_05", {-1, 0, 0, -1}},
+    {"vn_b_helmet_svh4_02_06", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_01_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_01_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_01_03", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_01_04", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_01_05", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_02_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_02_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_02_03", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_02_04", {-1, 0, 0, -1}},
+    {"vn_b_helmet_aph6_02_05", {-1, 0, 0, -1}},
+    {"vn_b_helmet_t56_01_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_t56_01_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_t56_01_03", {-1, 0, 0, -1}},
+    {"vn_b_helmet_t56_02_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_t56_02_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_t56_02_03", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_01_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_01_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_02_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_02_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_03_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_03_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_04_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_04_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_05_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_05_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_06_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_06_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_07_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_07_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_08_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_08_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_09_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_09_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_10_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_11_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_12_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_12_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_14_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_14_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_15_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_15_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_16_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_16_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_17_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_17_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_18_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_18_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_19_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_19_02", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_20_01", {-1, 0, 0, -1}},
+    {"vn_b_helmet_m1_20_02", {-1, 0, 0, -1}},
+    // OpFor
+    {"vn_b_helmet_sog_01", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_01", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_02", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_03", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_04", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_05", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_06", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_07", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_08", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_09", {0, -1, -1, -1}},
+    {"vn_o_helmet_nva_10", {0, -1, -1, -1}},
+    {"vn_o_helmet_vc_01", {0, -1, -1, -1}},
+    {"vn_o_helmet_vc_02", {0, -1, -1, -1}},
+    {"vn_o_helmet_vc_03", {0, -1, -1, -1}},
+    {"vn_o_helmet_vc_04", {0, -1, -1, -1}},
+    {"vn_o_helmet_vc_05", {0, -1, -1, -1}},
+    {"vn_o_helmet_shl61_01", {0, -1, -1, -1}},
+    {"vn_o_helmet_shl61_02", {0, -1, -1, -1}},
+    {"vn_o_helmet_tsh3_01", {0, -1, -1, -1}},
+    {"vn_o_helmet_tsh3_02", {0, -1, -1, -1}},
+    {"vn_o_helmet_zsh3_01", {0, -1, -1, -1}},
+    {"vn_o_helmet_zsh3_02", {0, -1, -1, -1}},
+    // Uniforms
+    // US Air Uniforms
+    {"vn_b_uniform_heli_01_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_01_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_01_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_01_04", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_01_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_02_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_02_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_02_03", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_02_04", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_02_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_03_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_k2b_03_02", {-1, 0, 0, -1}},
+    // US Infantry Uniforms
+    {"vn_b_uniform_macv_01_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_03", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_04", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_08", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_15", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_16", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_17", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_18", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_22", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_23", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_24", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_25", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_01_26", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_08", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_15", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_16", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_17", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_02_18", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_08", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_15", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_16", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_17", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_03_18", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_08", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_15", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_16", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_17", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_18", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_20", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_04_21", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_08", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_15", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_16", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_17", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_05_18", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_08", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_15", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_16", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_17", {-1, 0, 0, -1}},
+    {"vn_b_uniform_macv_06_18", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_01_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_01_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_01_03", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_01_04", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_01_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_01_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_02_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_02_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_02_03", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_02_04", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_02_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sog_02_06", {-1, 0, 0, -1}},
+    // Seal
+    {"vn_b_uniform_seal_01_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_01_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_01_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_01_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_01_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_02_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_02_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_02_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_02_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_02_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_03_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_04_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_05_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_05_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_05_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_05_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_05_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_06_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_06_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_06_07", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_06_05", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_06_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_07_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_07_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_07_03", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_07_04", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_08_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_08_02", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_08_03", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_08_04", {-1, 0, 0, -1}},
+    {"vn_b_uniform_seal_09_01", {-1, 0, 0, -1}},
+    // Anzac
+    {"vn_b_uniform_aus_01_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_aus_02_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_aus_03_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_aus_04_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_aus_05_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_aus_06_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_aus_07_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_aus_08_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_aus_09_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_aus_10_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_nz_01_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_nz_02_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_nz_03_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_nz_04_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_nz_05_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_nz_06_01", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sas_01_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sas_02_06", {-1, 0, 0, -1}},
+    {"vn_b_uniform_sas_03_06", {-1, 0, 0, -1}},
+    // NVA Infantry Uniforms
+    {"vn_o_uniform_nva_air_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_01_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_01_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_01_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_01_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_02_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_02_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_02_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_02_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_03_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_03_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_03_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_03_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_04_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_04_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_04_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_04_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_05_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_05_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_06_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_06_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_07_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_07_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_08_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_08_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_09_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_09_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_09_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_09_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_10_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_10_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_11_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_11_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_12_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_12_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_12_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_army_12_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_dc_13_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_dc_13_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_dc_13_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_dc_13_08", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_dc_14_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_dc_14_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_navy_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_navy_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_navy_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_nva_navy_04", {0, -1, -1, -1}},
+    // VC Uniforms
+    {"vn_o_uniform_vc_01_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_01_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_01_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_01_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_01_05", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_01_06", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_01_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_02_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_02_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_02_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_02_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_02_05", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_02_06", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_02_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_03_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_03_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_03_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_03_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_03_05", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_03_06", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_03_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_04_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_04_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_04_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_04_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_04_05", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_04_06", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_04_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_05_01", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_05_02", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_05_03", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_05_04", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_mf_01_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_mf_02_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_mf_03_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_mf_04_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_mf_09_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_mf_10_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_mf_11_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_mf_12_07", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_reg_11_08", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_reg_11_09", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_reg_11_10", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_reg_12_08", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_reg_12_09", {0, -1, -1, -1}},
+    {"vn_o_uniform_vc_reg_12_10", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_01_11", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_01_12", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_01_13", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_01_14", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_02_11", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_02_12", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_02_13", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_02_14", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_03_11", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_03_12", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_03_13", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_03_14", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_04_11", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_04_12", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_04_13", {0, -1, -1, -1}},
+    {"vn_o_uniform_pl_army_04_14", {0, -1, -1, -1}},
+    // Vests
+    // US Vests
+    {"vn_b_vest_aircrew_01", {-1, 0, 0, -1}},
+    {"vn_b_vest_aircrew_02", {-1, 0, 0, -1}},
+    {"vn_b_vest_aircrew_03", {-1, 0, 0, -1}},
+    {"vn_b_vest_aircrew_04", {-1, 0, 0, -1}},
+    {"vn_b_vest_aircrew_05", {-1, 0, 0, -1}},
+    {"vn_b_vest_aircrew_06", {-1, 0, 0, -1}},
+    {"vn_b_vest_aircrew_07", {-1, 0, 0, -1}},
+    {"vn_b_vest_sog_01", {-1, 0, 0, -1}},
+    {"vn_b_vest_sog_02", {-1, 0, 0, -1}},
+    {"vn_b_vest_sog_03", {-1, 0, 0, -1}},
+    {"vn_b_vest_sog_04", {-1, 0, 0, -1}},
+    {"vn_b_vest_sog_05", {-1, 0, 0, -1}},
+    {"vn_b_vest_sog_06", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_01", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_02", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_03", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_04", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_05", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_06", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_07", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_08", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_09", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_10", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_11", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_12", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_13", {-1, 0, 0, -1}},
+    {"vn_b_vest_usarmy_14", {-1, 0, 0, -1}},
+    {"vn_b_vest_seal_01", {-1, 0, 0, -1}},
+    {"vn_b_vest_seal_02", {-1, 0, 0, -1}},
+    {"vn_b_vest_seal_03", {-1, 0, 0, -1}},
+    {"vn_b_vest_seal_04", {-1, 0, 0, -1}},
+    {"vn_b_vest_seal_05", {-1, 0, 0, -1}},
+    {"vn_b_vest_seal_06", {-1, 0, 0, -1}},
+    {"vn_b_vest_seal_07", {-1, 0, 0, -1}},
+    {"vn_b_vest_usmc_01", {-1, 0, 0, -1}},
+    {"vn_b_vest_usmc_02", {-1, 0, 0, -1}},
+    {"vn_b_vest_usmc_03", {-1, 0, 0, -1}},
+    {"vn_b_vest_usmc_04", {-1, 0, 0, -1}},
+    {"vn_b_vest_usmc_05", {-1, 0, 0, -1}},
+    {"vn_b_vest_usmc_06", {-1, 0, 0, -1}},
+    {"vn_b_vest_usmc_07", {-1, 0, 0, -1}},
+    {"vn_b_vest_usmc_08", {-1, 0, 0, -1}},
+    {"vn_b_vest_usmc_09", {-1, 0, 0, -1}},
+    // Anzac
+    {"vn_b_vest_anzac_01", {-1, 0, 0, -1}},
+    {"vn_b_vest_anzac_02", {-1, 0, 0, -1}},
+    {"vn_b_vest_anzac_03", {-1, 0, 0, -1}},
+    {"vn_b_vest_anzac_04", {-1, 0, 0, -1}},
+    {"vn_b_vest_anzac_05", {-1, 0, 0, -1}},
+    {"vn_b_vest_anzac_06", {-1, 0, 0, -1}},
+    {"vn_b_vest_anzac_07", {-1, 0, 0, -1}},
+    {"vn_b_vest_anzac_08", {-1, 0, 0, -1}},
+    {"vn_b_vest_anzac_09", {-1, 0, 0, -1}},
+    {"vn_b_vest_anzac_10", {-1, 0, 0, -1}},
+    {"vn_b_vest_sas_01", {-1, 0, 0, -1}},
+    {"vn_b_vest_sas_02", {-1, 0, 0, -1}},
+    {"vn_b_vest_sas_03", {-1, 0, 0, -1}},
+    {"vn_b_vest_sas_04", {-1, 0, 0, -1}},
+    // NVA Vests
+    {"vn_o_vest_01", {0, -1, 0, -1}},
+    {"vn_o_vest_02", {0, -1, 0, -1}},
+    {"vn_o_vest_03", {0, -1, 0, -1}},
+    {"vn_o_vest_04", {0, -1, 0, -1}},
+    {"vn_o_vest_05", {0, -1, 0, -1}},
+    {"vn_o_vest_06", {0, -1, 0, -1}},
+    {"vn_o_vest_07", {0, -1, 0, -1}},
+    {"vn_o_vest_08", {0, -1, 0, -1}},
+    // VC Vests
+    {"vn_o_vest_vc_01", {0, -1, 0, -1}}, // Vest - VC (Assault)
+    {"vn_o_vest_vc_02", {0, -1, 0, -1}}, // Vest - VC (Rifle)
+    {"vn_o_vest_vc_03", {0, -1, 0, -1}}, // Vest - VC (MG)
+    {"vn_o_vest_vc_04", {0, -1, 0, -1}}, // Vest - VC (Medic)
+    {"vn_o_vest_vc_05", {0, -1, 0, -1}}, // Vest - VC (Leader)
+};
+
+backpacks[] =
+{
+    // Blufor
+    {"B_Parachute", {0, 0, 0, -1}}, // ARMA3 Steerable
+    {"vn_b_pack_01", {-1, 0, 0, -1}}, // SOG (CISO)
+    {"vn_b_pack_01_02", {-1, 0, 0, -1}}, // CIDG (CISO)
+    {"vn_b_pack_02", {-1, 0, 0, -1}}, // SOG (CISO MG)
+    {"vn_b_pack_02_02", {-1, 0, 0, -1}}, // CIDG (CISO MG)
+    {"vn_b_pack_03", {-1, 0, 0, -1}}, // SOG (CISO RTO)
+    {"vn_b_pack_03_02", {-1, 0, 0, -1}}, // CIDG (CISO RTO)
+    {"vn_b_pack_04", {-1, 0, 0, -1}}, // SOG (CISO Scout)
+    {"vn_b_pack_04_02", {-1, 0, 0, -1}}, // CIDG (CISO Scout)
+    {"vn_b_pack_05", {-1, 0, 0, -1}}, // SOG (CISO Demo)
+    {"vn_b_pack_05_02", {-1, 0, 0, -1}}, // CIDG (CISO Demo)
+    {"vn_b_pack_lw_01", {-1, 0, 0, -1}}, // Army (Rifleman)
+    {"vn_b_pack_lw_02", {-1, 0, 0, -1}}, // Army (MG)
+    {"vn_b_pack_lw_03", {-1, 0, 0, -1}}, // Army (Scout)
+    {"vn_b_pack_lw_04", {-1, 0, 0, -1}}, // Army (Engineer)
+    {"vn_b_pack_lw_05", {-1, 0, 0, -1}}, // Army (MG Ammo)
+    {"vn_b_pack_lw_06", {-1, 0, 0, -1}}, // Army (RTO 2)
+    {"vn_b_pack_lw_07", {-1, 0, 0, -1}}, // Army (Medic)
+    {"vn_b_pack_m5_01", {-1, 0, 0, -1}}, // Army (Medic M5)
+    {"vn_b_pack_prc77_01", {-1, 0, 0, -1}}, // Army (RTO)
+    {"vn_b_pack_trp_01", {-1, 0, 0, -1}}, // SOG (Tropical MG)
+    {"vn_b_pack_trp_01_02", {-1, 0, 0, -1}}, // Army (Tropical MG)
+    {"vn_b_pack_trp_02", {-1, 0, 0, -1}}, // SOG (Tropical)
+    {"vn_b_pack_trp_02_02", {-1, 0, 0, -1}}, // Army (Tropical)
+    {"vn_b_pack_trp_03", {-1, 0, 0, -1}}, // SOG (Tropical Demo)
+    {"vn_b_pack_trp_03_02", {-1, 0, 0, -1}}, // Army (Tropical Demo)
+    {"vn_b_pack_trp_04", {-1, 0, 0, -1}}, // SOG (Tropical RTO)
+    {"vn_b_pack_trp_04_02", {-1, 0, 0, -1}}, // Army (Tropical RTO)
+    {"vn_b_pack_seal_01", {-1, -1, -1, -1}}, // SEAL (Diver) removed due to non protection under water
+    {"vn_b_pack_p08_01", {-1, 0, 0, -1}}, // ANZAC (P08 1)
+    {"vn_b_pack_p08_02", {-1, 0, 0, -1}}, // ANZAC (P08 2)
+    {"vn_b_pack_p08_03", {-1, 0, 0, -1}}, // ANZAC (P08 3)
+    {"vn_b_pack_p44_01", {-1, 0, 0, -1}}, // ANZAC (P44 1)
+    {"vn_b_pack_p44_02", {-1, 0, 0, -1}}, // ANZAC (P44 2)
+    {"vn_b_pack_p44_03", {-1, 0, 0, -1}}, // ANZAC (P44 3)
+    {"vn_b_pack_pfield_01", {-1, 0, 0, -1}}, // ANZAC (Field 1)
+    {"vn_b_pack_pfield_02", {-1, 0, 0, -1}}, // ANZAC (Field 2)
+    {"vn_b_pack_ba18_01", {-1, 0, 0, -1}}, // Parachute (BA18)
+    {"vn_b_pack_ba22_01", {-1, 0, 0, -1}}, // Parachute (BA22)
+    {"vn_b_pack_t10_01", {0, 0, 0, 0}}, // Parachute (T10) OPEN TO ALL
+    {"vn_b_pack_m41_01", {-1, 0, 0, -1}}, // USMC (M41 1)
+    {"vn_b_pack_m41_02", {-1, 0, 0, -1}}, // USMC (M41 2)
+    {"vn_b_pack_m41_03", {-1, 0, 0, -1}}, // USMC (M41 3)
+    {"vn_b_pack_m41_04", {-1, 0, 0, -1}}, // USMC (M41 4)
+    {"vn_b_pack_m41_05", {-1, 0, 0, -1}}, // USMC (M41 RTO)
+    {"vn_b_pack_arvn_01", {-1, 0, 0, -1}}, // ARVN 1
+    {"vn_b_pack_arvn_02", {-1, 0, 0, -1}}, // ARVN 2
+    {"vn_b_pack_arvn_03", {-1, 0, 0, -1}}, // ARVN 3
+    {"vn_b_pack_arvn_04", {-1, 0, 0, -1}}, // ARVN 4
+    // Blufor Static Backpacks
+    {"vn_b_pack_static_ammo_01", {-1, 0, 0, -1}}, // ARMY (Ammo Resupply)
+    {"vn_b_pack_static_base_01", {-1, 0, 0, -1}}, // ARMY (Weapon Base)
+    {"vn_b_pack_static_tow", {-1, 0, 0, -1}}, // ARMY (BGM-71 TOW)
+    {"vn_b_pack_static_m1919a4_high_01", {-1, 0, 0, -1}}, // ARMY (M1919A4 high)
+    {"vn_b_pack_static_m1919a4_low_01", {-1, 0, 0, -1}}, // ARMY (M1919A4 low)
+    {"vn_b_pack_static_m1919a6_01", {-1, 0, 0, -1}}, // ARMY (M1919A6)
+    {"vn_b_pack_static_m29_01", {-1, -1, -1, -1}}, // ARMY (M29 Mortar 81mm) BLACKLIST
+    {"vn_b_pack_static_m2_01", {-1, -1, -1, -1}}, // ARMY (M2 Mortar 60mm) BLACKLIST
+    {"vn_b_pack_static_m2_high_01", {-1, 0, 0, -1}}, // ARMY (M2 high)
+    {"vn_b_pack_static_m2_low_01", {-1, 0, 0, -1}}, // ARMY (M2 low)
+    {"vn_b_pack_static_m60_high_01", {-1, 0, 0, -1}}, // ARMY (M60 high)
+    {"vn_b_pack_static_m60_low_01", {-1, 0, 0, -1}}, // ARMY (M60 low)
+    {"vn_b_pack_static_mk18", {-1, 0, 0, -1}}, // ARMY (MK18)
+    {"vn_b_pack_static_m2_scoped_high_01", {-1, 0, 0, -1}}, // ARMY (M2 Scoped high)
+    {"vn_b_pack_static_m2_scoped_low_01", {-1, 0, 0, -1}}, // ARMY (M2 Scoped low)
+    // OpFor
+    {"vn_c_pack_01", {0, -1, 0, -1}}, // Pack (Basket)
+    {"vn_c_pack_02", {0, -1, 0, -1}}, // Pack (Ganh Hang Rong)
+    {"vn_o_pack_01", {0, -1, 0, -1}}, // NVA 1
+    {"vn_o_pack_02", {0, -1, 0, -1}}, // NVA 2
+    {"vn_o_pack_03", {0, -1, 0, -1}}, // NVA (RPG)
+    {"vn_o_pack_04", {0, -1, 0, -1}}, // NVA (Assault)
+    {"vn_o_pack_05", {0, -1, 0, -1}}, // NVA (Sapper)
+    {"vn_o_pack_06", {0, -1, 0, -1}}, // NVA (Recon)
+    {"vn_o_pack_07", {0, -1, 0, -1}}, // NVA (Recon/RPG)
+    {"vn_o_pack_08", {0, -1, 0, -1}}, // NVA (Mortar Ammo)
+    {"vn_o_pack_t884_01", {0, -1, 0, -1}}, // NVA T884 Radio
+    {"vn_i_pack_parachute_01", {-1, -1, -1, -1}}, // Parachute (Independent) BLACKLIST
+    {"vn_o_pack_parachute_01", {0, -1, 0, -1}}, // Parachute (Opfor)
+    // Opfor Static Backpacks
+    {"vn_o_pack_static_ammo_01", {0, -1, 0, -1}}, // NVA (Ammo Resupply)
+    {"vn_o_pack_static_base_01", {0, -1, 0, -1}}, // NVA (Weapon Base)
+    {"vn_o_pack_static_dp28_01", {0, -1, 0, -1}}, // NVA (DP27)
+    {"vn_o_pack_static_dshkm_high_01", {0, -1, 0, -1}}, // NVA (DShKM high)
+    {"vn_o_pack_static_dshkm_high_02", {0, -1, 0, -1}}, // NVA (DShKM AA)
+    {"vn_o_pack_static_dshkm_low_01", {0, -1, 0, -1}}, // NVA (DShKM Armour)
+    {"vn_o_pack_static_dshkm_low_02", {0, -1, 0, -1}}, // NVA (DShKM low)
+    {"vn_o_pack_static_rpd_01", {0, -1, 0, -1}}, // NVA (RPD)
+    {"vn_o_pack_static_type53_01", {0, -1, 0, -1}}, // NVA (Type 53 Mortar)
+    {"vn_o_pack_static_type63_01", {0, -1, 0, -1}}, // NVA (Type 63 Mortar)
+    {"vn_o_pack_static_at3_01", {0, -1, 0, -1}}, // NVA (AT-3)
+    {"vn_o_pack_static_pk_high_01", {0, -1, 0, -1}}, // NVA (PK high)
+    {"vn_o_pack_static_pk_low_01", {0, -1, 0, -1}}, // NVA (PK low)
+    {"vn_o_pack_static_sgm_low_01", {0, -1, 0, -1}}, // NVA (SGM low, shield)
+    {"vn_o_pack_static_sgm_low_02", {0, -1, 0, -1}}, // NVA (SGM low)
+    {"vn_o_pack_static_sgm_high_01", {0, -1, 0, -1}}, // NVA (SGM high)
+    {"vn_o_pack_static_mg42_low", {0, -1, 0, -1}}, // NVA (MG42 low)
+    {"vn_o_pack_static_mg42_high", {0, -1, 0, -1}}, // NVA (MG42 high)
+    {"vn_o_pack_static_m1910_low_01", {0, -1, 0, -1}}, // NVA (M1910 low, shield)
+    {"vn_o_pack_static_m1910_low_02", {0, -1, 0, -1}}, // NVA (M1910 low)
+    {"vn_o_pack_static_m1910_high_01", {0, -1, 0, -1}}, // NVA (M1910 high)
+    {"vn_o_pack_static_type56rr_01", {0, -1, 0, -1}}, // NVA (Type 56 Recoilless)
+};
+vehicles[] =
+{
+/*    
+    //Nickel Steel
+	{"vnx_b_armor_m163_01",				{-1, 0, 0, 0}},	// M113 Vulcan Cannon
+	{"vnx_b_armor_lvtp5_01",			{-1, 0, 0, 0}},	// Marine Landing Vehicle
+	{"vnx_b_air_hh1h_04_01",			{-1, 0, 0, 0}},	// Rescue Unarmed
+	{"vnx_b_air_hh1h_01_01",			{-1, 0, 0, 0}},	// Rescue Dustoff
+	{"vnx_b_air_hh1h_02_01",			{-1, 0, 0, 0}},	// Rescue Slick
+	{"vnx_b_air_hh34_03_01",			{-1, 0, 0, 0}},	// Rescue Seahorse 2xM60
+	{"vnx_b_air_hh34_01_01",			{-1, 0, 0, 0}},	// Rescue Seahorse 1xM60
+	{"vnx_b_air_ov10a_navy_bmb",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_navy_cap",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_navy_cas",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_navy_ehcas",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_navy_hbmb",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_navy_mr",			{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_navy_mbmb",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_navy_hcas",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_navy_lbmb",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_covey",			{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_cryer",			{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ac119_01_01",			{-1, 0, 0, 0}},	// AC119 Gunship CAS
+	{"vnx_b_air_ac119_04_01",			{-1, 0, 0, 0}},	// C119 Bomber Daisy Cutter
+	{"vnx_b_air_ac119_03_01",			{-1, 0, 0, 0}},	// C119 Cargo
+	{"vnx_b_air_ac119_03_02",			{-1, 0, 0, 0}},	// C119 Cargo
+	{"vnx_b_air_ac119_02_01",			{-1, 0, 0, 0}},	// C119 Transport
+	{"vnx_b_air_ac119_02_02",			{-1, 0, 0, 0}},	// C119 Transport
+	{"vnx_b_air_ov10a_usmc_bmb",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_usmc_cap",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_usmc_cas",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_usmc_ehcas",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_usmc_hbmb",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_usmc_hcas",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_usmc_lbmb",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_usmc_mbmb",		{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_usmc_mr",			{-1, 0, 0, 0}},	//
+	{"vnx_b_air_ov10a_aus_covey",		{-1, 0, 0, 0}},	//
+	{"vnx_o_wheeled_tuktuk_mg_02_vc",	{0, -1, 0, 0}},	// MG Rear
+	{"vnx_o_wheeled_tuktuk_mg_01_vc",	{0, -1, 0, 0}},	// MG Top Front
+	{"vnx_o_wheeled_tuktuk_01_vc",		{0, -1, 0, 0}},	// Unarmed
+*/    
 			{ "NonSteerable_Parachute_F", 			{ 0, 0, 0, 0}},
 			{ "Steerable_Parachute_F", 				{ 0, 0, 0, 0}},
 			{ "vn_b_air_ah1g_01", 					{ 0, 0, 0, 0}},

--- a/mission/config/subconfigs/crates.hpp
+++ b/mission/config/subconfigs/crates.hpp
@@ -16,180 +16,247 @@ class MedicalCrate
 class AmmoCrateLight
 {
 	objectClassname = "Box_NATO_Ammo_F";
-	weapons[] = {{"vn_m127",3},{"vn_m72",30}};
-	magazines[] = {
-		{"vn_m1911_mag",20},
-		{"vn_mk22_mag",20},
-		{"vn_m16_40_mag",15},
-		{"vn_welrod_mag",20},
-		{"vn_m61_grenade_mag",10},
-		{"vn_m67_grenade_mag",10},
-		{"vn_v40_grenade_mag",10},
-		{"vn_m18_green_mag",10},
-		{"vn_m18_purple_mag",10},
-		{"vn_m18_red_mag",10},
-		{"vn_m18_white_mag",25},
-		{"vn_m18_yellow_mag",10},
-		{"vn_m14_grenade_mag",5},
-		{"vn_m34_grenade_mag",5},
-		{"vn_m127_mag",15},
-		{"vn_hd_mag",20},
-		{"vn_hp_mag",20},
-		{"vn_m10_mag",20},
-		{"vn_m16_30_mag",60},
-		{"vn_m63a_30_mag",30},
-		{"vn_m16_20_mag",60},
-		{"vn_carbine_15_mag",30},
-		{"vn_carbine_30_mag",30},
-		{"vn_m4956_10_mag",30},
-		{"vn_m14_mag",30},
-		{"vn_m1895_mag",20},
-		{"vn_mc10_mag",30},
-		{"vn_sten_mag",30},
-		{"vn_m3a1_mag",30},
-		{"vn_m45_mag",30},
-		{"vn_l1a1_20_mag", 30},
-		{"vn_l1a1_30_02_mag",30},
-		{"vn_f1_smg_mag", 30},
-		{"vn_l34a1_smg_mag", 30},
-		{"vn_m1_garand_mag", 30},
-		{"vn_mpu_mag", 30},
-		{"vn_m1928_mag", 30},
-		{"vn_m72_mag", 30},
-		{"vn_m20a1b1_01", 5},
-		{"vn_m20a1b1_heat_mag",	20},
-		{"vn_m20a1b1_wp_mag", 3},
-		{"vn_pm_mag",20},
-        {"vn_tt33_mag",20},
-        {"vn_ppk_mag",20},
-        {"vn_p38_mag",20},
-        {"vn_vz61_mag",20},
-        {"vn_mat49_mag",30},
-        {"vn_m1a1_30_mag",30},
-        {"vn_hp_mag",30},
-        {"vn_m14_10_mag",30},
-        {"vn_l1a1_30_mag",60}
-	};
-	items[] = {};
-	backpacks[] = {{"vn_b_pack_static_base_01", 5},{"vn_b_pack_static_tow",5},{"vn_b_pack_static_ammo_01",2}};
+	weapons[] = {
+    {"vn_m127",     3},
+	{"vn_m72",		2},
+	{"vn_m1911",    2},
+	{"vn_hp",       2},
+	{"vn_m16",      2},
+	{"vn_l1a1_01",  2}
+		};
+	magazines[] = {				
+/*
+//Nickel Steel					
+	{"vnx_hd_02_mag",		20},
+	{"vnx_gjet_mag",		20},
+	{"vnx_c96_mag",			20},
+	{"vnx_m12_smg_32_mag",	30},
+	{"vnx_m12_smg_20_mag",	30},
+	{"vnx_m50_smg_mag",		30},				
+*/
+//Pistol					
+	{"vn_welrod_mag",		20},
+	{"vn_hp_mag",			20},
+	{"vn_pm_mag",			20},
+	{"vn_tt33_mag",			20},
+	{"vn_hd_mag",			20},
+	{"vn_hp_mag",			20},
+	{"vn_m1911_mag",		20},
+	{"vn_mk22_mag",			20},
+	{"vn_m10_mag",			20},
+	{"vn_m1895_mag",		20},
+	{"vn_ppk_mag",			20},
+	{"vn_p38_mag",			20},
+	{"vn_vz61_mag",			20},
+//SMG					
+	{"vn_m3a1_mag",			30},
+	{"vn_m45_mag",			30},
+	{"vn_mat49_mag",		30},
+	{"vn_mc10_mag",			30},
+	{"vn_sten_mag",			30},
+	{"vn_m1a1_30_mag",		30},
+	{"vn_m1928_mag",		30},
+	{"vn_mpu_mag",			30},
+	{"vn_f1_smg_mag",		30},
+//Carbine					
+	{"vn_carbine_15_mag",	30},
+	{"vn_carbine_30_mag",	30},
+	{"vn_hp_sd_mag",		30},
+	{"vn_m4956_10_mag",		30},
+//Assault Rifle					
+	{"vn_m16_20_mag",		30},
+	{"vn_m16_30_mag",		60},
+	{"vn_m16_40_mag",		30},
+	{"vn_m63a_30_mag",		30},
+//Rifle					
+	{"vn_m14_10_mag",		30},
+	{"vn_m14_mag",			30},
+	{"vn_m1_garand_mag",	30},
+	{"vn_l1a1_20_mag",		30},
+	{"vn_l1a1_30_mag",		60},
+//Other					
+	{"vn_m61_grenade_mag",	10},
+	{"vn_m67_grenade_mag",	10},
+	{"vn_v40_grenade_mag",	10},
+	{"vn_m18_green_mag",	10},
+	{"vn_m18_purple_mag",	10},
+	{"vn_m18_red_mag",		10},
+	{"vn_m18_white_mag",	25},
+	{"vn_m18_yellow_mag",	10},
+	{"vn_m14_grenade_mag",	5},
+	{"vn_m34_grenade_mag",	5},
+	{"vn_40mm_m406_he_mag",	10},
+	{"vn_40mm_m433_hedp_mag",10},
+	{"vn_m127_mag",			30},
+	{"Chemlight_Blue",		5},
+	{"Chemlight_Green",		5},
+	{"Chemlight_Yellow",	5},
+	{"vn_b_item_lighter_01",2},
+	{"vn_m72_mag",			2}
+		};
+	items[] = {
+	{"vn_b_item_trapkit",	5}
+		};
+	backpacks[] = {
+	{"vn_b_pack_static_base_01",		4},
+	{"vn_b_pack_static_m60_high_01",	2},
+	{"vn_b_pack_static_m60_low_01",		2},
+	{"vn_b_pack_static_m1919a4_high_01",2},
+	{"vn_b_pack_static_m1919a4_low_01",	2}
+		};        
 };
 
 class AmmoCrateSupport
 {
 	objectClassname = "Box_NATO_Support_F";
 	weapons[] = {
-		{"vn_m79",2},
-		{"vn_m127",15},
-		{"vn_m20a1b1_01", 5}
-	};
-	magazines[] = {
-		{"vn_m60_100_mag",50},
-		{"vn_l1a1_30_02_mag",30},
-		{"vn_rpd_100_mag",10},
-		{"vn_m63a_100_mag", 20},
-		{"vn_m63a_150_t_mag",30},
-		{"vn_m40a1_mag",30},
-		{"vn_m127_mag",50},
-		{"vn_m128_mag",20},
-		{"vn_m129_mag",20},
-		{"vn_m16_40_mag",15},
-		{"vn_m61_grenade_mag",10},
-		{"vn_m67_grenade_mag",10},
-		{"vn_v40_grenade_mag",10},
-		{"vn_m18_purple_mag",20},
-		{"vn_m18_red_mag",20},
-		{"vn_m18_white_mag",30},
-		{"vn_m18_yellow_mag",20},
-		{"vn_m14_grenade_mag",10},
-		{"vn_m34_grenade_mag",10},
-		{"vn_40mm_m651_cs_mag",20},
-		{"vn_40mm_m583_flare_w_mag",40},
-		{"vn_40mm_m661_flare_g_mag",20},
-		{"vn_40mm_m662_flare_r_mag",20},
-		{"vn_40mm_m695_flare_y_mag",20},
-		{"vn_40mm_m680_smoke_w_mag",40},
-		{"vn_40mm_m682_smoke_r_mag",20},
-		{"vn_40mm_m715_smoke_g_mag",20},
-		{"vn_40mm_m716_smoke_y_mag",20},
-		{"vn_40mm_m717_smoke_p_mag",20},
-		{"vn_m20a1b1_heat_mag",	20},
-		{"vn_m20a1b1_wp_mag", 3},
-		{"vn_m1918_mag",40},
-        {"vn_l1a1_30_02_mag",40},
-        {"vn_m1897_fl_mag",30},
-        {"vn_m1897_buck_mag",30},
-        {"vn_m1903_mag",30},
-        {"vn_m36_mag",30},
-        {"vn_mk1_udg_mag",30},
-        {"vn_type56_t_mag",20},
-        {"vn_mg42_50_mag",20},
-        {"vn_mp40_mag",20},
-        {"vn_ppsh41_71_mag",10},
-        {"vn_22mm_lume_mag",20},
-        {"vn_22mm_m22_smoke_mag",20},
-        {"vn_22mm_cs_mag",20}
-	};
-	items[] = {{"vn_b_item_trapkit",5}};
+	{"vn_m127",		10},
+	{"vn_m79",		4},
+	{"vn_m72",		2},
+	{"vn_m60",		2},
+	{"vn_m1897",	2}
+    	};
+	magazines[] = {					
+/*
+//Nickel Steel					
+	{"vnx_m77e_fl_mag",				60},
+	{"vnx_m77e_buck_mag",			30},
+	{"vnx_m77e_so_mag",				30},
+	{"vnx_fm2429_mag",				40},
+	{"vnx_no4_mag",					30},
+	{"vnx_37mm_baton_mag",			20},
+	{"vnx_37mm_cs_fin_mag",			20},
+	{"vnx_37mm_cs_mag",				20},
+	{"vnx_37mm_cs_skat_mag",		20},
+	{"vnx_37mm_cs_spray_mag",		20},
+	{"vnx_37mm_flare_mag",			20},
+	{"vnx_mk3a2_grenade_mag",		20},
+	{"vnx_stg44_t_mag",				20},				
+*/
+//LMG					
+	{"vn_m60_100_mag",				30},
+	{"vn_m63a_150_mag",				15},
+	{"vn_m63a_100_mag",				20},
+	{"vn_m1918_mag",				40},
+	{"vn_l1a1_30_02_mag",			40},
+//Shotgun					
+	{"vn_m1897_fl_mag",				60},
+	{"vn_m1897_buck_mag",			30},
+//Bolt-Action					
+	{"vn_m40a1_mag",				30},
+	{"vn_m1903_mag",				30},
+	{"vn_m36_mag",					30},
+//Other					
+	{"vn_mk1_udg_mag",				20},
+//OpFor					
+	{"vn_rpd_100_mag",				10},
+	{"vn_type56_t_mag",				20},
+	{"vn_mg42_50_mag",				20},
+	{"vn_mp40_mag",					20},
+	{"vn_ppsh41_71_mag",			10},
+//Other					
+	{"vn_m127_mag",					40},
+	{"vn_m128_mag",					40},
+	{"vn_m129_mag",					40},
+	{"vn_m61_grenade_mag",			10},
+	{"vn_m67_grenade_mag",			10},
+	{"vn_v40_grenade_mag",			10},
+	{"vn_m18_purple_mag",			20},
+	{"vn_m18_red_mag",				20},
+	{"vn_m18_white_mag",			30},
+	{"vn_m18_yellow_mag",			20},
+	{"vn_m14_grenade_mag",			10},
+	{"vn_m34_grenade_mag",			10},
+	{"vn_40mm_m651_cs_mag",			20},
+	{"vn_40mm_m583_flare_w_mag",	30},
+	{"vn_40mm_m661_flare_g_mag",	30},
+	{"vn_40mm_m662_flare_r_mag",	30},
+	{"vn_40mm_m695_flare_y_mag",	30},
+	{"vn_40mm_m680_smoke_w_mag",	40},
+	{"vn_40mm_m682_smoke_r_mag",	20},
+	{"vn_40mm_m715_smoke_g_mag",	20},
+	{"vn_40mm_m716_smoke_y_mag",	20},
+	{"vn_40mm_m717_smoke_p_mag",	20},
+	{"vn_22mm_lume_mag",			40},
+	{"vn_22mm_m22_smoke_mag",		20},
+	{"vn_22mm_cs_mag",				20},
+	{"Chemlight_Blue",				20},
+	{"Chemlight_Green",				20},
+	{"Chemlight_Yellow",			20},
+	{"vn_m72_mag",					2}
+    	};
+	items[] = {
+    {"MineDetector",5}
+        };
 	backpacks[] = {
-		{"vn_b_pack_static_base_01", 10},
-		{"vn_b_pack_static_m2_high_01",3},
-		{"vn_b_pack_static_m60_high_01",5},
-		{"vn_b_pack_static_mk18",2}
-	};
+	{"vn_b_pack_static_base_01",	4},
+	{"vn_b_pack_static_ammo_01",	2},	
+	{"vn_b_pack_static_m2_high_01",	3},
+	{"vn_b_pack_static_m2_low_01",	3},
+	{"vn_b_pack_static_mk18",		2}
+    	};
 };
 
 class AmmoCrateExplosives
 {
 	objectClassname = "Box_NATO_AmmoOrd_F";
 	weapons[] = {
-		{"vn_m79",2},
-		{"vn_m72",10}
-	};
+	{"vn_m79",			2},
+	{"vn_m72",			10},
+	{"vn_m20a1b1_01",	2}
+    	};
 	magazines[] = {
-		{"vn_m61_grenade_mag",30},
-		{"vn_m67_grenade_mag",30},
-		{"vn_v40_grenade_mag",30},
-		{"vn_40mm_m651_cs_mag",20},
-		{"vn_40mm_m381_he_mag",20},
-		{"vn_40mm_m406_he_mag",20},
-		{"vn_40mm_m433_hedp_mag",20},
-		{"vn_m72_mag", 20},
-		{"vn_40mm_m583_flare_w_mag",20},
-		{"vn_40mm_m661_flare_g_mag",20},
-		{"vn_40mm_m662_flare_r_mag",20},
-		{"vn_40mm_m695_flare_y_mag",20},
-		{"vn_40mm_m680_smoke_w_mag",20},
-		{"vn_40mm_m682_smoke_r_mag",20},
-		{"vn_40mm_m715_smoke_g_mag",20},
-		{"vn_40mm_m716_smoke_y_mag",20},
-		{"vn_40mm_m717_smoke_p_mag",20},
-		{"vn_mine_m18_mag",15},
-		{"vn_mine_m18_range_mag",10},
-		{"vn_mine_tripwire_m49_02_mag",10},
-		{"vn_mine_tripwire_m49_04_mag",10},
-		{"vn_mine_tripwire_m16_02_mag",20},
-		{"vn_mine_tripwire_m16_04_mag",20},
-		{"vn_mine_m16_mag",20},
-		{"vn_mine_m15_mag",10},
-		{"vn_mine_m14_mag",40},
-		{"vn_mine_m112_remote_mag",15},
-		{"vn_mine_m18_x3_mag",10},
-		{"vn_mine_m18_x3_range_mag",10},
-		{"vn_mine_satchel_remote_02_mag",10},
-		{"vn_m20a1b1_01", 5},
-		{"vn_m20a1b1_heat_mag",	20},
-		{"vn_m20a1b1_wp_mag", 3},
-		{"vn_m20a1b1_heat_mag",5},
-        {"vn_m20a1b1_wp_mag",5},
-        {"vn_22mm_m17_frag_mag",20},
-        {"vn_22mm_m1a2_frag_mag",20},
-        {"vn_22mm_m9_heat_mag",20},
-        {"vn_22mm_m19_wp_mag",20},
-        {"vn_22mm_m61_frag_mag",20},
-        {"vn_22mm_n94_heat_mag",20}
-	};
-	items[] = {};
-	backpacks[] = {{"vn_b_pack_static_base_01", 5}};
+//Handgrenade					
+	{"vn_m61_grenade_mag",				30},
+	{"vn_m67_grenade_mag",				30},
+	{"vn_v40_grenade_mag",				30},
+	{"vn_m14_grenade_mag",				30},
+	{"vn_m34_grenade_mag",				30},
+//Rocket					
+	{"vn_m72_mag",						10},
+	{"vn_m20a1b1_heat_mag",				12},
+	{"vn_m20a1b1_wp_mag",				12},
+//Grenade Launcher					
+	{"vn_40mm_m651_cs_mag",				20},
+	{"vn_40mm_m381_he_mag",				60},
+	{"vn_40mm_m406_he_mag",				60},
+	{"vn_40mm_m433_hedp_mag",			60},
+	{"vn_40mm_m583_flare_w_mag",		30},
+	{"vn_40mm_m661_flare_g_mag",		30},
+	{"vn_40mm_m662_flare_r_mag",		30},
+	{"vn_40mm_m695_flare_y_mag",		30},
+	{"vn_40mm_m680_smoke_w_mag",		20},
+	{"vn_40mm_m682_smoke_r_mag",		20},
+	{"vn_40mm_m715_smoke_g_mag",		20},
+	{"vn_40mm_m716_smoke_y_mag",		20},
+	{"vn_40mm_m717_smoke_p_mag",		20},
+//Rifle Grenade					
+	{"vn_22mm_m17_frag_mag",			20},
+	{"vn_22mm_m1a2_frag_mag",			20},
+	{"vn_22mm_m9_heat_mag",				20},
+	{"vn_22mm_m19_wp_mag",				20},
+	{"vn_22mm_m61_frag_mag",			20},
+	{"vn_22mm_n94_heat_mag",			20},
+//Mine					
+	{"vn_mine_m18_mag",					20},
+	{"vn_mine_tripwire_m49_02_mag",		20},
+	{"vn_mine_tripwire_m49_04_mag",		20},
+	{"vn_mine_tripwire_f1_02_mag",		20},
+	{"vn_mine_tripwire_f1_04_mag",		20},
+	{"vn_mine_m14_mag",					40},
+	{"vn_mine_m112_remote_mag",			20},
+	{"vn_mine_m18_x3_mag",				20},
+	{"vn_mine_limpet_01_mag",			10},
+	{"vn_mine_bangalore_mag",			10},
+	{"vn_mine_satchel_remote_02_mag",	10}
+    	};
+	items[] = {
+   	{"MineDetector",	5}
+        };
+	backpacks[] = {
+	{"vn_b_pack_static_base_01",	2},
+	{"vn_b_pack_static_tow",		4}
+        };
 };
 
 class FoodCrate


### PR DESCRIPTION
Arsenal Update with missing weapon fix
Crate Update with additional statics, more 40mm grenades and glowsticks, fixed missing ammo for m1 shorty, basic weapons added. Brings inline with the same update on the Nickel Steel server without NS Assets