### PR TITLE
fixed the trashcan cleenup

### DIFF
--- a/maps/cam_lao_nam/mission.sqm
+++ b/maps/cam_lao_nam/mission.sqm
@@ -16,7 +16,7 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=32915;
+		nextID=33031;
 	};
 	class Camera
 	{
@@ -13569,7 +13569,6 @@ class Mission
 							flags=4;
 							class Attributes
 							{
-								init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 								name="arsenal_cleanup_19";
 								disableSimulation=1;
 							};
@@ -16108,7 +16107,6 @@ class Mission
 							flags=4;
 							class Attributes
 							{
-								init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 								name="arsenal_cleanup_15";
 								disableSimulation=1;
 							};
@@ -19682,7 +19680,6 @@ class Mission
 									side="Empty";
 									class Attributes
 									{
-										init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 										name="arsenal_cleanup_24";
 										disableSimulation=1;
 									};
@@ -20887,7 +20884,6 @@ class Mission
 							flags=4;
 							class Attributes
 							{
-								init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 								name="arsenal_cleanup_21";
 								disableSimulation=1;
 							};
@@ -22032,7 +22028,6 @@ class Mission
 							flags=4;
 							class Attributes
 							{
-								init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 								name="arsenal_cleanup_20";
 								disableSimulation=1;
 							};
@@ -24490,7 +24485,6 @@ class Mission
 							flags=4;
 							class Attributes
 							{
-								init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 								name="arsenal_cleanup_22";
 								disableSimulation=1;
 							};
@@ -25386,7 +25380,6 @@ class Mission
 							flags=4;
 							class Attributes
 							{
-								init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 								name="arsenal_cleanup_18";
 								disableSimulation=1;
 							};
@@ -28071,7 +28064,6 @@ class Mission
 							flags=4;
 							class Attributes
 							{
-								init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 								name="arsenal_cleanup_23";
 								disableSimulation=1;
 							};
@@ -32413,7 +32405,6 @@ class Mission
 							flags=4;
 							class Attributes
 							{
-								init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 								name="arsenal_cleanup_17";
 								disableSimulation=1;
 							};
@@ -54858,7 +54849,7 @@ class Mission
 					name="connector_attapeu_sihanoukville_1";
 					text="Connector Attapeu to Sihanoukville";
 					type="mil_arrow";
-					angle=228.70764;
+					angle=228.70763;
 					id=19648;
 					atlOffset=-52.366173;
 				};
@@ -55177,7 +55168,7 @@ class Mission
 					name="connector_son_tay_ling_ho_1";
 					text="Connector Son Tay to Ling Ho";
 					type="mil_arrow";
-					angle=56.768127;
+					angle=56.768124;
 					id=19677;
 					atlOffset=-28.567219;
 				};

--- a/maps/vn_khe_sanh/mission.sqm
+++ b/maps/vn_khe_sanh/mission.sqm
@@ -16,7 +16,7 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=2992;
+		nextID=3019;
 	};
 	class Camera
 	{
@@ -12330,7 +12330,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_5";
 				disableSimulation=1;
 			};
@@ -12366,7 +12365,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_6";
 				disableSimulation=1;
 			};
@@ -12402,7 +12400,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_7";
 				disableSimulation=1;
 			};
@@ -12439,7 +12436,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_8";
 				disableSimulation=1;
 			};
@@ -12476,7 +12472,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_9";
 				disableSimulation=1;
 			};
@@ -12512,7 +12507,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_10";
 				disableSimulation=1;
 			};
@@ -12549,7 +12543,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_11";
 				disableSimulation=1;
 			};
@@ -12586,7 +12579,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_12";
 				disableSimulation=1;
 			};
@@ -12622,7 +12614,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_13";
 				disableSimulation=1;
 			};
@@ -12659,7 +12650,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_14";
 				disableSimulation=1;
 			};
@@ -12696,7 +12686,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_15";
 				disableSimulation=1;
 			};
@@ -12732,7 +12721,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_16";
 				disableSimulation=1;
 			};
@@ -12860,7 +12848,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_17";
 				disableSimulation=1;
 			};
@@ -12978,7 +12965,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_18";
 				disableSimulation=1;
 			};
@@ -22057,7 +22043,7 @@ class Mission
 			name="mf_respawn_macv";
 			text="@STR_vn_mf_respawn_macv";
 			type="Empty";
-			angle=195.46646;
+			angle=195.46645;
 			id=2421;
 			atlOffset=-0.020980835;
 		};
@@ -22406,7 +22392,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_57";
 				disableSimulation=1;
 			};
@@ -30758,7 +30743,6 @@ class Mission
 			side="Empty";
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_19";
 				disableSimulation=1;
 			};
@@ -31196,7 +31180,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_20";
 				disableSimulation=1;
 			};
@@ -40239,7 +40222,6 @@ class Mission
 			flags=4;
 			class Attributes
 			{
-				init="this addAction [""Clean Up"", { " \n "  {deleteVehicle _x;} forEach nearestObjects [player, [""WeaponHolder"", ""GroundWeaponHolder""], 20]; " \n "}]; " \n "this attachTo [TrashPadOne];";
 				name="arsenal_cleanup_21";
 				disableSimulation=1;
 			};

--- a/maps/vn_the_bra/mission.sqm
+++ b/maps/vn_the_bra/mission.sqm
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=2201;
+		nextID=2235;
 	};
 	class Camera
 	{
-		pos[]={3234.7,73.949646,4682.043};
-		dir[]={0.95489466,-0.22707304,-0.19134806};
-		up[]={0.22264688,0.97387767,-0.044615444};
-		aside[]={-0.19648057,0,-0.98050767};
+		pos[]={3350.2207,61.803062,4353.4199};
+		dir[]={0.32926986,-0.64404154,0.69050121};
+		up[]={0.27721056,0.76499051,0.58132935};
+		aside[]={0.90262711,0,-0.43042344};
 	};
 };
 binarizationWanted=0;
@@ -6104,7 +6104,7 @@ class Mission
 							class PositionInfo
 							{
 								position[]={3301.4888,40.443352,4318.6577};
-								angles[]={0,3.4291193,-0};
+								angles[]={0,3.4291193,0};
 							};
 							side="Empty";
 							flags=5;
@@ -6140,7 +6140,7 @@ class Mission
 							class PositionInfo
 							{
 								position[]={3303.6772,40.398502,4318.96};
-								angles[]={0,2.5969737,-0};
+								angles[]={0,2.5969737,0};
 							};
 							side="Empty";
 							flags=5;
@@ -7132,7 +7132,6 @@ class Mission
 					side="Empty";
 					class Attributes
 					{
-						init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 						name="arsenal_cleanup_23";
 						disableSimulation=1;
 					};
@@ -9075,7 +9074,6 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 						name="arsenal_cleanup_19";
 						disableSimulation=1;
 					};
@@ -13830,6 +13828,7 @@ class Mission
 		{
 			dataType="Layer";
 			name="HTO";
+			state=1;
 			class Entities
 			{
 				items=2;
@@ -21303,7 +21302,6 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 						name="arsenal_cleanup_15";
 						disableSimulation=1;
 					};
@@ -22110,7 +22108,6 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 						name="arsenal_cleanup_17";
 						disableSimulation=1;
 					};
@@ -23250,7 +23247,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={3388.697,39.794388,4331.52};
+						position[]={3388.7397,39.801247,4331.5181};
 						angles[]={0,0.90210831,0};
 					};
 					side="Empty";
@@ -23262,7 +23259,7 @@ class Mission
 					};
 					id=2231;
 					type="Land_vn_object_trashcan_01";
-					atlOffset=0.13000107;
+					atlOffset=0.0063018799;
 				};
 				class Item14
 				{
@@ -25189,7 +25186,6 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 						name="arsenal_cleanup_22";
 						disableSimulation=1;
 					};
@@ -26234,7 +26230,6 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 						name="arsenal_cleanup_18";
 						disableSimulation=1;
 					};
@@ -27807,7 +27802,6 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 						name="arsenal_cleanup_20";
 						disableSimulation=1;
 					};
@@ -28620,7 +28614,6 @@ class Mission
 					flags=4;
 					class Attributes
 					{
-						init="this addAction [""Clean Up"", {{ deleteVehicle _x; } forEach nearestObjects [player,[""WeaponHolder"",""GroundWeaponHolder""],20];}]; this attachTo [TrashPadOne];";
 						name="arsenal_cleanup_21";
 						disableSimulation=1;
 					};

--- a/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
+++ b/mission/functions/systems/arsenal_cleanup/fn_arsenal_trash_cleanup_init.sqf
@@ -1,10 +1,13 @@
 /*
     File: fn_arsenal_trash_cleanup_init.sqf
     Author: Savage Game Design
+	modified by: Tylervip
     Public: Yes
 
     Description:
-        Called to initialise the trashcans on the map near arsenals.
+        Initialise all trashcans on the map near arsenals by finding
+        all missionNamespace variables starting with "arsenal_cleanup"
+        and adding the Clean Up action.
 
     Parameter(s):
         None
@@ -16,26 +19,28 @@
         call vn_mf_fnc_arsenal_trash_cleanup_init;
 */
 
-private _arsenals = allMapMarkers select {_x find "arsenal" isEqualTo 0};
+// Get all missionNamespace variable names starting with "arsenal_cleanup"
+private _trashCans = allVariables missionNamespace select {_x find "arsenal_cleanup" isEqualTo 0} apply {missionNamespace getVariable [_x,objNull]};
 
+// Add Clean Up action to each trashcan
 {
-	private _trashCan = missionNamespace getVariable [format["arsenal_cleanup_%1",_forEachIndex], objNull];
-	_trashCan addAction
-	[
-		"Clean Up",
-		{
-			params ["_target", "_caller", "_actionId", "_arguments"];
-			["arsenalcleanup", [_target]] call para_c_fnc_call_on_server;
-		},
-		nil,
-		1.5,
-		true,
-		true,
-		"",
-		"true",
-		5,
-		false,
-		"",
-		""
-	];
-} forEach _arsenals;
+    if (!isNull _x) then {
+        _x addAction [
+            "Clean Up",
+            {
+                params ["_target","_caller","_actionId","_arguments"];
+                ["arsenalcleanup",[_target]] call para_c_fnc_call_on_server;
+            },
+            nil,
+            1.5,
+            true,
+            true,
+            "",
+            "true",
+            5,
+            false,
+            "",
+            ""
+        ];
+    };
+} forEach _trashCans;

--- a/mission/functions/systems/supply_cleanup/fn_supply_cleanup_init.sqf
+++ b/mission/functions/systems/supply_cleanup/fn_supply_cleanup_init.sqf
@@ -10,27 +10,28 @@
         call fn_supply_cleanup_init;
 */
 
-private _dumpsters = allMapMarkers select {_x find "supply" isEqualTo 0};
+// Get all missionNamespace variable names starting with "supply_cleanup"
+private _dumpsters = allVariables missionNamespace select {_x find "supply_cleanup" isEqualTo 0} apply {missionNamespace getVariable [_x,objNull]};
 
+// Add Clean Up action to each supply box
 {
-    private _dumpster = missionNamespace getVariable [format["supply_cleanup_%1", _forEachIndex], objNull];
-    if (isNull _dumpster) exitWith {};
-
-    _dumpster addAction [
-        "Clean Up Supply Boxes",
-        {
-            params ["_target", "_caller", "_actionId", "_arguments"];
-            ["supplyCleanup", [_target]] call para_c_fnc_call_on_server;
-        },
-        nil,
-        1.5,
-        true,
-        true,
-        "",
-        "true",
-        5,
-        false,
-        "",
-        ""
-    ];
+    if (!isNull _x) then {
+        _x addAction [
+            "Clean Up Supply Boxes",
+            {
+                params ["_target","_caller","_actionId","_arguments"];
+                ["supplyCleanup",[_target]] call para_c_fnc_call_on_server;
+            },
+            nil,
+            1.5,
+            true,
+            true,
+            "",
+            "true",
+            5,
+            false,
+            "",
+            ""
+        ];
+    };
 } forEach _dumpsters;


### PR DESCRIPTION
Replaces the original indexed lookup (arsenal_cleanup_%1) with a dynamic scan of all missionNamespace variables starting with arsenal_cleanup.

Removes dependency on _arsenals array and _forEachIndex.

Ensures all valid trashcan objects are discovered automatically using allVariables missionNamespace.

Adds the same Clean Up action to each detected trashcan while maintaining original behavior.

Makes the system more robust, editor-safe, and easier to extend without maintaining manual indices.

Also did this to the supply clean up.