### PR TITLE
Update vehicle_respawn_info.hpp

### DIFF
--- a/mission/config/subconfigs/vehicle_respawn_info.hpp
+++ b/mission/config/subconfigs/vehicle_respawn_info.hpp
@@ -946,7 +946,7 @@ class spawn_point_types {
 			};
 
 			class m113 {
-				name = "M113";
+				name = "M113/APCs (1/2)";
 				icon = VEHICLE_ICON_ARMOUR;
 				vehicles[] = {
 					"vn_b_armor_m132_01",
@@ -954,6 +954,13 @@ class spawn_point_types {
 					"vn_b_armor_m113_acav_05",
 					"vn_b_armor_m113_acav_06",
 					"vn_b_armor_m125_01",
+				};
+			};
+
+			class m113_2 {
+				name = "M113/APCs (2/2)";
+				icon = VEHICLE_ICON_ARMOUR;
+				vehicles[] = {
 					"vn_b_armor_m113_01",
 					"vn_b_armor_m113_acav_01",
 					"vn_b_armor_m113_acav_02",


### PR DESCRIPTION
fix for
"ERROR: VM_WIN_INIT: The amount of entries for the Wheel menu must be at least 2 and max 10. Given: 11"