### PR TITLE
Add earplugs toggle keybinding and dynamic volume

### DIFF
--- a/mission/config/subconfigs/keys.hpp
+++ b/mission/config/subconfigs/keys.hpp
@@ -203,15 +203,15 @@ class vn_mf_channel_disable_all
 	access = 1;
 };
 
-class vn_mf_veh_asset_locate_vehicle_spawn_point
+class vn_mf_earplugs_toggle
 {
 	defaultKey = DIK_F5;
 	shift = "false";
 	ctrl = "false";
 	alt = "false";
-	function = "vn_mf_fnc_veh_asset_client_locate_vehicle_spawn_point";
+	function = "vn_mf_fnc_earplugs_toggle";
 	down = 0;
-	displayName = "Locate Vehicle's Spawner";
+	displayName = "Toggle Earplugs";
 	access = 1;
 };
 

--- a/mission/functions/systems/earplugs/fn_earplugs.sqf
+++ b/mission/functions/systems/earplugs/fn_earplugs.sqf
@@ -22,4 +22,14 @@ params
 
 localNamespace setVariable ["vn_mf_earplugs",_status];
 systemChat localize (["STR_VN_QOL_EARPLUGS_OUT","STR_VN_QOL_EARPLUGS_IN"] select _status);
-0.5 fadeSound ([1,0.2] select _status);
+private _isInVehicle = vehicle player != player;
+
+// Get the appropriate volume based on the player's state
+private _volume = if (_isInVehicle) then {
+    missionNamespace getVariable ["vn_mf_earplugs_volume_vehicle", 0.5]
+} else {
+    missionNamespace getVariable ["vn_mf_earplugs_volume_ground", 0.5]
+};
+
+// Apply the volume
+_volume fadeSound ([1, _volume] select _status);


### PR DESCRIPTION
Replace the old vehicle-spawner key class with an earplugs toggle binding (vn_mf_earplugs_toggle) and point it to vn_mf_fnc_earplugs_toggle; update the display name to "Toggle Earplugs". Update the earplugs function to choose volume based on whether the player is in a vehicle, reading missionNamespace vars (vn_mf_earplugs_volume_vehicle / vn_mf_earplugs_volume_ground, default 0.5) and applying the selected volume via fadeSound. This allows separate earplug levels for vehicle vs on-foot use.