### PR TITLE
Ref #0003 Tree fix for HQ/Depo

### DIFF
--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_factory.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_factory.sqf
@@ -43,6 +43,13 @@ params ["_pos"];
 		private _currentVehicles = vehicles;
 
 		vn_site_objects append _factoryObjects;
+		
+		// --- Disable damage for sniper trees ---
+		(_factoryObjects select { (typeOf _x) find "Land_vn_o_snipertree" != -1 
+		}) apply {
+			_x allowDamage false;
+		};
+		
 
 		private _objectTypesToDestroy = [
 			"Land_vn_wf_vehicle_service_point_east",

--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_hq.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_hq.sqf
@@ -59,6 +59,13 @@ params ["_pos"];
 		private _hqObjects = [_spawnPos] call vn_mf_fnc_sites_create_compositions_hq;
 		vn_site_objects append _hqObjects;
 
+		// Disable damage for sniper trees
+		(_hqObjects select { 
+			(typeOf _x) find "Land_vn_o_snipertree" != -1
+		}) apply {
+			_x allowDamage false;
+		};
+
 		private _fnc_dynSimKindOfChecker = {
 			params ["_object"];
 			(_x isKindOf "StaticWeapon" || _x isKindOf "Building" || _x isKindOf "House" || _x isKindOf "LandVehicle")


### PR DESCRIPTION
disable the damage on the sniper trees so they don't get destroyed and don't spawn the brut trunk. this will still be cleaned up in the teardown