### PR TITLE
Added Signs to Buildables

### DIFF
--- a/mission/config/subconfigs/buildables.hpp
+++ b/mission/config/subconfigs/buildables.hpp
@@ -4946,3 +4946,131 @@ class vn_flag_arvn
 		};
 	};
 };
+
+class Land_vn_sign_mines_f
+{
+	name = "";
+	type = "sign";
+	categories[] = {"signs"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "Land_vn_sign_mines_f";
+		};
+		class middle_state
+		{
+			object_class = "Land_vn_sign_mines_f";
+		};
+		class final_state
+		{
+			object_class = "Land_vn_sign_mines_f";
+		};
+	};
+};
+
+class vn_sign_fob_07
+{
+	name = "";
+	type = "sign";
+	categories[] = {"signs"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "vn_sign_fob_07";
+		};
+		class middle_state
+		{
+			object_class = "vn_sign_fob_07";
+		};
+		class final_state
+		{
+			object_class = "vn_sign_fob_07";
+		};
+	};
+};
+
+class vn_sign_fob_08
+{
+	name = "";
+	type = "sign";
+	categories[] = {"signs"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "vn_sign_fob_08";
+		};
+		class middle_state
+		{
+			object_class = "vn_sign_fob_08";
+		};
+		class final_state
+		{
+			object_class = "vn_sign_fob_08";
+		};
+	};
+};
+
+class vn_sign_so_01
+{
+	name = "";
+	type = "sign";
+	categories[] = {"signs"};
+	rank = 0;
+	SUPPLY_CAPACITY(50, DAYS_TO_SECONDS(1));
+	resupply = "BuildingSupplies";
+	conditions[] = {
+		CONDITION_HAS_RANK,
+		CONDITION_IS_ENGINEER,
+		CONDITION_IS_ON_FOOT,
+		CONDITION_NOT_IN_RESTRICTED_ZONE,
+		CONDITION_IS_ACAV
+	};
+	class build_states
+	{
+		class initial_state
+		{
+			object_class = "vn_sign_so_01";
+		};
+		class middle_state
+		{
+			object_class = "vn_sign_so_01";
+		};
+		class final_state
+		{
+			object_class = "vn_sign_so_01";
+		};
+	};
+};

--- a/mission/stringtable.xml
+++ b/mission/stringtable.xml
@@ -1366,6 +1366,10 @@
         <Original>Storage</Original>
         <English>Storage</English>
       </Key>
+      <Key ID="STR_vn_mf_buildingMenu_category_signs">
+        <Original>Signs</Original>
+        <English>Signs</English>
+      </Key>
     </Container>
     <Container name="supplies">
       <Key ID="STR_vn_mf_light_ammo_supplies">


### PR DESCRIPTION
These changes got overwritten before the pull request was processed. Resubmitting.

Added to buildable.hpp:
  Land_vn_sign_mines_f
  vn_sign_fob_07
  vn_sign_fob_08
  vn_sign_so_01

Added to stringtables.xml:
  STR_vn_mf_buildingMenu_category_signs

Added all 4 signs to SIGNS category in the build menu.