### PR TITLE
Add M577 mobile respawn system & food crate monitor

### DIFF
--- a/mission/config/functions.hpp
+++ b/mission/config/functions.hpp
@@ -24,6 +24,20 @@ class CfgFunctions
 			class eject_and_parachute {};
 		};
 
+		class mobile_respawn
+		{
+			file = "functions\systems\mobile_respawn";
+			class isTentDeployed {};
+			class mobile_respawn_track_vehicle {};
+			class mobile_respawn_add_supplies {};
+			class mobile_respawn_has_supplies {};
+			class mobile_respawn_init {};
+			class mobile_respawn_job {};
+			class mobile_respawn_register_apc {};
+			class mobile_respawn_unregister_apc {};
+			class mobile_respawn_consume {};
+		};
+
 		class core_helpers
 		{
 			file = "functions\core\helpers";
@@ -486,6 +500,7 @@ class CfgFunctions
 			class action_supplies {};
 			class client_request_supplies {};
 			class create_supply_officer {};
+			class monitor_food_crate {};
 			class override_crate_contents {};
 			class supplyrequest {};
 		};

--- a/mission/config/subconfigs/crates.hpp
+++ b/mission/config/subconfigs/crates.hpp
@@ -264,7 +264,10 @@ class FoodCrate
 	objectClassname = "vn_b_ammobox_supply_02";
 	weapons[] = {};
 	magazines[] = {};
-	items[] = {};
+	items[] = {
+	{"vn_prop_food_box_01_03", 10},
+	{"vn_prop_drink_06", 10}
+	};
 	backpacks[] = {};
 };
 

--- a/mission/config/subconfigs/supplydrops.hpp
+++ b/mission/config/subconfigs/supplydrops.hpp
@@ -52,7 +52,7 @@ class support
 		name = "STR_vn_mf_food_supplies";
 		className = "vn_b_ammobox_supply_02";
 		icon = "\vn\ui_f_vietnam\ui\wheelmenu\img\icons\vn_ico_mf_sup_food_ca.paa";
-		//crateName = "FoodCrate";
+		crateConfig = "FoodCrate";
 	};
 
 	class MedicalSupplies

--- a/mission/config/subconfigs/vehicle_respawn_info.hpp
+++ b/mission/config/subconfigs/vehicle_respawn_info.hpp
@@ -791,6 +791,7 @@ class spawn_point_types {
 				vehicles[] = {
 					"vn_i_armor_m125_01",
 					"vn_i_armor_m132_01",
+					"vn_b_armor_m577_01",
 					"vn_i_armor_m113_acav_06",
 					"vn_i_armor_m113_acav_05",
 					"vn_i_armor_m113_acav_04",
@@ -949,6 +950,7 @@ class spawn_point_types {
 				icon = VEHICLE_ICON_ARMOUR;
 				vehicles[] = {
 					"vn_b_armor_m132_01",
+					"vn_b_armor_m577_01",
 					"vn_b_armor_m113_acav_05",
 					"vn_b_armor_m113_acav_06",
 					"vn_b_armor_m125_01",

--- a/mission/functions/systems/mobile_respawn/fn_isTentDeployed.sqf
+++ b/mission/functions/systems/mobile_respawn/fn_isTentDeployed.sqf
@@ -1,0 +1,25 @@
+/*
+    File: fn_isTentDeployed.sqf
+    Author: tylervip
+    Public: yes
+
+    Description:
+        Returns whether a vehicle's deployable tent is currently deployed.
+        Uses the "hide_tent" animation: 0 = deployed, 1 = stowed/hidden.
+
+    Parameter(s):
+        _vehicle - Vehicle to check [OBJECT]
+
+    Returns:
+        True if tent is deployed, false otherwise [BOOL]
+
+    Example(s):
+        [myAPC] call vn_mf_fnc_isTentDeployed
+*/
+
+params ["_vehicle"];
+
+if (isNull _vehicle) exitWith { false };
+
+// hide_tent animation: 0 = deployed, 1 = stowed (hidden)
+(_vehicle animationPhase "hide_tent") == 0

--- a/mission/functions/systems/mobile_respawn/fn_mobile_respawn_add_supplies.sqf
+++ b/mission/functions/systems/mobile_respawn/fn_mobile_respawn_add_supplies.sqf
@@ -1,0 +1,20 @@
+/*
+    File: fn_mobile_respawn_add_supplies.sqf
+    Author: tylervip
+    Public: yes
+
+    Description:
+        Adds mobile respawn food supplies to a vehicle.
+
+    Parameter(s):
+        _vehicle - Vehicle to add supplies to [Object]
+
+    Returns: nothing
+
+    Example(s): none
+*/
+
+params ["_vehicle"];
+
+_vehicle addItemCargoGlobal ["vn_prop_food_box_01_03", 5];
+_vehicle addItemCargoGlobal ["vn_prop_drink_06", 5];

--- a/mission/functions/systems/mobile_respawn/fn_mobile_respawn_consume.sqf
+++ b/mission/functions/systems/mobile_respawn/fn_mobile_respawn_consume.sqf
@@ -1,0 +1,89 @@
+/*
+    File: fn_mobile_respawn_consume.sqf
+    Author: tylervip
+    Public: yes
+
+    Description:
+        Consumes 1x MCI Ration Box and 1x Canteen 2L as the cost of a respawn.
+        Checks nearby food crates (within 30m) first, then falls back to the
+        APC's own cargo.
+
+    Parameter(s):
+        _vehicle - The M577 APC to consume resources from/near [OBJECT]
+
+    Returns:
+        True if resources were found and consumed, false if none available [BOOL]
+
+    Example(s):
+        [myAPC] call vn_mf_fnc_mobile_respawn_consume
+*/
+
+if (!isServer) exitWith { false };
+
+params ["_vehicle"];
+
+private _foodClass  = "vn_prop_food_box_01_03";
+private _drinkClass = "vn_prop_drink_06";
+
+private _fnc_hasClassInCargo = {
+    params ["_obj", "_className"];
+    (_className in (itemCargo _obj)) || (_className in (magazineCargo _obj))
+};
+
+// Helper: check if an object has at least 1 of each item
+private _fnc_hasResources = {
+    params ["_obj"];
+    ([_obj, _foodClass] call _fnc_hasClassInCargo) && ([_obj, _drinkClass] call _fnc_hasClassInCargo)
+};
+
+// Helper: remove 1x of an item class from item cargo by rebuilding the list
+private _fnc_removeOneFromItemCargo = {
+    params ["_obj", "_item"];
+    private _items = itemCargo _obj;
+    private _idx = _items find _item;
+    if (_idx < 0) exitWith {};
+    _items deleteAt _idx;
+    clearItemCargoGlobal _obj;
+    { _obj addItemCargoGlobal [_x, 1] } forEach _items;
+};
+
+// Helper: remove 1x of a class from magazine cargo by rebuilding the list
+private _fnc_removeOneFromMagazineCargo = {
+    params ["_obj", "_mag"];
+    private _mags = magazineCargo _obj;
+    private _idx = _mags find _mag;
+    if (_idx < 0) exitWith {};
+    _mags deleteAt _idx;
+    clearMagazineCargoGlobal _obj;
+    { _obj addMagazineCargoGlobal [_x, 1] } forEach _mags;
+};
+
+private _fnc_removeOneClass = {
+    params ["_obj", "_className"];
+    if (_className in (itemCargo _obj)) exitWith {
+        [_obj, _className] call _fnc_removeOneFromItemCargo;
+    };
+    if (_className in (magazineCargo _obj)) exitWith {
+        [_obj, _className] call _fnc_removeOneFromMagazineCargo;
+    };
+};
+
+// Priority 1 — nearby food crates within 30m
+private _nearbyCrates = _vehicle nearEntities [["vn_b_ammobox_supply_02"], 30];
+private _sourceCrate = _nearbyCrates select { [_x] call _fnc_hasResources };
+
+if (count _sourceCrate > 0) then {
+    private _crate = _sourceCrate select 0;
+    [_crate, _foodClass]  call _fnc_removeOneClass;
+    [_crate, _drinkClass] call _fnc_removeOneClass;
+    true
+} else {
+    // Priority 2 — APC own inventory
+    if ([_vehicle] call _fnc_hasResources) then {
+        [_vehicle, _foodClass]  call _fnc_removeOneClass;
+        [_vehicle, _drinkClass] call _fnc_removeOneClass;
+        true
+    } else {
+        false
+    };
+};

--- a/mission/functions/systems/mobile_respawn/fn_mobile_respawn_has_supplies.sqf
+++ b/mission/functions/systems/mobile_respawn/fn_mobile_respawn_has_supplies.sqf
@@ -1,0 +1,41 @@
+/*
+    File: fn_mobile_respawn_has_supplies.sqf
+    Author: tylervip
+    Public: yes
+
+    Description:
+        Checks whether food supplies are available to the APC —
+        either in a nearby food crate (within 30m) or in the APC's own cargo.
+        Does NOT consume anything.
+
+    Parameter(s):
+        _vehicle - The M577 APC to check [OBJECT]
+
+    Returns:
+        True if at least 1x ration + 1x canteen are available, false otherwise [BOOL]
+
+    Example(s):
+        [myAPC] call vn_mf_fnc_mobile_respawn_has_supplies
+*/
+
+params ["_vehicle"];
+
+private _foodClass  = "vn_prop_food_box_01_03";
+private _drinkClass = "vn_prop_drink_06";
+
+private _fnc_hasClassInCargo = {
+    params ["_obj", "_className"];
+    (_className in (itemCargo _obj)) || (_className in (magazineCargo _obj))
+};
+
+private _fnc_hasResources = {
+    params ["_obj"];
+    ([_obj, _foodClass] call _fnc_hasClassInCargo) && ([_obj, _drinkClass] call _fnc_hasClassInCargo)
+};
+
+private _nearbyCrates = _vehicle nearEntities [["vn_b_ammobox_supply_02"], 30];
+private _sourceCrate = _nearbyCrates select { [_x] call _fnc_hasResources };
+
+if (count _sourceCrate > 0) exitWith { true };
+
+[_vehicle] call _fnc_hasResources

--- a/mission/functions/systems/mobile_respawn/fn_mobile_respawn_init.sqf
+++ b/mission/functions/systems/mobile_respawn/fn_mobile_respawn_init.sqf
@@ -1,0 +1,35 @@
+/*
+    File: fn_mobile_respawn_init.sqf
+    Author: tylervip
+    Public: yes
+
+    Description:
+        Initialises the M577 mobile respawn system.
+        Collects all pre-placed M577 APCs into a tracking list and starts
+        the scheduler job that monitors tent deployment state.
+        Vehicle-asset-manager-spawned M577s are added to the tracking list
+        via a hook in fn_veh_asset_assign_vehicle_to_spawn_point.sqf.
+
+    Parameter(s):
+        None
+
+    Returns:
+        Nothing
+
+    Example(s):
+        [] call vn_mf_fnc_mobile_respawn_init
+*/
+
+if (!isServer) exitWith {};
+
+// Collect pre-placed M577s and seed them with initial food supplies
+vn_mf_m577_tracked_vehicles = vehicles select {
+    (typeOf _x) find "vn_b_armor_m577_01" == 0
+};
+
+{ [_x] call vn_mf_fnc_mobile_respawn_add_supplies } forEach vn_mf_m577_tracked_vehicles;
+
+diag_log format ["VN MikeForce: [mobile_respawn] Initialised - tracking %1 pre-placed M577(s)", count vn_mf_m577_tracked_vehicles];
+
+// Start the scheduler job - checks tent state every 10 seconds
+["m577_respawn_monitor", vn_mf_fnc_mobile_respawn_job, [], 10] call para_g_fnc_scheduler_add_job;

--- a/mission/functions/systems/mobile_respawn/fn_mobile_respawn_job.sqf
+++ b/mission/functions/systems/mobile_respawn/fn_mobile_respawn_job.sqf
@@ -1,0 +1,53 @@
+/*
+    File: fn_mobile_respawn_job.sqf
+    Author: tylervip
+    Public: yes
+
+    Description:
+        Scheduler job (runs every 10s) that monitors all tracked M577 APCs.
+        Registers a vehicle as a respawn point when its tent is deployed,
+        and unregisters it when the tent is stowed. Dead or null vehicles
+        are pruned from the tracking list.
+
+    Parameter(s):
+        None (called by scheduler)
+
+    Returns:
+        Nothing
+
+    Example(s):
+        ["m577_respawn_monitor", vn_mf_fnc_mobile_respawn_job, [], 10] call para_g_fnc_scheduler_add_job
+*/
+
+private _tracked = missionNamespace getVariable ["vn_mf_m577_tracked_vehicles", []];
+private _stillAlive = [];
+
+{
+    private _vehicle = _x;
+
+    // Prune destroyed/null vehicles from tracking
+    if (isNull _vehicle || !alive _vehicle) then {
+        // If it was registered, clean up
+        if !(_vehicle getVariable ["vn_mf_m577_respawn_id", []] isEqualTo []) then {
+            [_vehicle] call vn_mf_fnc_mobile_respawn_unregister_apc;
+        };
+        // Do not add to _stillAlive - drops from tracking list
+    } else {
+        _stillAlive pushBack _vehicle;
+
+        private _isTentDeployed = [_vehicle] call vn_mf_fnc_isTentDeployed;
+        private _isRegistered   = !(_vehicle getVariable ["vn_mf_m577_respawn_id", []] isEqualTo []);
+        private _hasSupplies    = [_vehicle] call vn_mf_fnc_mobile_respawn_has_supplies;
+
+        if (_isTentDeployed && !_isRegistered && _hasSupplies) then {
+            [_vehicle] call vn_mf_fnc_mobile_respawn_register_apc;
+        };
+
+        if (_isRegistered && (!_isTentDeployed || !_hasSupplies)) then {
+            [_vehicle] call vn_mf_fnc_mobile_respawn_unregister_apc;
+        };
+    };
+} forEach _tracked;
+
+// Update tracking list (removes dead vehicles)
+missionNamespace setVariable ["vn_mf_m577_tracked_vehicles", _stillAlive];

--- a/mission/functions/systems/mobile_respawn/fn_mobile_respawn_register_apc.sqf
+++ b/mission/functions/systems/mobile_respawn/fn_mobile_respawn_register_apc.sqf
@@ -1,0 +1,70 @@
+/*
+    File: fn_mobile_respawn_register_apc.sqf
+    Author: tylervip
+    Public: yes
+
+    Description:
+        Registers an M577 APC as a player respawn point.
+        Creates a map marker at the APC's position, registers it as a
+        respawn position for west and independent sides, stocks the APC
+        with initial food supplies, and adds an onPlayerRespawn event
+        handler that consumes food on each use. If food runs out the
+        respawn point is automatically unregistered.
+
+    Parameter(s):
+        _vehicle - The M577 APC to register [OBJECT]
+
+    Returns:
+        Nothing
+
+    Example(s):
+        [myAPC] call vn_mf_fnc_mobile_respawn_register_apc
+*/
+
+if (!isServer) exitWith {};
+
+params ["_vehicle"];
+
+// Guard - already registered
+if !(_vehicle getVariable ["vn_mf_m577_respawn_id", []] isEqualTo []) exitWith {
+    diag_log "VN MikeForce: [mobile_respawn] Attempt to re-register APC that is already registered";
+};
+
+// Create a unique marker at the APC's current position
+private _markerName = format ["vn_mf_m577_respawn_%1", netId _vehicle];
+private _marker = createMarker [_markerName, getPos _vehicle];
+_marker setMarkerAlpha 0;
+
+_vehicle setVariable ["vn_mf_m577_respawn_marker", _markerName, true];
+
+// Register as a respawn position for both sides
+private _respawnId = [west, _markerName, "M577 Command Post"] call BIS_fnc_addRespawnPosition;
+[independent, _markerName, "M577 Command Post"] call BIS_fnc_addRespawnPosition;
+
+_vehicle setVariable ["vn_mf_m577_respawn_id", _respawnId, true];
+
+// Clean up respawn immediately if this vehicle gets deleted/replaced
+private _deletedEhId = _vehicle addEventHandler ["Deleted", {
+    params ["_entity"];
+    [_entity] call vn_mf_fnc_mobile_respawn_unregister_apc;
+}];
+_vehicle setVariable ["vn_mf_m577_respawn_deleted_eh", _deletedEhId, true];
+
+// Add respawn event handler — consume food on each use, unregister if empty
+private _handler = ["onPlayerRespawn", [{
+    params ["_handlerParams", "_eventParams"];
+    _handlerParams params ["_vehicle", "_markerName"];
+    _eventParams params ["_player", "_identity"];
+
+    if (_identity isEqualTo _markerName) then {
+        private _hadFood = [_vehicle] call vn_mf_fnc_mobile_respawn_consume;
+        if (!_hadFood) then {
+            diag_log format ["VN MikeForce: [mobile_respawn] No food remaining at APC %1 - unregistering respawn", netId _vehicle];
+            [_vehicle] call vn_mf_fnc_mobile_respawn_unregister_apc;
+        };
+    };
+}, [_vehicle, _markerName]]] call para_g_fnc_event_add_handler;
+
+_vehicle setVariable ["vn_mf_m577_respawn_handler", _handler, true];
+
+diag_log format ["VN MikeForce: [mobile_respawn] Registered APC %1 at marker %2", netId _vehicle, _markerName];

--- a/mission/functions/systems/mobile_respawn/fn_mobile_respawn_track_vehicle.sqf
+++ b/mission/functions/systems/mobile_respawn/fn_mobile_respawn_track_vehicle.sqf
@@ -1,0 +1,22 @@
+/*
+    File: fn_mobile_respawn_track_vehicle.sqf
+    Author: tylervip
+    Public: yes
+
+    Description:
+        Adds supported M577 vehicles to the mobile respawn tracking list.
+
+    Parameter(s):
+        _vehicle - Vehicle to evaluate for tracking [Object]
+
+    Returns: nothing
+
+    Example(s): none
+*/
+
+params ["_vehicle"];
+
+if ((typeOf _vehicle) find "vn_b_armor_m577_01" == 0) then {
+    vn_mf_m577_tracked_vehicles = (missionNamespace getVariable ["vn_mf_m577_tracked_vehicles", []]) + [_vehicle];
+    [_vehicle] call vn_mf_fnc_mobile_respawn_add_supplies;
+};

--- a/mission/functions/systems/mobile_respawn/fn_mobile_respawn_unregister_apc.sqf
+++ b/mission/functions/systems/mobile_respawn/fn_mobile_respawn_unregister_apc.sqf
@@ -1,0 +1,48 @@
+/*
+    File: fn_mobile_respawn_unregister_apc.sqf
+    Author: tylervip
+    Public: yes
+
+    Description:
+        Removes an M577 APC as a player respawn point.
+        Cleans up the marker, respawn position registration, and event handler.
+
+    Parameter(s):
+        _vehicle - The M577 APC to unregister [OBJECT]
+
+    Returns:
+        Nothing
+
+    Example(s):
+        [myAPC] call vn_mf_fnc_mobile_respawn_unregister_apc
+*/
+
+if (!isServer) exitWith {};
+
+params ["_vehicle"];
+
+// Guard - skip if not registered
+if (_vehicle getVariable ["vn_mf_m577_respawn_id", []] isEqualTo []) exitWith {
+    diag_log "VN MikeForce: [mobile_respawn] Attempt to unregister APC that is not registered";
+};
+
+// Remove respawn position
+(_vehicle getVariable "vn_mf_m577_respawn_id") call BIS_fnc_removeRespawnPosition;
+
+// Delete map marker
+deleteMarker (_vehicle getVariable "vn_mf_m577_respawn_marker");
+
+// Remove onPlayerRespawn event handler
+["onPlayerRespawn", _vehicle getVariable "vn_mf_m577_respawn_handler"] call para_g_fnc_event_remove_handler;
+
+// Remove Deleted event handler
+private _deletedEhId = _vehicle getVariable ["vn_mf_m577_respawn_deleted_eh", -1];
+if (_deletedEhId >= 0) then {
+    _vehicle removeEventHandler ["Deleted", _deletedEhId];
+};
+
+// Clear all tracking variables
+_vehicle setVariable ["vn_mf_m577_respawn_id",      [], true];
+_vehicle setVariable ["vn_mf_m577_respawn_marker",  nil, true];
+_vehicle setVariable ["vn_mf_m577_respawn_handler", nil, true];
+_vehicle setVariable ["vn_mf_m577_respawn_deleted_eh", -1, true];

--- a/mission/functions/systems/supplies/fn_monitor_food_crate.sqf
+++ b/mission/functions/systems/supplies/fn_monitor_food_crate.sqf
@@ -1,0 +1,47 @@
+/*
+	File: fn_monitor_food_crate.sqf
+	Author: tylervip
+	Public: yes
+
+	Description:
+		Monitors a spawned food crate and deletes it once all cargo has been removed.
+
+	Parameter(s):
+	_crate - Food crate object to monitor [OBJECT]
+
+	Returns: nothing
+
+	Example(s):
+		[_crate] call vn_mf_fnc_monitor_food_crate
+*/
+
+if (!isServer) exitWith {};
+
+params ["_crate"];
+
+if (isNull _crate) exitWith {};
+if (_crate getVariable ["vn_mf_food_crate_monitoring", false]) exitWith {};
+
+_crate setVariable ["vn_mf_food_crate_monitoring", true, false];
+
+[_crate] spawn {
+	params ["_crate"];
+
+	private _fnc_hasCargo = {
+		params ["_crate"];
+
+		(({_x > 0} count ((getItemCargo _crate) select 1)) > 0)
+			|| (({_x > 0} count ((getMagazineCargo _crate) select 1)) > 0)
+			|| (({_x > 0} count ((getWeaponCargo _crate) select 1)) > 0)
+			|| (({_x > 0} count ((getBackpackCargo _crate) select 1)) > 0)
+	};
+
+	waitUntil {
+		sleep 30;
+		isNull _crate || {!alive _crate} || {!([_crate] call _fnc_hasCargo)}
+	};
+
+	if (!isNull _crate) then {
+		deleteVehicle _crate;
+	};
+};

--- a/mission/functions/systems/supplies/fn_override_crate_contents.sqf
+++ b/mission/functions/systems/supplies/fn_override_crate_contents.sqf
@@ -31,3 +31,8 @@ if (_clear) then
 { _crate addWeaponCargoGlobal _x } forEach getArray(_crateConfigData>> "weapons");
 { _crate addItemCargoGlobal _x } forEach getArray(_crateConfigData>> "items");
 { _crate addBackpackCargoGlobal _x } forEach getArray(_crateConfigData>> "backpacks");
+
+if (_crateConfig isEqualTo "FoodCrate") then
+{
+	[_crate] call vn_mf_fnc_monitor_food_crate;
+};

--- a/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_assign_vehicle_to_spawn_point.sqf
+++ b/mission/functions/systems/vehicle_asset_manager/server/fn_veh_asset_assign_vehicle_to_spawn_point.sqf
@@ -22,6 +22,10 @@ _spawnPoint set ["lastClassSpawned", typeOf _vehicle];
 [_spawnPoint, "currentVehicle", _vehicle] call vn_mf_fnc_veh_asset_set_global_variable;
 
 [_vehicle] call vn_mf_fnc_veh_asset_add_unlock_action;
+
+[_vehicle] call vn_mf_fnc_mobile_respawn_track_vehicle;
+
+// add the eject and parachute action to it
 if (_vehicle isKindOf "Helicopter") then {
     [_vehicle] remoteExecCall ["vn_mf_fnc_eject_and_parachute", 0, _vehicle];
 };

--- a/mission/para_server_init.sqf
+++ b/mission/para_server_init.sqf
@@ -293,6 +293,17 @@ call para_g_fnc_event_subsystem_init;
 
 /*
 =========================================================================================
+init: `vn_mf_fnc_mobile_respawn_init`
+=========================================================================================
+Initialises the M577 mobile tent respawn system.
+Requires both the scheduler and event subsystems to already be running.
+=========================================================================================
+*/
+
+[] call vn_mf_fnc_mobile_respawn_init;
+
+/*
+=========================================================================================
 init: `para_s_fnc_cleanup_subsystem_init`
 =========================================================================================
 Deletes bodies, objects and gear after a certain amount of time.


### PR DESCRIPTION
Implements a mobile respawn system for M577 APCs and adds food crate monitoring.

- Adds a new mobile_respawn function set (isTentDeployed, track_vehicle, add_supplies, has_supplies, init, job, register_apc, unregister_apc, consume) to manage M577-based respawn points: track vehicles, detect tent deployment, register/unregister respawn positions, consume supplies on respawn and prune dead vehicles.
- Hooks tracking into vehicle asset spawning (fn_veh_asset_assign_vehicle_to_spawn_point) and calls vn_mf_fnc_mobile_respawn_init from server init to start the scheduler job.
- Adds monitoring for spawned food crates (fn_monitor_food_crate) and calls it when FoodCrate is spawned so empty crates are automatically deleted.
- Updates crate configs: FoodCrate now contains food/drink items and supplydrops entry uses crateConfig = "FoodCrate".
- Updates vehicle_respawn_info to include vn_b_armor_m577_01 in relevant spawn lists.
- Registers new functions in mission config (functions.hpp) and invokes the crate monitor from fn_override_crate_contents.

This change enables portable M577 command-post respawns that require consumable food/drink supplies and cleans up empty supply crates automatically.