### PR TITLE
Add utility for 'Disable Weapon' action

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -433,6 +433,7 @@ class CfgFunctions
 			class sites_utils_std_teardown {};
 			class sites_utils_std_check_teardown {};
 			class sites_utils_normalise_object_placement {};
+			class sites_utils_add_disable_weapon_action {};
 		}
 
 		// simple scheduled utility job to make triple sure that critical

--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_artillery.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_artillery.sqf
@@ -81,15 +81,7 @@ params ["_pos"];
 			!(typeOf _x in _objectTypesToDestroy) &&
 			!(typeOf _x in ["vn_o_nva_65_static_zpu4", "vn_o_nva_static_zpu4"])
 		}) apply {
-			_x enableWeaponDisassembly false;
-			_x addAction [
-				"Disable Weapon",
-				{
-					params ["_target", "_caller", "_actionId", "_arguments"];
-					_target setDamage 1;
-					_target removeAction _actionId;
-				},[],1.5,false,false,"_caller distance _target < 5"
-			];
+			_x call vn_mf_fnc_sites_utils_add_disable_weapon_action;
 		};
 		private _objectsToDestroy = _artyObjs select {
 			typeOf _x in _objectTypesToDestroy;

--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_factory.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_factory.sqf
@@ -55,15 +55,7 @@ params ["_pos"];
 			_x isKindOf "StaticWeapon" &&
 			!(typeOf _x in ["vn_o_nva_65_static_zpu4", "vn_o_nva_static_zpu4"])
 		}) apply {
-			_x enableWeaponDisassembly false;
-			_x addAction [
-				"Disable Weapon",
-				{
-					params ["_target", "_caller", "_actionId", "_arguments"];
-					_target setDamage 1;
-					_target removeAction _actionId;
-				},[],1.5,false,false,"_caller distance _target < 5"
-			];
+			_x call vn_mf_fnc_sites_utils_add_disable_weapon_action;
 		};
 
 		private _objectTypesToDestroy = [

--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_fuel.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_fuel.sqf
@@ -48,15 +48,7 @@ params ["_pos"];
 			_x isKindOf "StaticWeapon" &&
 			!(typeOf _x in ["vn_o_nva_65_static_zpu4", "vn_o_nva_static_zpu4"])
 		}) apply {
-			_x enableWeaponDisassembly false;
-			_x addAction [
-				"Disable Weapon",
-				{
-					params ["_target", "_caller", "_actionId", "_arguments"];
-					_target setDamage 1;
-					_target removeAction _actionId;
-				},[],1.5,false,false,"_caller distance _target < 5"
-			];
+			_x call vn_mf_fnc_sites_utils_add_disable_weapon_action;
 		};
 
 		private _objectsToDestroy = _objs select {typeOf _x isEqualTo "Land_vn_tank_rust_f"};

--- a/mission/functions/systems/sites/create/site/fn_sites_create_site_hq.sqf
+++ b/mission/functions/systems/sites/create/site/fn_sites_create_site_hq.sqf
@@ -70,15 +70,7 @@ params ["_pos"];
 			_x isKindOf "StaticWeapon" &&
 			!(typeOf _x in ["vn_o_nva_65_static_zpu4", "vn_o_nva_static_zpu4"])
 		}) apply {
-			_x enableWeaponDisassembly false;
-			_x addAction [
-				"Disable Weapon",
-				{
-					params ["_target", "_caller", "_actionId", "_arguments"];
-					_target setDamage 1;
-					_target removeAction _actionId;
-				},[],1.5,false,false,"_caller distance _target < 5"
-			];
+			_x call vn_mf_fnc_sites_utils_add_disable_weapon_action;
 		};
 
 		private _fnc_dynSimKindOfChecker = {

--- a/mission/functions/systems/sites/utils/fn_sites_utils_add_disable_weapon_action.sqf
+++ b/mission/functions/systems/sites/utils/fn_sites_utils_add_disable_weapon_action.sqf
@@ -1,0 +1,35 @@
+/*
+    File: fn_sites_utils_add_disable_weapon_action.sqf
+    Author: Tylervip 
+    Public: Yes
+    
+    Description:
+        Adds a "Disable Weapon" action to a static weapon for multiplayer compatibility.
+    
+    Parameter(s):
+        _weapon - Static weapon object to add action to
+    
+    Returns:
+        Nothing
+    
+    Example(s):
+        _weapon call vn_mf_fnc_sites_utils_add_disable_weapon_action
+*/
+
+params ["_weapon"];
+
+_weapon enableWeaponDisassembly false;
+[_weapon, [
+	"Disable Weapon",
+	{
+		params ["_target", "_caller", "_actionId", "_arguments"];
+		[_target, 1] remoteExec ["setDamage", 0];
+		[_target, _actionId] remoteExec ["removeAction", _target];
+	},
+	nil,
+	2,
+	false,
+	true,
+	"",
+	"_this distance _target < 5"
+]] remoteExec ["addAction", 0];


### PR DESCRIPTION
Centralize the repeated 'Disable Weapon' addAction logic into a new utility function (vn_mf_fnc_sites_utils_add_disable_weapon_action). Added the function declaration to functions.hpp, replaced inline action blocks in artillery, factory, fuel, and hq site creation scripts with calls to the new util, and added the implementation which disables weapon disassembly and registers the action via remoteExec for multiplayer-safe behavior (action damages the weapon and removes itself). This reduces duplication and fixes MP compatibility.