### PR TITLE
Logi upgrade bh

### DIFF
--- a/mission/config/logistics.hpp
+++ b/mission/config/logistics.hpp
@@ -22,6 +22,11 @@ class vn_logistics
 		inventory_max_weight = 50;
 		inventory_max_size = 1;
 	};
+	class bn_bh_large
+	{
+		inventory_max_weight = 1200
+		inventory_max_size = 10
+	};
 	//Jeeps + Small Cars
 	class vn_b_wheeled_m151_01 : vn_defaults_small {};
 	class vn_b_wheeled_m151_01_mp : vn_defaults_small {};
@@ -56,6 +61,8 @@ class vn_logistics
 	class vn_b_wheeled_m54_01 : vn_defaults_large {};
 	class vn_b_wheeled_m54_01_airport : vn_defaults_large {};
 	class vn_b_wheeled_m54_02 : vn_defaults_large {};
+	class vn_b_wheeled_m54_01_sog : bn_bh_large {};
+	class vn_b_wheeled_m54_02_sog : bn_bh_large {};	
 	//M109 Command Truck
 	class vn_b_wheeled_m54_03 : vn_defaults_medium {};
 	//Repair Truck

--- a/mission/config/subconfigs/vehicle_respawn_info.hpp
+++ b/mission/config/subconfigs/vehicle_respawn_info.hpp
@@ -239,11 +239,11 @@ class spawn_point_types {
 				icon = VEHICLE_ICON_TRUCK;
 				vehicles[] = {
 					"vn_b_wheeled_m54_01",
-					"vn_b_wheeled_m54_01_sog",
+					// "vn_b_wheeled_m54_01_sog",
 					"vn_b_wheeled_m54_01_usmc",
 					"vn_b_wheeled_m54_02",
 					"vn_b_wheeled_m54_02_usmc",
-					"vn_b_wheeled_m54_02_sog",
+					// "vn_b_wheeled_m54_02_sog",
 					"vn_b_wheeled_m54_03",
 					"vn_b_wheeled_m54_03_usmc",
 				};
@@ -278,11 +278,11 @@ class spawn_point_types {
 				icon = VEHICLE_ICON_TRUCK;
 				vehicles[] = {
 					"vn_b_wheeled_m54_01",
-					"vn_b_wheeled_m54_01_sog",
+					//"vn_b_wheeled_m54_01_sog",
 					"vn_b_wheeled_m54_01_usmc",
 					"vn_b_wheeled_m54_02",
 					"vn_b_wheeled_m54_02_usmc",
-					"vn_b_wheeled_m54_02_sog",
+					//"vn_b_wheeled_m54_02_sog",
 					"vn_b_wheeled_m54_03",
 					"vn_b_wheeled_m54_03_usmc",
 				};
@@ -329,11 +329,11 @@ class spawn_point_types {
 				icon = VEHICLE_ICON_TRUCK;
 				vehicles[] = {
 					"vn_b_wheeled_m54_01",
-					"vn_b_wheeled_m54_01_sog",
+					//"vn_b_wheeled_m54_01_sog",
 					"vn_b_wheeled_m54_01_usmc",
 					"vn_b_wheeled_m54_02",
 					"vn_b_wheeled_m54_02_usmc",
-					"vn_b_wheeled_m54_02_sog",
+					//"vn_b_wheeled_m54_02_sog",
 					"vn_b_wheeled_m54_03",
 					"vn_b_wheeled_m54_03_usmc",
 				};
@@ -974,6 +974,7 @@ class spawn_point_types {
 				name = "M54 Transport Trucks";
 				icon = VEHICLE_ICON_TRUCK;
 				vehicles[] = {
+					"vn_b_wheeled_m54_01_sog",
 					"vn_b_wheeled_m54_02_sog",
 					"vn_b_wheeled_m54_03",
 				};

--- a/mission/config/subconfigs/vehicle_respawn_info.hpp
+++ b/mission/config/subconfigs/vehicle_respawn_info.hpp
@@ -986,6 +986,15 @@ class spawn_point_types {
 					"vn_b_wheeled_m54_ammo",
 				};
 			};
+
+			class jeeps {
+				name = "M151A1";
+				icon = VEHICLE_ICON_CAR;
+				vehicles[] = {
+					"vn_b_wheeled_m151_01",
+					"vn_b_wheeled_m151_02",
+				};
+			};
 		};
 	};
 


### PR DESCRIPTION
Increased logi capabilities of Black Horse trucks (Any m54 Sog black truck) to increase load to 1200 units, capable of holding two large construction crates.