### PR TITLE
Restrict siren action to Military Police

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -238,6 +238,7 @@ class CfgFunctions
 			class active_init {};
 			class active_siren {};
 			class active_whistle {};
+			class active_team_sound {};
 		};
 
 		class system_ammo_repack {

--- a/mission/config/subconfigs/keys.hpp
+++ b/mission/config/subconfigs/keys.hpp
@@ -215,15 +215,15 @@ class vn_mf_veh_asset_locate_vehicle_spawn_point
 	access = 1;
 };
 
-class vn_mf_toggle_earplugs
+class vn_mf_toggle_team_sound
 {
 	defaultKey = DIK_F6;
 	shift = "false";
 	ctrl = "false";
 	alt = "false";
-	function = "vn_mf_fnc_earplugs_toggle";
+	function = "vn_mf_fnc_active_team_sound";
 	down = 0;
-	displayName = "Toggle Earplugs";
+	displayName = "Toggle Team Sound";
 	access = 1;
 };
 

--- a/mission/config/wheel_menu_actions.hpp
+++ b/mission/config/wheel_menu_actions.hpp
@@ -83,7 +83,7 @@ class wheel_menu_actions
 	class siren : base_action
 	{
 		visible = "ALWAYS";
-		condition = "(([_target, 'MACV'] call vn_mf_fnc_player_on_team) || ([_target, 'MilitaryPolice'] call vn_mf_fnc_player_on_team))";
+		condition = "([_target, 'MilitaryPolice'] call vn_mf_fnc_player_on_team)";
 		text = "Siren";
 		icon = "custom\wheelmenu\siren.paa";
 		icon_highlighted = "";

--- a/mission/config/wheel_menu_actions.hpp
+++ b/mission/config/wheel_menu_actions.hpp
@@ -80,6 +80,7 @@ class wheel_menu_actions
 		spawn = 0;
 	};
 	
+	/*
 	class siren : base_action
 	{
 		visible = "ALWAYS";
@@ -91,6 +92,7 @@ class wheel_menu_actions
 		function = "vn_mf_fnc_active_siren";
 		spawn = 0;
 	};
+	*/
 
 	class whistle : base_action
 	{

--- a/mission/eventhandlers/mission/eh_HandleDisconnect.sqf
+++ b/mission/eventhandlers/mission/eh_HandleDisconnect.sqf
@@ -61,13 +61,20 @@ if !(isNull _unit) then
 	deleteVehicle _unit;
 };
 
- // Check and delete the siren if attached to this player
- if ((attachedTo vn_mf_siren) == _unit) then
- {
-     deleteVehicle vn_mf_siren;
-     vn_mf_siren_toggle = false;
- };
+	// Check and delete the siren if attached to this player
+	if ((attachedTo vn_mf_siren) == _unit) then
+	{
+		deleteVehicle vn_mf_siren;
+		vn_mf_siren_toggle = false;
+	};
 
-["%1 _vardata %2",_this, _vardata] call BIS_fnc_logFormat;
+	// Check and delete the whistle if attached to this player
+	if ((attachedTo vn_mf_whistle) == _unit) then
+	{
+		deleteVehicle vn_mf_whistle;
+		vn_mf_whistle = objNull;
+	};
+
+	["%1 _vardata %2",_this, _vardata] call BIS_fnc_logFormat;
 
 false

--- a/mission/eventhandlers/mission/eh_HandleDisconnect.sqf
+++ b/mission/eventhandlers/mission/eh_HandleDisconnect.sqf
@@ -61,6 +61,13 @@ if !(isNull _unit) then
 	deleteVehicle _unit;
 };
 
+ // Check and delete the siren if attached to this player
+ if ((attachedTo vn_mf_siren) == _unit) then
+ {
+     deleteVehicle vn_mf_siren;
+     vn_mf_siren_toggle = false;
+ };
+
 ["%1 _vardata %2",_this, _vardata] call BIS_fnc_logFormat;
 
 false

--- a/mission/functions/systems/actives/fn_active_siren.sqf
+++ b/mission/functions/systems/actives/fn_active_siren.sqf
@@ -4,7 +4,7 @@
 	Public: No
 	
 	Description:
-		Toggles a siren (Only for MACV/MPs)
+		Toggles a siren (Only for Military Police)
 	
 	Parameter(s): none
 	

--- a/mission/functions/systems/actives/fn_active_team_sound.sqf
+++ b/mission/functions/systems/actives/fn_active_team_sound.sqf
@@ -1,0 +1,18 @@
+/*
+	File: fn_active_team_sound.sqf
+	Author: Tylervip
+	Public: No
+	
+	Description:
+		Calls both siren and whistle functions. Each function internally checks if the player is on the correct team.
+	
+	Parameter(s): none
+	
+	Returns:
+	
+	Example(s):
+		call vn_mf_fnc_active_team_sound;
+*/
+
+call vn_mf_fnc_active_siren;
+call vn_mf_fnc_active_whistle;


### PR DESCRIPTION
Limit the siren wheel action to only the 'MilitaryPolice' team by removing the previous MACV check in mission/config/wheel_menu_actions.hpp. Also update the fn_active_siren.sqf header comment to reflect that the siren toggle is for Military Police only.