### PR TITLE
Disable weapon disassembly on static weapons

### DIFF
--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_artillery.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_artillery.sqf
@@ -40,6 +40,8 @@ params ["_pos"];
 
 		vn_site_objects append _artyObjs;
 
+
+
 		/*
 		TODO: mortar site compositions currently have a bunch
 		of ammo crates dotted around that have a holdAction attached to them
@@ -72,7 +74,23 @@ params ["_pos"];
 			"vn_o_vc_static_d44",
 			"vn_o_vc_static_d44_01"
 		];
-
+		
+		// --- Disable weapon disassembly for static weapons ---
+		(_artyObjs select {
+			_x isKindOf "StaticWeapon" &&
+			!(typeOf _x in _objectTypesToDestroy) &&
+			!(typeOf _x in ["vn_o_nva_65_static_zpu4", "vn_o_nva_static_zpu4"])
+		}) apply {
+			_x enableWeaponDisassembly false;
+			_x addAction [
+				"Disable Weapon",
+				{
+					params ["_target", "_caller", "_actionId", "_arguments"];
+					_target setDamage 1;
+					_target removeAction _actionId;
+				},[],1.5,false,false,"_caller distance _target < 5"
+			];
+		};
 		private _objectsToDestroy = _artyObjs select {
 			typeOf _x in _objectTypesToDestroy;
 		};

--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_factory.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_factory.sqf
@@ -50,6 +50,21 @@ params ["_pos"];
 			_x allowDamage false;
 		};
 		
+		// --- Disable weapon disassembly for static weapons ---
+		(_factoryObjects select {
+			_x isKindOf "StaticWeapon" &&
+			!(typeOf _x in ["vn_o_nva_65_static_zpu4", "vn_o_nva_static_zpu4"])
+		}) apply {
+			_x enableWeaponDisassembly false;
+			_x addAction [
+				"Disable Weapon",
+				{
+					params ["_target", "_caller", "_actionId", "_arguments"];
+					_target setDamage 1;
+					_target removeAction _actionId;
+				},[],1.5,false,false,"_caller distance _target < 5"
+			];
+		};
 
 		private _objectTypesToDestroy = [
 			"Land_vn_wf_vehicle_service_point_east",
@@ -142,6 +157,7 @@ params ["_pos"];
 		private _respawnID = [east, _DepotRespawnMarker] call BIS_fnc_addRespawnPosition;
 		private _respawnObj = createVehicle ["Land_vn_o_platform_04", _dc_spawnPos, [], 5, "NONE"];
 		_respawnObj setVariable ["vn_respawn", [_DepotRespawnMarker, _respawnID]];
+		
 		vn_dc_adhoc_respawns pushBack [_DepotRespawnMarker, _respawnID];
 		
 		_siteStore setVariable ["aiObjectives", _objectives];

--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_fuel.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_fuel.sqf
@@ -43,6 +43,22 @@ params ["_pos"];
 
 		vn_site_objects append _objs;
 
+		// --- Disable weapon disassembly for static weapons ---
+		(_objs select {
+			_x isKindOf "StaticWeapon" &&
+			!(typeOf _x in ["vn_o_nva_65_static_zpu4", "vn_o_nva_static_zpu4"])
+		}) apply {
+			_x enableWeaponDisassembly false;
+			_x addAction [
+				"Disable Weapon",
+				{
+					params ["_target", "_caller", "_actionId", "_arguments"];
+					_target setDamage 1;
+					_target removeAction _actionId;
+				},[],1.5,false,false,"_caller distance _target < 5"
+			];
+		};
+
 		private _objectsToDestroy = _objs select {typeOf _x isEqualTo "Land_vn_tank_rust_f"};
 
 		private _markerPos = _spawnPos getPos [10 + random 20, random 360];

--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_hq.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_hq.sqf
@@ -65,6 +65,21 @@ params ["_pos"];
 		}) apply {
 			_x allowDamage false;
 		};
+		// --- Disable weapon disassembly for static weapons ---
+		(_hqObjects select {
+			_x isKindOf "StaticWeapon" &&
+			!(typeOf _x in ["vn_o_nva_65_static_zpu4", "vn_o_nva_static_zpu4"])
+		}) apply {
+			_x enableWeaponDisassembly false;
+			_x addAction [
+				"Disable Weapon",
+				{
+					params ["_target", "_caller", "_actionId", "_arguments"];
+					_target setDamage 1;
+					_target removeAction _actionId;
+				},[],1.5,false,false,"_caller distance _target < 5"
+			];
+		};
 
 		private _fnc_dynSimKindOfChecker = {
 			params ["_object"];
@@ -124,6 +139,7 @@ params ["_pos"];
 		_respawnObj setVariable ["vn_respawn", [_hqRespawnMarker,_respawnID]];
 
 		vn_dc_adhoc_respawns pushBack [_hqRespawnMarker,_respawnID];
+
 		_siteStore setVariable ["aiObjectives", _objectives];
 		_siteStore setVariable ["markers", [_hqMarker]];
 		_siteStore setVariable ["partialMarkers", [_markerPartial]];


### PR DESCRIPTION
Prevent players from disassembling static weapons spawned by site generators by calling enableWeaponDisassembly false and adding a "Disable Weapon" action that sets the target to damaged (setDamage 1) and removes the action. Changes applied to artillery, factory, fuel and HQ site creation scripts. ZPU4 static types (vn_o_nva_65_static_zpu4, vn_o_nva_static_zpu4) are excluded to preserve their original behavior. Also includes small respawn/spacing tidy in factory/HQ scripts.