### PR TITLE
Prevent damage to hidden unsafe terrain objects

### DIFF
--- a/mission/functions/systems/sites/fn_sites_create_initial_static_ai_crews.sqf
+++ b/mission/functions/systems/sites/fn_sites_create_initial_static_ai_crews.sqf
@@ -34,7 +34,10 @@ private _initialMountedAiGroups = vn_site_objects
 			"vn_o_nva_static_zpu4",
 			"vn_o_vc_static_dshkm_low_01",
 			"vn_o_vc_static_pk_high",
-			"vn_o_vc_static_rpd_high"
+			"vn_o_vc_static_rpd_high",
+			"vn_o_vc_static_dshkm_high_01",
+			"vn_o_vc_static_sgm_low_01",
+			"vn_o_vc_static_mg42_low"
 		];
 	}
 	apply {

--- a/mission/functions/systems/sites/fn_sites_hide_unsafe_terrain_objects.sqf
+++ b/mission/functions/systems/sites/fn_sites_hide_unsafe_terrain_objects.sqf
@@ -71,6 +71,7 @@ _nearbyTerrainObjs apply {
 	if (_sitePos inArea _areaArr) then {
 
 		_x hideObjectGlobal true;
+		_x allowDamage false;
 
 		/*
 		rocks can have bushes placed on top of them.


### PR DESCRIPTION
Added `allowDamage false` to terrain objects that are hidden for site safety, ensuring they cannot be damaged after being hidden. and won't spawn a wreck, covring up OBJs
<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/723da8bb-aa0b-41f7-ab43-3a491b7d4144" />
