### PR TITLE
Add admin log toggle & friendly-fire scoring

### DIFF
--- a/mission/eventhandlers/mission/eh_EntityKilled.sqf
+++ b/mission/eventhandlers/mission/eh_EntityKilled.sqf
@@ -53,6 +53,21 @@ if (_is_unit_player) then
 		}
 		else
 		{
+			// Check if killed player is on same team (friendly fire) or enemy
+			private _unitTeam = _unit getVariable ["vn_mf_db_player_group", "MikeForce"];
+			private _instigatorTeam = _instigator getVariable ["vn_mf_db_player_group", "MikeForce"];
+
+			if (_unitTeam isEqualTo _instigatorTeam) then
+			{
+				_kill_type = "friendlyfire";
+				[[_instigator],"rank", -25] call vn_mf_fnc_change_player_stat;
+			}
+			else
+			{
+				_kill_type = "kills";
+				[[_instigator],"rank", 25] call vn_mf_fnc_change_player_stat;
+			};
+
 			{
 				private _inMACV = [_x, "MACV"] call para_g_fnc_db_check_whitelist;
 				private _instigatorIsMACV = [_instigator] call para_g_fnc_db_check_curator;
@@ -62,11 +77,11 @@ if (_is_unit_player) then
 				if !(_inMACV) then { continue };
 				
 				systemChat _message;
-				["AdminLog", [_message]] remoteExec ["para_c_fnc_show_notification", _x];
+				if (localNamespace getVariable ["vn_adminLogEnabled", true]) then {
+					["AdminLog", [_message]] remoteExec ["para_c_fnc_show_notification", _x];
+				};
 			} forEach allPlayers;
 
-			_kill_type = "friendlyfire";
-			[[_instigator],"rank", -25] call vn_mf_fnc_change_player_stat;
 			[[_instigator],_kill_type] call vn_mf_fnc_change_player_stat;
 		};
 	};

--- a/mission/eventhandlers/mission/eh_MarkerDeleted.sqf
+++ b/mission/eventhandlers/mission/eh_MarkerDeleted.sqf
@@ -28,5 +28,7 @@ if (_text == "") exitWith { };
 	if !(_inMACV) then { continue };
 	
 	[format ["[MACV] %1 has deleted a map marker. Contents: '%2'", name player, _text]] remoteExec ["systemChat", _x];
-	["AdminLog", [format ["%1 has deleted a map marker.", name player]]] remoteExec ["para_c_fnc_show_notification", _x];
+	if (localNamespace getVariable ["vn_adminLogEnabled", true]) then {
+		["AdminLog", [format ["%1 has deleted a map marker.", name player]]] remoteExec ["para_c_fnc_show_notification", _x];
+	};
 } forEach allPlayers;

--- a/mission/para_player_init_client.sqf
+++ b/mission/para_player_init_client.sqf
@@ -441,9 +441,14 @@ if (isNil { localNamespace getVariable "vn_showPlayerIcons" }) then {
     localNamespace setVariable ["vn_showPlayerIcons", true]; // ON by default
 };
 
+if (isNil { localNamespace getVariable "vn_adminLogEnabled" }) then {
+    localNamespace setVariable ["vn_adminLogEnabled", true]; // ON by default
+};
+
 vn_fnc_toggle_playericons = {
     params ["_state"];
     localNamespace setVariable ["vn_showPlayerIcons", _state];
+    localNamespace setVariable ["vn_adminLogEnabled", _state];
     hint format ["Player Names: %1", if (_state) then {"ENABLED"} else {"DISABLED"}];
 };
 


### PR DESCRIPTION
Introduce a client-side admin log toggle (vn_adminLogEnabled, default ON) and gate admin notifications on it in eh_EntityKilled and eh_MarkerDeleted to allow disabling admin notifications. Add friendly-fire detection in eh_EntityKilled by comparing player group (vn_mf_db_player_group) and apply appropriate rank changes for kills vs friendly fire, removing a duplicate stat update. Initialize vn_adminLogEnabled in para_player_init_client and wire the existing player-icons toggle to also set the admin-log state.